### PR TITLE
Fix snap-machine rubber-banding and actuator input in practice mode

### DIFF
--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -60,6 +60,62 @@ const LOCAL_VEHICLE_RENDER_VERTICAL_RATE = 12.0;
 const LOCAL_VEHICLE_RENDER_YAW_RATE = 24.0;
 const LOCAL_VEHICLE_RENDER_TILT_RATE = 10.0;
 
+/** Left-stick → actuator channel when keyboard bindings read all zeros (gamepad). */
+function snapMachineGamepadChannelValue(
+  action: string,
+  moveX: number,
+  moveY: number,
+): number {
+  const mx = Math.max(-1, Math.min(1, moveX));
+  const my = Math.max(-1, Math.min(1, moveY));
+  let v = 0;
+  switch (action) {
+    case 'motorSpin':
+    case 'hingeSpin':
+    case 'sliderPos':
+      v = my;
+      break;
+    case 'armPitch':
+    case 'flapDeflect':
+    case 'armPitchElbow':
+      v = my;
+      break;
+    case 'armYaw':
+    case 'armYawTurret':
+      v = mx;
+      break;
+    case 'throttle':
+    case 'propellerSpin':
+      v = Math.max(0, my);
+      break;
+    case 'gripperClose':
+      v = Math.max(0, my);
+      break;
+    default:
+      v = my;
+      break;
+  }
+  return Math.max(-127, Math.min(127, Math.round(v * 127)));
+}
+
+function mergeSnapMachineChannelsFromGamepad(
+  actionChannels: string[],
+  keyboardChannels: Int8Array,
+  moveX: number,
+  moveY: number,
+): Int8Array {
+  const out = new Int8Array(8);
+  const kLen = Math.min(keyboardChannels.length, 8);
+  for (let i = 0; i < kLen; i += 1) {
+    out[i] = keyboardChannels[i] ?? 0;
+  }
+  for (let idx = 0; idx < actionChannels.length && idx < 8; idx += 1) {
+    if (out[idx] !== 0) continue;
+    out[idx] = snapMachineGamepadChannelValue(actionChannels[idx] ?? '', moveX, moveY);
+  }
+  return out;
+}
+
 type FrameDebugCallback = (
   frameTimeMs: number,
   rendererInfo: { render: { calls: number; triangles: number }; memory: { geometries: number; textures: number } },
@@ -575,16 +631,23 @@ export function GameWorld({
     let liveMachineChannels: Int8Array | undefined;
     if (isOperatingMachineNow) {
       const actionChannels = prediction.getSnapMachineActionChannels();
-      liveMachineChannels = new Int8Array(8);
+      const keyboardChannels = new Int8Array(8);
       for (let idx = 0; idx < actionChannels.length && idx < 8; idx += 1) {
         const action = actionChannels[idx];
         const binding = machineBindings.find((b) => b.action === action);
         if (!binding) continue;
         let value = 0;
-        if (inputManagerRef.current?.isCodeDown(binding.posKey)) value += 1;
-        if (binding.negKey && inputManagerRef.current?.isCodeDown(binding.negKey)) value -= 1;
-        liveMachineChannels[idx] = Math.max(-127, Math.min(127, Math.round(value * 127)));
+        if (inputManagerRef.current?.isCodeDown(binding.posKey)) value += binding.scale;
+        if (binding.negKey && inputManagerRef.current?.isCodeDown(binding.negKey)) value -= binding.scale;
+        keyboardChannels[idx] = Math.max(-127, Math.min(127, Math.round(value * 127)));
       }
+      const ax = rawInputSample.action;
+      liveMachineChannels = mergeSnapMachineChannelsFromGamepad(
+        actionChannels,
+        keyboardChannels,
+        ax?.moveX ?? 0,
+        ax?.moveY ?? 0,
+      );
     }
     const inputSample = isOperatingMachineNow
       ? {

--- a/client/src/scene/SnapMachines.tsx
+++ b/client/src/scene/SnapMachines.tsx
@@ -234,6 +234,11 @@ export function SnapMachines({ world, getBodyPoses }: SnapMachinesProps) {
     };
   }, [snapMachines]);
 
+  // Run after parent `GameWorld` `useFrame` (priority 0): R3F calls lower
+  // priorities first, so we must read `getBodyPoses` *after* wasm ticks
+  // (`updateSnapMachine` / `syncRemoteSnapMachine`) or we alternate one
+  // frame of stale poses with the authored `machineRoot` layout — visible
+  // as pose flicker in the recording.
   useFrame(() => {
     for (const [machineId, data] of machineDataRef.current) {
       const poses = getBodyPoses(machineId);
@@ -255,7 +260,7 @@ export function SnapMachines({ world, getBodyPoses }: SnapMachinesProps) {
         group.quaternion.set(poses[o + 3], poses[o + 4], poses[o + 5], poses[o + 6]);
       }
     }
-  });
+  }, 1);
 
   return <group ref={groupRef} />;
 }

--- a/shared/src/snap_machine.rs
+++ b/shared/src/snap_machine.rs
@@ -105,6 +105,9 @@ pub struct SnapMachine {
     /// channel index → action name lives here. Both server and client must
     /// derive this identically.
     action_channels: Vec<String>,
+    /// Envelope-resolved keyboard bindings (defaults + `controls` overrides).
+    /// Stored at install so wasm can expose the same table the HUD walks.
+    bindings: Vec<crate::snap_machine_controls::MachineBinding>,
     /// Optional control profile from the envelope (for client-side keybind
     /// derivation). Cloned so the envelope JSON can be dropped after install.
     controls: Option<snap_machines_rapier::MachineControls>,
@@ -197,6 +200,8 @@ impl SnapMachine {
         let plan_for_meta = envelope.plan.clone();
         let controls = envelope.controls.take();
 
+        let bindings = crate::snap_machine_controls::derive_machine_bindings(envelope_json);
+
         let runtime = MachineRuntime::install_envelope(world, envelope)?;
 
         let mut body_ids: Vec<String> =
@@ -209,6 +214,7 @@ impl SnapMachine {
             runtime,
             body_ids,
             action_channels,
+            bindings,
             controls,
             display_name,
         })
@@ -226,6 +232,25 @@ impl SnapMachine {
 
     pub fn action_channels(&self) -> &[String] {
         &self.action_channels
+    }
+
+    /// Player-facing bindings captured at install (envelope `controls` or
+    /// defaults). Same row format as [`SnapMachine::bindings_wire_string`].
+    pub fn machine_bindings(&self) -> &[crate::snap_machine_controls::MachineBinding] {
+        &self.bindings
+    }
+
+    /// `\n`-delimited rows: `action\tposKey\tnegKey\tscale` (`negKey` may be
+    /// empty).
+    pub fn bindings_wire_string(&self) -> String {
+        self.bindings
+            .iter()
+            .map(|b| {
+                let neg = b.neg_key.as_deref().unwrap_or("");
+                format!("{}\t{}\t{}\t{}", b.action, b.pos_key, neg, b.scale)
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     pub fn controls(&self) -> Option<&snap_machines_rapier::MachineControls> {
@@ -322,6 +347,20 @@ impl SnapMachine {
             rb.set_body_type(RigidBodyType::KinematicPositionBased, true);
             rb.set_linvel(Vector3::zeros(), false);
             rb.set_angvel(Vector3::zeros(), false);
+        }
+    }
+
+    /// Restore dynamic bodies so [`Self::apply_input`] can integrate motors.
+    /// Used by client wasm for the locally operated machine only.
+    pub fn unfreeze_to_dynamic(&self, bodies: &mut RigidBodySet) {
+        for id in &self.body_ids {
+            let Some(handle) = self.runtime.body_handle(id) else {
+                continue;
+            };
+            let Some(rb) = bodies.get_mut(handle) else {
+                continue;
+            };
+            rb.set_body_type(RigidBodyType::Dynamic, true);
         }
     }
 

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -1324,12 +1324,27 @@ impl WasmSimWorld {
 
     #[wasm_bindgen(js_name = setLocalSnapMachine)]
     pub fn set_local_snap_machine(&mut self, machine_id: u32) {
+        if let Some(prev) = self.local_machine_id {
+            if prev != machine_id {
+                if let Some(m) = self.machines.get(&prev) {
+                    m.freeze_to_kinematic(&mut self.sim.rigid_bodies);
+                }
+            }
+        }
         self.local_machine_id = Some(machine_id);
         self.machine_pending_inputs.clear();
+        if let Some(m) = self.machines.get(&machine_id) {
+            m.unfreeze_to_dynamic(&mut self.sim.rigid_bodies);
+        }
     }
 
     #[wasm_bindgen(js_name = clearLocalSnapMachine)]
     pub fn clear_local_snap_machine(&mut self) {
+        if let Some(mid) = self.local_machine_id {
+            if let Some(m) = self.machines.get(&mid) {
+                m.freeze_to_kinematic(&mut self.sim.rigid_bodies);
+            }
+        }
         self.local_machine_id = None;
         self.machine_pending_inputs.clear();
     }
@@ -1373,22 +1388,10 @@ impl WasmSimWorld {
     /// enter.
     #[wasm_bindgen(js_name = getSnapMachineBindings)]
     pub fn get_snap_machine_bindings(&self, id: u32) -> String {
-        // We need the source envelope JSON to call
-        // `derive_machine_bindings`, but the installed `SnapMachine`
-        // only retains the `action_channels` + `controls`. Fall back
-        // to per-channel defaults since the common case — a machine
-        // without an explicit controls block — is handled perfectly
-        // by the default_action_key table.
-        let Some(machine) = self.machines.get(&id) else {
-            return String::new();
-        };
-        let mut rows = Vec::with_capacity(machine.action_channels().len());
-        for action in machine.action_channels() {
-            let (pos, neg) = crate::snap_machine_controls::default_action_key(action);
-            let neg_str = neg.unwrap_or("");
-            rows.push(format!("{action}\t{pos}\t{neg_str}\t1"));
-        }
-        rows.join("\n")
+        self.machines
+            .get(&id)
+            .map(SnapMachine::bindings_wire_string)
+            .unwrap_or_default()
     }
 
     /// Returns body world poses for the renderer, packed as a flat `f32`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Snap-machines in the client wasm world were spawned as **kinematic** bodies (correct for mirroring parked machines from the server). When you entered a machine, `tickSnapMachine` still ran `apply_input`, but **motors and joints do not integrate like a driven machine on kinematic bodies**, so each authoritative snapshot overwrote poses from the server, which showed up as **teleport / rubber-band** while prediction and snapshots disagreed.

## Changes

- **Client wasm:** On `setLocalSnapMachine`, call `SnapMachine::unfreeze_to_dynamic` for the operated machine; on `clearLocalSnapMachine` (and when switching machines), call `freeze_to_kinematic` again so non-operated machines stay stable mirrors.
- **`SnapMachine`:** Persist `derive_machine_bindings` at install and expose `bindings_wire_string` so `getSnapMachineBindings` matches envelope `controls` overrides, not only per-action defaults.
- **`GameWorld`:** Multiply key channel values by each binding `scale` (was ignored). If keyboard sampling yields zeros for a channel, **merge in gamepad left-stick** values mapped by action name (`motorSpin` → forward/back stick, `armYaw` → left/right, etc.) so gamepad-only play still drives actuators.
- **`SnapMachines`:** `useFrame` for applying `getBodyPoses` to Three.js groups now uses **renderPriority 1** so it runs **after** parent `GameWorld`’s `useFrame` (priority 0). Previously the child subscribed first and read poses **before** `tickSnapMachine` / reconcile ran each frame, alternating one frame of stale/zero poses with the authored `machineRoot` transform — the **pose flicker** visible in the demo video.

## Testing

- `cd shared && cargo test` (47 tests)
- `cd client && npm run build` (rebuilds wasm from `shared/`)

Note: full-repo `make check-server` failed in this environment due to missing system OpenSSL for the game server crate; the **shared** crate and client build succeeded.

## Practice mode screen recording (snap-machine E/Q, exit B)

<a href="https://cursor.com/agents/bc-e7673dfc-45a2-4a1d-9331-97bb96e4c5aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsnap-machine-practice-demo.mp4"><img src="https://cursor.com/artifacts/c/art-8097e6d1-89dd-4506-a1e3-af7dea68aef7" alt="snap-machine-practice-demo.mp4" /></a>

_(Re-record after merging the `SnapMachines` useFrame priority fix if you want an updated clip without flicker.)_

## Not done (optional follow-up)

- **react-three-a11y** was not added in this PR to avoid scope creep; say if you want it wired around `SnapMachines` / interactables next.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7673dfc-45a2-4a1d-9331-97bb96e4c5aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7673dfc-45a2-4a1d-9331-97bb96e4c5aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

