### PR TITLE
Let practice bots drive vehicles to reach distant targets

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -291,6 +291,12 @@ export function App({
   const handleToggleBotDebugOverlay = useCallback((value: boolean) => {
     setPracticeBotDebugOverlay(value);
   }, []);
+  const handleSetBotUseVehicles = useCallback((value: boolean) => {
+    const runtime = practiceBotRuntimeRef.current;
+    if (!runtime) return;
+    runtime.setUseVehicles(value);
+    refreshPracticeBotStats();
+  }, [refreshPracticeBotStats]);
 
   useEffect(() => {
     if (!practiceMode) {
@@ -947,6 +953,7 @@ export function App({
         onUpdateNavTuning={handleUpdateBotNavTuning}
         onResetNavTuning={handleResetBotNavTuning}
         onToggleDebugOverlay={handleToggleBotDebugOverlay}
+        onSetUseVehicles={handleSetBotUseVehicles}
       />
       <EnergyBar
         hp={displayStats.hp}

--- a/client/src/bots/agent/vehicleSteering.test.ts
+++ b/client/src/bots/agent/vehicleSteering.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  rotateVectorByQuaternionInverse,
+  vehicleAgentStateToIntent,
+  type Quaternion,
+} from './vehicleSteering';
+import {
+  BTN_BACK,
+  BTN_FORWARD,
+  BTN_LEFT,
+  BTN_RIGHT,
+} from '../../net/sharedConstants';
+
+const IDENTITY: Quaternion = [0, 0, 0, 1];
+
+/** Unit quaternion rotating `angle` radians around the world +Y axis. */
+function quatY(angle: number): Quaternion {
+  const h = angle * 0.5;
+  return [0, Math.sin(h), 0, Math.cos(h)];
+}
+
+const PASSTHROUGH = Object.freeze({
+  yaw: 0.25,
+  pitch: -0.1,
+  mode: 'driving' as const,
+  targetPlayerId: null,
+  vehicleId: 7,
+  firePrimary: false,
+  vehicleAction: null,
+});
+
+describe('rotateVectorByQuaternionInverse', () => {
+  it('returns the original vector for the identity quaternion', () => {
+    const v: [number, number, number] = [1.5, -2, 3.25];
+    const out = rotateVectorByQuaternionInverse(v, IDENTITY);
+    expect(out[0]).toBeCloseTo(1.5);
+    expect(out[1]).toBeCloseTo(-2);
+    expect(out[2]).toBeCloseTo(3.25);
+  });
+
+  it('inverts a +90° yaw rotation around Y', () => {
+    // The chassis is yawed +90° (facing −X in world). Rotating (−1, 0, 0)
+    // back into chassis-local should give (0, 0, −1) — "forward" in the
+    // chassis frame.
+    const q = quatY(Math.PI / 2);
+    const world: [number, number, number] = [-1, 0, 0];
+    const local = rotateVectorByQuaternionInverse(world, q);
+    expect(local[0]).toBeCloseTo(0, 5);
+    expect(local[1]).toBeCloseTo(0, 5);
+    expect(local[2]).toBeCloseTo(-1, 5);
+  });
+
+  it('is its own inverse with a forward rotation', () => {
+    // Rotating a vector by q and then by q^-1 should round-trip.
+    const q: Quaternion = [0.2, 0.3, 0.1, Math.sqrt(1 - 0.04 - 0.09 - 0.01)];
+    const v: [number, number, number] = [2, 0.5, -1.5];
+    // forwardRotate(v, q) = inverse-rotate(v, conjugate(q))
+    const conj: Quaternion = [-q[0], -q[1], -q[2], q[3]];
+    const rotated = rotateVectorByQuaternionInverse(v, conj);
+    const roundTripped = rotateVectorByQuaternionInverse(rotated, q);
+    expect(roundTripped[0]).toBeCloseTo(2, 5);
+    expect(roundTripped[1]).toBeCloseTo(0.5, 5);
+    expect(roundTripped[2]).toBeCloseTo(-1.5, 5);
+  });
+});
+
+describe('vehicleAgentStateToIntent', () => {
+  it('emits BTN_FORWARD only for a target directly ahead', () => {
+    // Chassis-local forward is −Z, so a world velocity of (0, 0, −10)
+    // is straight ahead when the quaternion is identity.
+    const intent = vehicleAgentStateToIntent([0, 0, -10], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeFalsy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+    expect(intent.buttons & BTN_BACK).toBeFalsy();
+  });
+
+  it('emits forward + right for a target ahead-right of the chassis', () => {
+    // Desired velocity in world space points +X/−Z → local heading ~+45°.
+    const intent = vehicleAgentStateToIntent([5, 0, -5], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_RIGHT).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeFalsy();
+    expect(intent.buttons & BTN_BACK).toBeFalsy();
+  });
+
+  it('emits forward + left for a target ahead-left of the chassis', () => {
+    const intent = vehicleAgentStateToIntent([-5, 0, -5], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeTruthy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+    expect(intent.buttons & BTN_BACK).toBeFalsy();
+  });
+
+  it('reverses and counter-steers when the target is directly behind', () => {
+    // Desired velocity is +Z world-space; chassis-local heading ~180°
+    // (fully behind). We expect reverse, and since the target is
+    // "straight back" the heading is exactly π so we fall just inside
+    // the BTN_BACK arm with no steer (heading magnitude on threshold).
+    const intent = vehicleAgentStateToIntent([0, 0, 10], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_BACK).toBeTruthy();
+    expect(intent.buttons & BTN_FORWARD).toBeFalsy();
+  });
+
+  it('reverses + opposite-steer for a target behind and to the right', () => {
+    // Behind-right in world space → atan2(x, forward) where forward = −(−z)
+    // is positive.  With local x ≈ +1 and local forward ≈ −0.17 the
+    // heading lands around +1.74 rad (≈100°), just outside the forward
+    // arc (100°). We should reverse and steer LEFT to swing the nose.
+    const intent = vehicleAgentStateToIntent([10, 0, 1.8], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_BACK).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeTruthy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+  });
+
+  it('honors a yawed chassis — target directly ahead of a rotated car', () => {
+    // Car is yawed +90° around Y. Its local forward in world space is
+    // therefore along the rotated −Z axis → world +X direction. A world
+    // velocity of (+1, 0, 0) should register as "dead ahead".
+    //
+    // NOTE: rotation sign convention — quatY(+π/2) yaws in the
+    // right-handed sense around +Y, which maps chassis −Z to world… well,
+    // the test asserts the output, whichever way it turns out: we just
+    // need to confirm the code picks BTN_FORWARD and no steer when the
+    // world velocity matches whatever "forward" the chassis resolves to.
+    const chassis = quatY(Math.PI / 2);
+    // To find the correct world-space "ahead" for this chassis, rotate
+    // the local forward (0,0,-1) by the chassis quaternion. We can reuse
+    // `rotateVectorByQuaternionInverse` by passing the conjugate, which
+    // gives a forward rotation.
+    const conj: Quaternion = [-chassis[0], -chassis[1], -chassis[2], chassis[3]];
+    const worldForward = rotateVectorByQuaternionInverse([0, 0, -1], conj);
+    // Scale to a real speed.
+    const worldVel: [number, number, number] = [
+      worldForward[0] * 10,
+      worldForward[1] * 10,
+      worldForward[2] * 10,
+    ];
+    const intent = vehicleAgentStateToIntent(worldVel, chassis, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeFalsy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+  });
+
+  it('emits no drive buttons when desired velocity is below the deadband', () => {
+    const intent = vehicleAgentStateToIntent([0, 0, -0.1], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons).toBe(0);
+    // Passthrough fields are still forwarded unchanged.
+    expect(intent.yaw).toBeCloseTo(PASSTHROUGH.yaw);
+    expect(intent.pitch).toBeCloseTo(PASSTHROUGH.pitch);
+    expect(intent.vehicleId).toBe(PASSTHROUGH.vehicleId);
+  });
+
+  it('passes vehicleId/vehicleAction through to the returned intent', () => {
+    const intent = vehicleAgentStateToIntent([0, 0, -3], IDENTITY, {
+      ...PASSTHROUGH,
+      vehicleAction: 'exit',
+    });
+    expect(intent.vehicleAction).toBe('exit');
+    expect(intent.vehicleId).toBe(PASSTHROUGH.vehicleId);
+    expect(intent.mode).toBe('driving');
+  });
+});

--- a/client/src/bots/agent/vehicleSteering.test.ts
+++ b/client/src/bots/agent/vehicleSteering.test.ts
@@ -39,15 +39,15 @@ describe('rotateVectorByQuaternionInverse', () => {
   });
 
   it('inverts a +90° yaw rotation around Y', () => {
-    // The chassis is yawed +90° (facing −X in world). Rotating (−1, 0, 0)
-    // back into chassis-local should give (0, 0, −1) — "forward" in the
-    // chassis frame.
+    // The chassis is yawed +90° (facing +X in world). Rotating (+1, 0, 0)
+    // back into chassis-local should give (0, 0, +1) — "forward" in the
+    // chassis frame (forward = +Z).
     const q = quatY(Math.PI / 2);
-    const world: [number, number, number] = [-1, 0, 0];
+    const world: [number, number, number] = [1, 0, 0];
     const local = rotateVectorByQuaternionInverse(world, q);
     expect(local[0]).toBeCloseTo(0, 5);
     expect(local[1]).toBeCloseTo(0, 5);
-    expect(local[2]).toBeCloseTo(-1, 5);
+    expect(local[2]).toBeCloseTo(1, 5);
   });
 
   it('is its own inverse with a forward rotation', () => {
@@ -66,9 +66,9 @@ describe('rotateVectorByQuaternionInverse', () => {
 
 describe('vehicleAgentStateToIntent', () => {
   it('emits BTN_FORWARD only for a target directly ahead', () => {
-    // Chassis-local forward is −Z, so a world velocity of (0, 0, −10)
-    // is straight ahead when the quaternion is identity.
-    const intent = vehicleAgentStateToIntent([0, 0, -10], IDENTITY, PASSTHROUGH);
+    // Chassis forward is +Z, so a world velocity of (0, 0, +10) is
+    // straight ahead when the quaternion is identity.
+    const intent = vehicleAgentStateToIntent([0, 0, 10], IDENTITY, PASSTHROUGH);
     expect(intent.buttons & BTN_FORWARD).toBeTruthy();
     expect(intent.buttons & BTN_LEFT).toBeFalsy();
     expect(intent.buttons & BTN_RIGHT).toBeFalsy();
@@ -76,8 +76,8 @@ describe('vehicleAgentStateToIntent', () => {
   });
 
   it('emits forward + right for a target ahead-right of the chassis', () => {
-    // Desired velocity in world space points +X/−Z → local heading ~+45°.
-    const intent = vehicleAgentStateToIntent([5, 0, -5], IDENTITY, PASSTHROUGH);
+    // Desired velocity in world space points +X/+Z → local heading ~+45°.
+    const intent = vehicleAgentStateToIntent([5, 0, 5], IDENTITY, PASSTHROUGH);
     expect(intent.buttons & BTN_FORWARD).toBeTruthy();
     expect(intent.buttons & BTN_RIGHT).toBeTruthy();
     expect(intent.buttons & BTN_LEFT).toBeFalsy();
@@ -85,7 +85,7 @@ describe('vehicleAgentStateToIntent', () => {
   });
 
   it('emits forward + left for a target ahead-left of the chassis', () => {
-    const intent = vehicleAgentStateToIntent([-5, 0, -5], IDENTITY, PASSTHROUGH);
+    const intent = vehicleAgentStateToIntent([-5, 0, 5], IDENTITY, PASSTHROUGH);
     expect(intent.buttons & BTN_FORWARD).toBeTruthy();
     expect(intent.buttons & BTN_LEFT).toBeTruthy();
     expect(intent.buttons & BTN_RIGHT).toBeFalsy();
@@ -93,43 +93,37 @@ describe('vehicleAgentStateToIntent', () => {
   });
 
   it('reverses and counter-steers when the target is directly behind', () => {
-    // Desired velocity is +Z world-space; chassis-local heading ~180°
+    // Desired velocity is −Z world-space; chassis-local heading ~180°
     // (fully behind). We expect reverse, and since the target is
     // "straight back" the heading is exactly π so we fall just inside
     // the BTN_BACK arm with no steer (heading magnitude on threshold).
-    const intent = vehicleAgentStateToIntent([0, 0, 10], IDENTITY, PASSTHROUGH);
+    const intent = vehicleAgentStateToIntent([0, 0, -10], IDENTITY, PASSTHROUGH);
     expect(intent.buttons & BTN_BACK).toBeTruthy();
     expect(intent.buttons & BTN_FORWARD).toBeFalsy();
   });
 
   it('reverses + opposite-steer for a target behind and to the right', () => {
-    // Behind-right in world space → atan2(x, forward) where forward = −(−z)
-    // is positive.  With local x ≈ +1 and local forward ≈ −0.17 the
+    // Behind-right in world space → atan2(x, forward) where forward = z
+    // is negative.  With local x ≈ +10 and local forward ≈ −1.8 the
     // heading lands around +1.74 rad (≈100°), just outside the forward
     // arc (100°). We should reverse and steer LEFT to swing the nose.
-    const intent = vehicleAgentStateToIntent([10, 0, 1.8], IDENTITY, PASSTHROUGH);
+    const intent = vehicleAgentStateToIntent([10, 0, -1.8], IDENTITY, PASSTHROUGH);
     expect(intent.buttons & BTN_BACK).toBeTruthy();
     expect(intent.buttons & BTN_LEFT).toBeTruthy();
     expect(intent.buttons & BTN_RIGHT).toBeFalsy();
   });
 
   it('honors a yawed chassis — target directly ahead of a rotated car', () => {
-    // Car is yawed +90° around Y. Its local forward in world space is
-    // therefore along the rotated −Z axis → world +X direction. A world
-    // velocity of (+1, 0, 0) should register as "dead ahead".
-    //
-    // NOTE: rotation sign convention — quatY(+π/2) yaws in the
-    // right-handed sense around +Y, which maps chassis −Z to world… well,
-    // the test asserts the output, whichever way it turns out: we just
-    // need to confirm the code picks BTN_FORWARD and no steer when the
-    // world velocity matches whatever "forward" the chassis resolves to.
+    // Car is yawed +90° around Y. Its local forward (+Z) in world space
+    // is therefore +X. A world velocity of (+10, 0, 0) should register
+    // as "dead ahead".
     const chassis = quatY(Math.PI / 2);
     // To find the correct world-space "ahead" for this chassis, rotate
-    // the local forward (0,0,-1) by the chassis quaternion. We can reuse
+    // the local forward (0,0,+1) by the chassis quaternion. We can reuse
     // `rotateVectorByQuaternionInverse` by passing the conjugate, which
     // gives a forward rotation.
     const conj: Quaternion = [-chassis[0], -chassis[1], -chassis[2], chassis[3]];
-    const worldForward = rotateVectorByQuaternionInverse([0, 0, -1], conj);
+    const worldForward = rotateVectorByQuaternionInverse([0, 0, 1], conj);
     // Scale to a real speed.
     const worldVel: [number, number, number] = [
       worldForward[0] * 10,
@@ -143,7 +137,7 @@ describe('vehicleAgentStateToIntent', () => {
   });
 
   it('emits no drive buttons when desired velocity is below the deadband', () => {
-    const intent = vehicleAgentStateToIntent([0, 0, -0.1], IDENTITY, PASSTHROUGH);
+    const intent = vehicleAgentStateToIntent([0, 0, 0.1], IDENTITY, PASSTHROUGH);
     expect(intent.buttons).toBe(0);
     // Passthrough fields are still forwarded unchanged.
     expect(intent.yaw).toBeCloseTo(PASSTHROUGH.yaw);
@@ -152,7 +146,7 @@ describe('vehicleAgentStateToIntent', () => {
   });
 
   it('passes vehicleId/vehicleAction through to the returned intent', () => {
-    const intent = vehicleAgentStateToIntent([0, 0, -3], IDENTITY, {
+    const intent = vehicleAgentStateToIntent([0, 0, 3], IDENTITY, {
       ...PASSTHROUGH,
       vehicleAction: 'exit',
     });

--- a/client/src/bots/agent/vehicleSteering.ts
+++ b/client/src/bots/agent/vehicleSteering.ts
@@ -1,0 +1,187 @@
+/**
+ * Translates a vehicle-mode crowd agent's planned motion into concrete
+ * driving commands: throttle / reverse / steer bits on a {@link BotIntent}.
+ *
+ * The navcat crowd plans in world-space velocities; the server's
+ * `input_to_vehicle_cmd` in `shared/src/movement.rs:31` interprets
+ * `move_y`/`move_x` (or the equivalent button bits) in the vehicle's local
+ * frame:
+ *   - `move_y > 0` → throttle → chassis drives along its local **−Z** axis
+ *     (Rapier raycast-vehicle convention; see `vehicle_wheel_params`).
+ *   - `move_x > 0` → steer right in the vehicle's forward direction.
+ *
+ * So to go from "desired world velocity" → "buttons", we rotate the
+ * world-space desired velocity into chassis-local coordinates via the
+ * **inverse** of the chassis quaternion and look at the resulting (x, z):
+ *
+ *   localForward = −localZ  // "ahead" direction in chassis frame
+ *   localRight   =  localX  // "right" direction in chassis frame
+ *   heading      = atan2(localRight, localForward)   // 0 = ahead, +π/2 = right
+ *
+ * - Small |heading|: press BTN_FORWARD, maybe nudge LEFT / RIGHT to stay on
+ *   the crowd's desired bearing.
+ * - Target in the frontal arc but off-axis: forward + hard steer.
+ * - Target behind: reverse (BTN_BACK) and counter-steer, which pivots the
+ *   nose around. Good enough to unstick the bot on a bad approach; proper
+ *   3-point turns are out of scope.
+ *
+ * This is a pure function — no side effects, no globals — so it's
+ * trivially unit-testable and can be reused from a Node load test or a
+ * browser preview alike.
+ */
+
+import type { crowd as navcatCrowd } from 'navcat/blocks';
+
+import {
+  BTN_BACK,
+  BTN_FORWARD,
+  BTN_LEFT,
+  BTN_RIGHT,
+} from '../../net/sharedConstants';
+import type { BotIntent, BotMode, Vec3Tuple } from '../types';
+
+type Agent = navcatCrowd.Agent;
+
+/** Chassis orientation quaternion in `[x, y, z, w]` order (match `VehicleStateMeters`). */
+export type Quaternion = readonly [number, number, number, number];
+
+export interface VehicleSteeringOptions {
+  /**
+   * Minimum desired planar speed (m/s) before we start pressing any
+   * drive button. Below this the bot just coasts — avoids jittering
+   * throttle on a waypoint we've essentially already hit.
+   */
+  minDesiredSpeed?: number;
+  /**
+   * Half-width (radians) of the "dead ahead" zone where we won't emit
+   * left/right steer bits at all. Outside the deadband we commit to a
+   * discrete LEFT or RIGHT.
+   */
+  steerDeadband?: number;
+  /**
+   * Half-angle (radians, from +local forward) of the frontal arc where
+   * we throttle forward. Outside this arc the target is "behind" and we
+   * reverse. Default 100° → forward arc is ±100° (forward-biased — we
+   * only reverse when the target is clearly to the rear).
+   */
+  forwardArc?: number;
+}
+
+const DEFAULTS = Object.freeze<Required<VehicleSteeringOptions>>({
+  minDesiredSpeed: 0.5,
+  steerDeadband: 0.08, // ~4.6°
+  forwardArc: (100 * Math.PI) / 180,
+});
+
+/** Rotates `v` by the **inverse** of unit quaternion `q` (i.e. into `q`'s local frame). */
+export function rotateVectorByQuaternionInverse(v: Vec3Tuple, q: Quaternion): Vec3Tuple {
+  const [qx, qy, qz, qw] = q;
+  // Conjugate (inverse for a unit quaternion):
+  const ix = -qx;
+  const iy = -qy;
+  const iz = -qz;
+  // v' = q* v q (pure-quaternion multiplication, expanded).
+  // Using the Rodrigues-style form:
+  //   t = 2 * (q.xyz × v)
+  //   v' = v + q.w * t + q.xyz × t
+  const tx = 2 * (iy * v[2] - iz * v[1]);
+  const ty = 2 * (iz * v[0] - ix * v[2]);
+  const tz = 2 * (ix * v[1] - iy * v[0]);
+  return [
+    v[0] + qw * tx + (iy * tz - iz * ty),
+    v[1] + qw * ty + (iz * tx - ix * tz),
+    v[2] + qw * tz + (ix * ty - iy * tx),
+  ];
+}
+
+/**
+ * Pure conversion: given the crowd's desired velocity and the chassis
+ * orientation, emit a {@link BotIntent} with the right drive buttons set.
+ *
+ * `yaw` and `pitch` in the returned intent are passed through unchanged
+ * from the caller — `input_to_vehicle_cmd` in `shared/src/movement.rs`
+ * ignores them, but snapshot code still echoes them back to observers, so
+ * we keep the bot's head aimed wherever the caller wants.
+ */
+export function vehicleAgentStateToIntent(
+  desiredVelocity: Vec3Tuple,
+  chassisQuaternion: Quaternion,
+  passthrough: {
+    yaw: number;
+    pitch: number;
+    mode: BotMode;
+    targetPlayerId: number | null;
+    vehicleId: number;
+    firePrimary?: boolean;
+    vehicleAction?: 'enter' | 'exit' | null;
+  },
+  options: VehicleSteeringOptions = {},
+): BotIntent {
+  const opts = { ...DEFAULTS, ...options };
+
+  const planarSpeed = Math.hypot(desiredVelocity[0], desiredVelocity[2]);
+  let buttons = 0;
+
+  if (planarSpeed >= opts.minDesiredSpeed) {
+    const local = rotateVectorByQuaternionInverse(desiredVelocity, chassisQuaternion);
+    // Chassis local forward is −Z (see Rapier sign convention in
+    // `vehicle_wheel_params`). +X is right.
+    const forward = -local[2];
+    const right = local[0];
+    // 0 = straight ahead, +π/2 = full right, ±π = directly behind.
+    const heading = Math.atan2(right, forward);
+    const absHeading = Math.abs(heading);
+
+    if (absHeading <= opts.forwardArc) {
+      // Target is in the frontal arc: drive forward, steer toward it.
+      buttons |= BTN_FORWARD;
+      if (heading > opts.steerDeadband) {
+        buttons |= BTN_RIGHT;
+      } else if (heading < -opts.steerDeadband) {
+        buttons |= BTN_LEFT;
+      }
+    } else {
+      // Target is behind: reverse, and steer the **opposite** way so the
+      // nose swings around toward the target. (When reversing, pressing
+      // RIGHT steers the front wheels right, which in turn pivots the
+      // rear-end right and the nose left — so we invert here.)
+      buttons |= BTN_BACK;
+      if (heading > opts.steerDeadband) {
+        buttons |= BTN_LEFT;
+      } else if (heading < -opts.steerDeadband) {
+        buttons |= BTN_RIGHT;
+      }
+    }
+  }
+
+  return {
+    buttons,
+    yaw: passthrough.yaw,
+    pitch: passthrough.pitch,
+    firePrimary: passthrough.firePrimary ?? false,
+    mode: passthrough.mode,
+    targetPlayerId: passthrough.targetPlayerId,
+    vehicleAction: passthrough.vehicleAction ?? null,
+    vehicleId: passthrough.vehicleId,
+  };
+}
+
+/**
+ * Convenience wrapper that pulls `desiredVelocity` off a navcat agent.
+ * Returns `undefined` if the agent is missing (caller should synthesize
+ * an idle intent in that case).
+ */
+export function vehicleAgentToIntent(
+  agent: Agent | undefined,
+  chassisQuaternion: Quaternion,
+  passthrough: Parameters<typeof vehicleAgentStateToIntent>[2],
+  options: VehicleSteeringOptions = {},
+): BotIntent | undefined {
+  if (!agent) return undefined;
+  const desired: Vec3Tuple = [
+    agent.desiredVelocity[0],
+    agent.desiredVelocity[1],
+    agent.desiredVelocity[2],
+  ];
+  return vehicleAgentStateToIntent(desired, chassisQuaternion, passthrough, options);
+}

--- a/client/src/bots/agent/vehicleSteering.ts
+++ b/client/src/bots/agent/vehicleSteering.ts
@@ -6,15 +6,15 @@
  * `input_to_vehicle_cmd` in `shared/src/movement.rs:31` interprets
  * `move_y`/`move_x` (or the equivalent button bits) in the vehicle's local
  * frame:
- *   - `move_y > 0` → throttle → chassis drives along its local **−Z** axis
- *     (Rapier raycast-vehicle convention; see `vehicle_wheel_params`).
+ *   - `move_y > 0` → throttle → chassis drives along its local **+Z** axis
+ *     (`index_forward_axis = 2` in `create_vehicle_physics`).
  *   - `move_x > 0` → steer right in the vehicle's forward direction.
  *
  * So to go from "desired world velocity" → "buttons", we rotate the
  * world-space desired velocity into chassis-local coordinates via the
  * **inverse** of the chassis quaternion and look at the resulting (x, z):
  *
- *   localForward = −localZ  // "ahead" direction in chassis frame
+ *   localForward =  localZ  // "ahead" direction in chassis frame
  *   localRight   =  localX  // "right" direction in chassis frame
  *   heading      = atan2(localRight, localForward)   // 0 = ahead, +π/2 = right
  *
@@ -124,9 +124,9 @@ export function vehicleAgentStateToIntent(
 
   if (planarSpeed >= opts.minDesiredSpeed) {
     const local = rotateVectorByQuaternionInverse(desiredVelocity, chassisQuaternion);
-    // Chassis local forward is −Z (see Rapier sign convention in
-    // `vehicle_wheel_params`). +X is right.
-    const forward = -local[2];
+    // Chassis forward is +Z (see `index_forward_axis = 2` in
+    // `create_vehicle_physics`). +X is right.
+    const forward = local[2];
     const right = local[0];
     // 0 = straight ahead, +π/2 = full right, ±π = directly behind.
     const heading = Math.atan2(right, forward);

--- a/client/src/bots/crowd/BotCrowd.ts
+++ b/client/src/bots/crowd/BotCrowd.ts
@@ -7,18 +7,22 @@ import {
   createFindNearestPolyResult,
   DEFAULT_QUERY_FILTER,
   findNearestPoly,
+  findPath,
   findRandomPoint,
+  FindPathResultFlags,
   INVALID_NODE_REF,
   type NavMesh,
   type NodeRef,
+  type QueryFilter,
   type Vec3,
 } from 'navcat';
 
 import type { WorldDocument } from '../../world/worldDocument';
-import type { Vec3Tuple } from '../types';
+import type { Vec3Tuple, VehicleProfile } from '../types';
 import {
   buildBotNavMesh,
   buildBotNavMeshFromSharedProfile,
+  buildVehicleBotNavMesh,
   type BotNavMesh,
   type BuildBotNavMeshOptions,
   type BuildBotNavMeshFromSharedProfileOptions,
@@ -274,6 +278,56 @@ export class BotCrowd {
     if (!result.success) return null;
     return [result.position[0], result.position[1], result.position[2]];
   }
+
+  /**
+   * Overrides the query filter on a previously-added agent. Used by the
+   * vehicle FSM when a bot switches between foot and vehicle mode so A*
+   * recosts the remaining corridor through the lens of the new chassis.
+   *
+   * Returns false if the agent id is unknown.
+   */
+  setAgentQueryFilter(agentOrHandleId: string | BotHandle, filter: QueryFilter): boolean {
+    const id = typeof agentOrHandleId === 'string' ? agentOrHandleId : agentOrHandleId.id;
+    const agent = this.crowd.agents[id];
+    if (!agent) return false;
+    agent.queryFilter = filter;
+    return true;
+  }
+
+  /**
+   * One-shot path query — runs navcat's {@link findPath} with the given
+   * filter and sums Euclidean distances between straight-path points.
+   * Returns `null` if the path is partial or fails (caller should treat
+   * that as "unreachable for this transport mode").
+   *
+   * This is the core of the walk-vs-drive comparison in the bot brain:
+   * divide the returned length by the relevant cruise speed and you get
+   * a travel-time estimate. The `filter`'s `getCost` influence is *not*
+   * reflected in the returned length (A* uses it for corridor selection,
+   * but we measure the physical distance of the resulting corridor).
+   */
+  estimatePathLength(start: Vec3Tuple, end: Vec3Tuple, filter: QueryFilter): number | null {
+    const startVec: Vec3 = [start[0], start[1], start[2]];
+    const endVec: Vec3 = [end[0], end[1], end[2]];
+    const halfExtents: Vec3 = [
+      this.snapHalfExtents[0],
+      this.snapHalfExtents[1],
+      this.snapHalfExtents[2],
+    ];
+    const result = findPath(this.nav.navMesh, startVec, endVec, halfExtents, filter);
+    if (!result.success) return null;
+    // Reject partial paths — the caller wants an all-or-nothing answer.
+    if ((result.flags & FindPathResultFlags.PARTIAL_PATH) !== 0) return null;
+    const pts = result.path;
+    if (pts.length < 2) return 0;
+    let total = 0;
+    for (let i = 1; i < pts.length; i += 1) {
+      const a = pts[i - 1].position;
+      const b = pts[i].position;
+      total += Math.hypot(b[0] - a[0], b[1] - a[1], b[2] - a[2]);
+    }
+    return total;
+  }
 }
 
 export function createBotCrowd(world: WorldDocument, options: BotCrowdOptions): BotCrowd {
@@ -292,5 +346,33 @@ export async function createBotCrowdFromSharedProfile(
   const maxAgentRadius = options.maxAgentRadius ?? 2.5;
   const crowdInstance = crowd.create(maxAgentRadius);
   const snap = options.snapHalfExtents ?? DEFAULT_SNAP_HALF_EXTENTS;
+  return new BotCrowd(nav, crowdInstance, snap);
+}
+
+/**
+ * Builds a {@link BotCrowd} backed by a **vehicle-sized** navmesh.
+ *
+ * Geometry is produced by {@link buildVehicleBotNavMesh}, which inflates
+ * `walkableRadius` to the profile's chassis radius and tightens the
+ * climb + slope limits. The resulting crowd uses a larger
+ * `maxAgentRadius` (at least `profile.agentRadius + 0.3`) so navcat's
+ * neighbor grid is sized correctly for the wider agents.
+ *
+ * Use this alongside the existing foot crowd in {@link PracticeBotRuntime}
+ * so each bot can switch between the two depending on whether it's on
+ * foot or seated in a vehicle.
+ */
+export function createVehicleBotCrowd(
+  world: WorldDocument,
+  profile: VehicleProfile,
+  options: { maxAgentRadius?: number; snapHalfExtents?: Vec3Tuple } = {},
+): BotCrowd {
+  const nav = buildVehicleBotNavMesh(world, profile);
+  const maxAgentRadius = Math.max(options.maxAgentRadius ?? 0, profile.agentRadius + 0.3, 2.5);
+  const crowdInstance = crowd.create(maxAgentRadius);
+  // Wider snap extents — the vehicle mesh sits a bit higher off the
+  // terrain after erosion, so the foot-tier `[2, 4, 2]` sometimes misses
+  // the closest poly for a vehicle spawn point right on the asphalt.
+  const snap: Vec3Tuple = options.snapHalfExtents ?? [3, 6, 3];
   return new BotCrowd(nav, crowdInstance, snap);
 }

--- a/client/src/bots/crowd/vehicleQueryFilter.test.ts
+++ b/client/src/bots/crowd/vehicleQueryFilter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeTurnAwareCost,
+  SOFT_TURN_WEIGHT,
+  TIGHT_TURN_PENALTY_BIAS,
+  TIGHT_TURN_PENALTY_SCALE,
+} from './vehicleQueryFilter';
+
+type V3 = readonly [number, number, number];
+
+describe('computeTurnAwareCost', () => {
+  const turningRadius = 5;
+
+  it('returns the raw Euclidean cost on a straight segment', () => {
+    // pa → center → pb are collinear. θ=0 so sinHalf≈0 → early return.
+    const pa: V3 = [0, 0, 0];
+    const center: V3 = [0, 0, 5];
+    const pb: V3 = [0, 0, 10];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    expect(cost).toBeCloseTo(10, 5);
+  });
+
+  it('applies a small soft penalty on a gentle curve', () => {
+    // Symmetric V that threads a wide corner — segmentLen well above the
+    // turning radius limit so we should hit the soft-cost branch only.
+    const pa: V3 = [0, 0, 0];
+    const center: V3 = [0, 0, 20];
+    const pb: V3 = [4, 0, 40];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    const base = Math.hypot(4, 0, 40);
+    // Soft weight scales θ/π ∈ [0, 1] by SOFT_TURN_WEIGHT=0.3.
+    expect(cost).toBeGreaterThan(base);
+    expect(cost).toBeLessThan(base * (1 + SOFT_TURN_WEIGHT));
+  });
+
+  it('applies the hard penalty on a sharp 90° corner', () => {
+    // pa approaches from −Z, pb exits along +X through a tight corner.
+    // Short segments keep segmentLen below what a 5 m turning radius
+    // can physically execute.
+    const pa: V3 = [0, 0, -2];
+    const center: V3 = [0, 0, 0];
+    const pb: V3 = [2, 0, 0];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    const base = Math.hypot(2 - 0, 0, 0 - (-2));
+    // Hard-penalty branch: base * 100 + 50.
+    expect(cost).toBeCloseTo(
+      base * TIGHT_TURN_PENALTY_SCALE + TIGHT_TURN_PENALTY_BIAS,
+      5,
+    );
+  });
+
+  it('does not apply the hard penalty when segments are long enough for the chassis', () => {
+    // Same 90° bend, but with 20 m approach/exit — requiredRadius ≈ 20/sin(45°)
+    // ≈ 28.3 m, well above turningRadius=5.
+    const pa: V3 = [0, 0, -20];
+    const center: V3 = [0, 0, 0];
+    const pb: V3 = [20, 0, 0];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    const base = Math.hypot(20, 0, 20);
+    // Should land in the soft branch — roughly base + 15% (θ=π/2).
+    expect(cost).toBeGreaterThan(base);
+    expect(cost).toBeLessThan(base * (1 + SOFT_TURN_WEIGHT));
+  });
+
+  it('is safe on a zero-length approach or exit vector', () => {
+    // pa === center → inLen=0 → should not produce NaN; falls back to base.
+    const pa: V3 = [5, 0, 0];
+    const center: V3 = [5, 0, 0];
+    const pb: V3 = [10, 0, 0];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    expect(cost).toBeCloseTo(5, 5);
+  });
+});

--- a/client/src/bots/crowd/vehicleQueryFilter.ts
+++ b/client/src/bots/crowd/vehicleQueryFilter.ts
@@ -1,0 +1,150 @@
+/**
+ * Vehicle-aware navcat {@link QueryFilter}.
+ *
+ * Unlike `DEFAULT_QUERY_FILTER` (which costs an edge solely by Euclidean
+ * distance), this filter adds a **turn penalty** derived from the agent's
+ * minimum turning radius. A path that threads a sharp right-angle corner
+ * is heavily discouraged vs. a gentle curve the chassis can physically
+ * execute at cruise speed.
+ *
+ * The filter is attached to vehicle-mode agents via `AgentParams.queryFilter`
+ * in {@link BotCrowd}. Foot agents continue to use `DEFAULT_QUERY_FILTER`.
+ *
+ * ## How the turn penalty works
+ *
+ * For each A* edge call, navcat passes `(pa, pb, navMesh, prevRef, curRef,
+ * nextRef)` where `pa` is the portal crossing from the previous node into
+ * the current node, and `pb` is the portal crossing out of the current
+ * node toward the next node. We approximate the local path direction
+ * change by:
+ *
+ *   in  = centroid(curRef) - pa
+ *   out = pb - centroid(curRef)
+ *
+ * and compute the angle θ between those two. We then estimate the radius
+ * of the arc the vehicle would have to sweep through the node from the
+ * classic chord formula:
+ *
+ *   requiredRadius ≈ segmentLen / (2 · sin(θ/2))
+ *
+ * where `segmentLen = |in| + |out|`. If `requiredRadius < turningRadius`,
+ * the edge gets a large penalty so A* routes around that corner. Gentle
+ * curves (small θ) get a very small penalty; straight segments cost
+ * exactly `|pb - pa|`, matching `DEFAULT_QUERY_FILTER` so the planner
+ * still produces sensible distance-first paths on open terrain.
+ */
+
+import {
+  DEFAULT_QUERY_FILTER,
+  getTileAndPolyByRef,
+  type NavMesh,
+  type NodeRef,
+  type QueryFilter,
+  type Vec3,
+} from 'navcat';
+
+import type { VehicleProfile } from '../types';
+
+/** Hard failure threshold applied to corners the vehicle can't physically take. */
+export const TIGHT_TURN_PENALTY_SCALE = 100;
+export const TIGHT_TURN_PENALTY_BIAS = 50;
+/** Mild preference for smoother paths on tractable corners. */
+export const SOFT_TURN_WEIGHT = 0.3;
+
+/**
+ * Core of the turn-aware A* cost, broken out as a pure function for
+ * unit-test access. Given the portal crossing positions (`pa` into the
+ * current node, `pb` out) and the centroid of the current node, returns
+ * the cost A* should apply to the edge.
+ *
+ * All positions are 3D world-space; turn angle is measured in the XZ
+ * plane (Y is up).
+ */
+export function computeTurnAwareCost(
+  pa: readonly [number, number, number],
+  pb: readonly [number, number, number],
+  center: readonly [number, number, number],
+  turningRadius: number,
+): number {
+  const dx = pb[0] - pa[0];
+  const dy = pb[1] - pa[1];
+  const dz = pb[2] - pa[2];
+  const baseCost = Math.hypot(dx, dy, dz);
+
+  const inx = center[0] - pa[0];
+  const inz = center[2] - pa[2];
+  const outx = pb[0] - center[0];
+  const outz = pb[2] - center[2];
+  const inLen = Math.hypot(inx, inz);
+  const outLen = Math.hypot(outx, outz);
+  if (inLen < 1e-4 || outLen < 1e-4) return baseCost;
+
+  const cosTheta = (inx * outx + inz * outz) / (inLen * outLen);
+  const clamped = cosTheta < -1 ? -1 : cosTheta > 1 ? 1 : cosTheta;
+  const theta = Math.acos(clamped); // 0..π
+
+  const halfTheta = theta * 0.5;
+  const sinHalf = Math.sin(halfTheta);
+  if (sinHalf < 1e-4) return baseCost; // straight segment
+
+  const segmentLen = inLen + outLen;
+  const requiredRadius = segmentLen / (2 * sinHalf);
+
+  if (requiredRadius < turningRadius) {
+    return baseCost * TIGHT_TURN_PENALTY_SCALE + TIGHT_TURN_PENALTY_BIAS;
+  }
+  return baseCost * (1 + SOFT_TURN_WEIGHT * (theta / Math.PI));
+}
+
+/**
+ * Builds a `QueryFilter` suitable for a vehicle-mode crowd agent. The
+ * returned filter closes over `profile.turningRadius` — pass a fresh one
+ * if the profile changes.
+ */
+export function createVehicleQueryFilter(profile: VehicleProfile): QueryFilter {
+  return {
+    passFilter(nodeRef: NodeRef, navMesh: NavMesh): boolean {
+      // Delegate area/flag checks to the default filter. The vehicle
+      // navmesh was built with a larger walkable-radius erosion, so the
+      // narrow passages are already absent from the tile set — we don't
+      // need a second layer of area filtering here.
+      return DEFAULT_QUERY_FILTER.passFilter(nodeRef, navMesh);
+    },
+    getCost(
+      pa: Vec3,
+      pb: Vec3,
+      navMesh: NavMesh,
+      prevRef: NodeRef | undefined,
+      curRef: NodeRef,
+      nextRef: NodeRef | undefined,
+    ): number {
+      const baseCost = Math.hypot(pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]);
+      // Edge of the corridor (start or end): no turn context available.
+      if (prevRef === undefined || nextRef === undefined) return baseCost;
+      const center = getPolyCentroid(navMesh, curRef);
+      if (!center) return baseCost;
+      return computeTurnAwareCost(pa, pb, center, profile.turningRadius);
+    },
+  };
+}
+
+/** Computes the XZ-plane centroid of a polygon given its node reference. */
+function getPolyCentroid(navMesh: NavMesh, ref: NodeRef): Vec3 | null {
+  const result = getTileAndPolyByRef(ref, navMesh);
+  if (!result.success) return null;
+  const { tile, poly } = result;
+  const vertexIndices = poly.vertices;
+  const count = vertexIndices.length;
+  if (count === 0) return null;
+  let cx = 0;
+  let cy = 0;
+  let cz = 0;
+  for (let i = 0; i < count; i += 1) {
+    const base = vertexIndices[i] * 3;
+    cx += tile.vertices[base];
+    cy += tile.vertices[base + 1];
+    cz += tile.vertices[base + 2];
+  }
+  const inv = 1 / count;
+  return [cx * inv, cy * inv, cz * inv] as Vec3;
+}

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -17,10 +17,19 @@ export {
   BotCrowd,
   createBotCrowd,
   createBotCrowdFromSharedProfile,
+  createVehicleBotCrowd,
   type BotCrowdOptions,
   type BotCrowdFromSharedProfileOptions,
   type BotHandle,
 } from './crowd/BotCrowd';
+export { createVehicleQueryFilter } from './crowd/vehicleQueryFilter';
+export {
+  vehicleAgentStateToIntent,
+  vehicleAgentToIntent,
+  rotateVectorByQuaternionInverse,
+  type Quaternion,
+  type VehicleSteeringOptions,
+} from './agent/vehicleSteering';
 export { BotBrain, type BotBrainOptions } from './agent/BotBrain';
 export {
   agentStateToIntent,
@@ -42,10 +51,12 @@ export type {
   BotSelfState,
   ObservedPlayer,
   Vec3Tuple,
+  VehicleProfile,
 } from './types';
 export {
   PracticeBotRuntime,
   PRACTICE_BOT_ID_BASE,
+  DEFAULT_VEHICLE_PROFILE,
   type BotDebugInfo,
   type BotObstacleDebugInfo,
   type LocalSelfAccessor,

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -1,7 +1,11 @@
 import { pathCorridor } from 'navcat/blocks';
+import { DEFAULT_QUERY_FILTER } from 'navcat';
+import { createVehicleQueryFilter } from '../crowd/vehicleQueryFilter';
+import { vehicleAgentStateToIntent } from '../agent/vehicleSteering';
 
 import type { PracticeBotHost } from '../../net/localPracticeClient';
 import { FLAG_DEAD } from '../../net/protocol';
+import { FLAG_IN_VEHICLE } from '../../net/sharedConstants';
 import { buildInputFromButtons } from '../../scene/inputBuilder';
 import type { SharedPlayerNavigationProfile } from '../../wasm/sharedPhysics';
 import type { WorldDocument } from '../../world/worldDocument';
@@ -16,6 +20,7 @@ import {
   BotCrowd,
   createBotCrowd,
   createBotCrowdFromSharedProfile,
+  createVehicleBotCrowd,
   type BotHandle,
 } from '../crowd/BotCrowd';
 import type {
@@ -24,6 +29,7 @@ import type {
   BotSelfState,
   ObservedPlayer,
   Vec3Tuple,
+  VehicleProfile,
 } from '../types';
 
 export type LocalSelfAccessor = () => LocalSelfSnapshot | null;
@@ -48,11 +54,37 @@ export interface PracticeBotRuntimeOptions {
   cellSize?: number;
   cellHeight?: number;
   tileSizeVoxels?: number;
+  /** Whether bots start with vehicle mode enabled. */
+  useVehicles?: boolean;
+  /** Override the default vehicle profile used by the walk-vs-drive planner. */
+  vehicleProfile?: VehicleProfile;
 }
 
 export interface PracticeBotRuntimeSyncOptions extends PracticeBotRuntimeOptions {
   navigationProfile: SharedPlayerNavigationProfile;
 }
+
+/**
+ * Stock {@link VehicleProfile} for the default practice-mode vehicle (the
+ * small Rapier raycast car). Values are intentionally conservative — tune
+ * `turningRadius` and `cruiseSpeed` after playtesting.
+ *
+ * - `turningRadius`: at `VEHICLE_MAX_STEER_RAD = 0.5 rad` and a 1.8 m
+ *   wheelbase, the kinematic lower bound is ≈ 1.8 / tan(0.5) ≈ 3.3 m. We
+ *   bump to 5 m to account for the raycast-vehicle's drift and the fact
+ *   that A* costs use centroids, not wheelbase geometry.
+ * - `cruiseSpeed`: empirical — the chassis reaches ~14 m/s on a straight
+ *   with the default engine force. 12 m/s leaves margin for the car
+ *   actually *exiting* a corner.
+ */
+export const DEFAULT_VEHICLE_PROFILE: VehicleProfile = Object.freeze({
+  turningRadius: 5,
+  agentRadius: 1.3,
+  agentHeight: 1.5,
+  cruiseSpeed: 12,
+  enterDistance: 2.5,
+  enterExitOverheadSec: 1.5,
+});
 
 export interface PracticeBotStats {
   bots: number;
@@ -60,6 +92,10 @@ export interface PracticeBotStats {
   maxSpeed: number;
   navTriangles: number;
   running: boolean;
+  /** Whether the vehicle-aware planner is currently enabled. */
+  useVehicles: boolean;
+  /** Number of vehicle-sized tris in the lazy vehicle navmesh, 0 if unbuilt. */
+  vehicleNavTriangles: number;
 }
 
 export interface PracticeBotNavDebugConfig {
@@ -79,6 +115,13 @@ export interface PracticeBotNavTuning {
   walkableSlopeAngleDegrees: number;
   cellHeight: number;
 }
+
+type VehicleFsmStage =
+  | 'on_foot'
+  | 'walking_to_vehicle'
+  | 'entering_vehicle'
+  | 'driving'
+  | 'exiting_vehicle';
 
 export interface BotObstacleDebugInfo {
   kind: 'vehicle';
@@ -104,6 +147,10 @@ export interface BotDebugInfo {
   targetPlayerId: number | null;
   maxSpeed: number;
   firePrimary: boolean;
+  /** Vehicle FSM stage — `'on_foot'` for walking bots. */
+  vehicleStage: VehicleFsmStage;
+  /** Vehicle id this bot is currently reserving / driving, or null. */
+  reservedVehicleId: number | null;
 }
 
 export interface PracticeBotDetachOptions {
@@ -123,6 +170,23 @@ interface PracticeBot {
   behaviorKind: PracticeBotBehaviorKind;
   seq: number;
   lastIntent: BotIntent;
+  /**
+   * Current vehicle FSM stage. Driven by `tickVehicleFsm`; `on_foot` is
+   * the ground state whenever `useVehicles` is false.
+   */
+  vehicleStage: VehicleFsmStage;
+  /** Vehicle id this bot has reserved, or null. */
+  reservedVehicleId: number | null;
+  /** Handle into the vehicle-sized crowd while `vehicleStage === 'driving'`. */
+  vehicleHandle: BotHandle | null;
+  /**
+   * Last destination the brain asked for (foot-mode target). We cache it
+   * so the vehicle FSM can continue the journey on the vehicle navmesh
+   * after entering a car.
+   */
+  pendingDestination: Vec3Tuple | null;
+  /** Tick count since the last FSM transition — used for timeouts. */
+  fsmTicks: number;
 }
 
 const DEFAULT_BEHAVIOR: PracticeBotBehaviorKind = 'harass';
@@ -144,6 +208,26 @@ export class PracticeBotRuntime {
   private lastTickMs = 0;
   private running = false;
   private readonly vehicleObstacleAgents = new Map<number, string>();
+  private readonly world: WorldDocument;
+  private readonly maxAgentRadius: number;
+  /** Whether the walk-vs-drive planner is active. */
+  private useVehicles: boolean;
+  /** Static physical profile of the vehicle the bots would drive. */
+  private readonly vehicleProfile: VehicleProfile;
+  /**
+   * Lazy second crowd built on the first call to `setUseVehicles(true)`.
+   * The underlying navmesh has a larger walkable radius so narrow
+   * passages that a player can squeeze through are excluded. Bots only
+   * inhabit it while driving.
+   */
+  private vehicleCrowd: BotCrowd | null = null;
+  /** navcat QueryFilter paired with the vehicle crowd. Built lazily alongside it. */
+  private vehicleQueryFilter: ReturnType<typeof createVehicleQueryFilter> | null = null;
+  /**
+   * Reservation map — prevents two bots racing for the same car.
+   * Key: vehicleId. Value: botId holding the reservation.
+   */
+  private readonly reservedVehicles = new Map<number, number>();
 
   static createSync(world: WorldDocument, options: PracticeBotRuntimeSyncOptions): PracticeBotRuntime {
     const crowd = createBotCrowd(world, {
@@ -154,7 +238,7 @@ export class PracticeBotRuntime {
       cellHeight: options.cellHeight,
       tileSizeVoxels: options.tileSizeVoxels,
     });
-    return new PracticeBotRuntime(crowd, options);
+    return new PracticeBotRuntime(world, crowd, options);
   }
 
   static async create(
@@ -177,14 +261,18 @@ export class PracticeBotRuntime {
           cellHeight: options.cellHeight,
           tileSizeVoxels: options.tileSizeVoxels,
         });
-    return new PracticeBotRuntime(crowd, options);
+    return new PracticeBotRuntime(world, crowd, options);
   }
 
-  private constructor(crowd: BotCrowd, options: PracticeBotRuntimeOptions = {}) {
+  private constructor(world: WorldDocument, crowd: BotCrowd, options: PracticeBotRuntimeOptions = {}) {
+    this.world = world;
+    this.maxAgentRadius = options.maxAgentRadius ?? 0.6;
     this.crowd = crowd;
     this.behaviorKind = options.initialBehavior ?? DEFAULT_BEHAVIOR;
     this.maxSpeed = options.maxSpeed ?? DEFAULT_MAX_SPEED;
     this.tickHz = options.tickHz ?? DEFAULT_TICK_HZ;
+    this.useVehicles = options.useVehicles ?? false;
+    this.vehicleProfile = options.vehicleProfile ?? DEFAULT_VEHICLE_PROFILE;
   }
 
   attach(host: PracticeBotHost, getSelf: LocalSelfAccessor): void {
@@ -222,6 +310,13 @@ export class PracticeBotRuntime {
       this.crowd.removeObstacleAgent(agentId);
     }
     this.vehicleObstacleAgents.clear();
+    for (const bot of this.bots.values()) {
+      this.releaseBotVehicleResources(bot);
+      bot.vehicleStage = 'on_foot';
+      bot.pendingDestination = null;
+      bot.fsmTicks = 0;
+    }
+    this.reservedVehicles.clear();
     this.host = null;
     this.getSelf = null;
   }
@@ -237,6 +332,8 @@ export class PracticeBotRuntime {
       maxSpeed: this.maxSpeed,
       navTriangles: this.crowd.nav.geometry.triangleCount,
       running: this.running,
+      useVehicles: this.useVehicles,
+      vehicleNavTriangles: this.vehicleCrowd?.nav.geometry.triangleCount ?? 0,
     };
   }
 
@@ -253,6 +350,26 @@ export class PracticeBotRuntime {
       snapHalfExtents: this.crowd.debugSnapHalfExtents,
       mode: buildConfig.mode,
     };
+  }
+
+  setUseVehicles(value: boolean): void {
+    if (value === this.useVehicles) return;
+    this.useVehicles = value;
+    if (value) {
+      this.ensureVehicleCrowd();
+    } else {
+      for (const bot of this.bots.values()) {
+        this.resetBotToFoot(bot, /* sendExitPacket */ true);
+      }
+      this.reservedVehicles.clear();
+    }
+  }
+
+  private ensureVehicleCrowd(): BotCrowd {
+    if (this.vehicleCrowd) return this.vehicleCrowd;
+    this.vehicleCrowd = createVehicleBotCrowd(this.world, this.vehicleProfile);
+    this.vehicleQueryFilter = createVehicleQueryFilter(this.vehicleProfile);
+    return this.vehicleCrowd;
   }
 
   setBehavior(kind: PracticeBotBehaviorKind): void {
@@ -304,6 +421,11 @@ export class PracticeBotRuntime {
       behaviorKind: this.behaviorKind,
       seq: 0,
       lastIntent: makeIdleIntent(),
+      vehicleStage: 'on_foot',
+      reservedVehicleId: null,
+      vehicleHandle: null,
+      pendingDestination: null,
+      fsmTicks: 0,
     });
     if (this.host) {
       const alreadyConnected = this.host.remotePlayers.has(id);
@@ -321,6 +443,7 @@ export class PracticeBotRuntime {
   removeBot(id: number): boolean {
     const bot = this.bots.get(id);
     if (!bot) return false;
+    this.releaseBotVehicleResources(bot);
     this.crowd.removeBot(bot.handle);
     this.bots.delete(id);
     this.host?.disconnectBot(id);
@@ -329,10 +452,12 @@ export class PracticeBotRuntime {
 
   clear(): void {
     for (const bot of this.bots.values()) {
+      this.releaseBotVehicleResources(bot);
       this.crowd.removeBot(bot.handle);
       this.host?.disconnectBot(bot.id);
     }
     this.bots.clear();
+    this.reservedVehicles.clear();
     for (const agentId of this.vehicleObstacleAgents.values()) {
       this.crowd.removeObstacleAgent(agentId);
     }
@@ -378,6 +503,30 @@ export class PracticeBotRuntime {
     }
   }
 
+  private releaseBotVehicleResources(bot: PracticeBot): void {
+    if (bot.vehicleHandle && this.vehicleCrowd) {
+      this.vehicleCrowd.removeBot(bot.vehicleHandle);
+      bot.vehicleHandle = null;
+    }
+    if (bot.reservedVehicleId !== null) {
+      const current = this.reservedVehicles.get(bot.reservedVehicleId);
+      if (current === bot.id) {
+        this.reservedVehicles.delete(bot.reservedVehicleId);
+      }
+      bot.reservedVehicleId = null;
+    }
+  }
+
+  private resetBotToFoot(bot: PracticeBot, sendExitPacket: boolean): void {
+    if (sendExitPacket && bot.vehicleStage === 'driving' && bot.reservedVehicleId !== null && this.host) {
+      this.host.sendBotVehicleExit(bot.id, bot.reservedVehicleId);
+    }
+    this.releaseBotVehicleResources(bot);
+    bot.vehicleStage = 'on_foot';
+    bot.pendingDestination = null;
+    bot.fsmTicks = 0;
+  }
+
   getObstacleDebugInfos(): BotObstacleDebugInfo[] {
     if (!this.host) return [];
     const out: BotObstacleDebugInfo[] = [];
@@ -397,7 +546,14 @@ export class PracticeBotRuntime {
 
   private syncVehicleObstacles(host: PracticeBotHost): void {
     const seen = new Set<number>();
+    const selfDriven = new Set<number>();
+    for (const bot of this.bots.values()) {
+      if (bot.vehicleStage === 'driving' && bot.reservedVehicleId !== null) {
+        selfDriven.add(bot.reservedVehicleId);
+      }
+    }
     for (const [vehicleId, state] of host.vehicles) {
+      if (selfDriven.has(vehicleId)) continue;
       seen.add(vehicleId);
       const position: Vec3Tuple = [
         state.position[0],
@@ -493,6 +649,8 @@ export class PracticeBotRuntime {
         targetPlayerId: bot.lastIntent.targetPlayerId,
         maxSpeed: this.maxSpeed,
         firePrimary: bot.lastIntent.firePrimary,
+        vehicleStage: bot.vehicleStage,
+        reservedVehicleId: bot.reservedVehicleId,
       });
     }
     return out;
@@ -529,10 +687,28 @@ export class PracticeBotRuntime {
       if (remote) {
         this.crowd.syncBotPosition(bot.handle, remote.position);
       }
+      if (
+        bot.vehicleStage === 'driving'
+        && bot.vehicleHandle
+        && bot.reservedVehicleId !== null
+        && this.vehicleCrowd
+      ) {
+        const veh = host.vehicles.get(bot.reservedVehicleId);
+        if (veh) {
+          this.vehicleCrowd.syncBotPosition(bot.vehicleHandle, [
+            veh.position[0],
+            veh.position[1],
+            veh.position[2],
+          ]);
+        }
+      }
     }
 
     this.syncVehicleObstacles(host);
     this.crowd.step(dt);
+    if (this.vehicleCrowd) {
+      this.vehicleCrowd.step(dt);
+    }
 
     const selfTemplate: BotSelfState = {
       position: [0, 0, 0],
@@ -564,17 +740,347 @@ export class PracticeBotRuntime {
       selfTemplate.onGround = true;
       selfTemplate.dead = remote.hp <= 0;
 
-      bot.lastIntent = bot.brain.think(selfTemplate, observed);
+      // Foot brain always runs — it tells us the "natural" destination
+      // the behavior wants right now. The vehicle FSM may override the
+      // final intent (e.g. while driving we emit vehicle-steering bits
+      // instead of the walking buttons the brain computed).
+      const footIntent = bot.brain.think(selfTemplate, observed);
+      bot.pendingDestination = bot.handle.targetPosition
+        ? [
+            bot.handle.targetPosition[0],
+            bot.handle.targetPosition[1],
+            bot.handle.targetPosition[2],
+          ]
+        : null;
+
+      let intent = footIntent;
+      if (this.useVehicles) {
+        intent = this.tickVehicleFsm(bot, remote, footIntent) ?? footIntent;
+      }
+      bot.lastIntent = intent;
       bot.seq = (bot.seq + 1) & 0xffff;
       const cmd = buildInputFromButtons(
         bot.seq,
         0,
-        bot.lastIntent.buttons,
-        bot.lastIntent.yaw,
-        bot.lastIntent.pitch,
+        intent.buttons,
+        intent.yaw,
+        intent.pitch,
       );
       host.sendBotInputs(bot.id, [cmd]);
+      if (intent.vehicleAction === 'enter' && intent.vehicleId != null) {
+        host.sendBotVehicleEnter(bot.id, intent.vehicleId);
+      } else if (intent.vehicleAction === 'exit' && intent.vehicleId != null) {
+        host.sendBotVehicleExit(bot.id, intent.vehicleId);
+      }
     }
+  }
+
+  /**
+   * Drives the per-bot vehicle FSM for one tick. Returns a new intent
+   * that should replace the walking intent produced by the brain, or
+   * `null` to fall through to the brain's default.
+   *
+   * The FSM is stateful per bot but stateless across bots — each invocation
+   * reads the bot's `vehicleStage`, does at most one transition, and
+   * emits whatever intent the new stage produces.
+   */
+  private tickVehicleFsm(
+    bot: PracticeBot,
+    remote: { position: [number, number, number]; flags: number; yaw: number; pitch: number },
+    footIntent: BotIntent,
+  ): BotIntent | null {
+    const host = this.host;
+    if (!host) return null;
+    bot.fsmTicks += 1;
+
+    const botPosition: Vec3Tuple = [remote.position[0], remote.position[1], remote.position[2]];
+    const isInVehicle = (remote.flags & FLAG_IN_VEHICLE) !== 0;
+
+    switch (bot.vehicleStage) {
+      case 'on_foot': {
+        // Decide: should we switch to the vehicle route?
+        const destination = bot.pendingDestination;
+        if (!destination) return null;
+        const planarDist = Math.hypot(
+          destination[0] - botPosition[0],
+          destination[2] - botPosition[2],
+        );
+        // Short trips: don't bother. The walk-vs-drive overhead is too
+        // high, and bots clustering near a waypoint shouldn't scramble
+        // for cars.
+        if (planarDist < 15) return null;
+        const plan = this.planVehicleRoute(bot, botPosition, destination);
+        if (!plan) return null;
+        // Reserve the chosen vehicle and transition to walking_to_vehicle.
+        if (!this.tryReserveVehicle(plan.vehicleId, bot.id)) return null;
+        bot.reservedVehicleId = plan.vehicleId;
+        bot.vehicleStage = 'walking_to_vehicle';
+        bot.fsmTicks = 0;
+        // Override the brain's destination with the vehicle position so
+        // the foot agent path-plans toward it on this tick.
+        this.crowd.requestMoveTo(bot.handle, plan.vehiclePosition);
+        return null;
+      }
+
+      case 'walking_to_vehicle': {
+        const vehicleId = bot.reservedVehicleId;
+        if (vehicleId === null) {
+          bot.vehicleStage = 'on_foot';
+          return null;
+        }
+        const veh = host.vehicles.get(vehicleId);
+        if (!veh) {
+          // Vehicle vanished — abandon and go back to walking.
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        // Another driver beat us to it (human or a bot we don't track).
+        if (veh.driverId !== 0 && veh.driverId !== bot.id) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        // Keep steering toward the vehicle — the brain's normal moveTo
+        // call doesn't know the vehicle is our real goal, so we retarget
+        // the foot agent manually every tick.
+        const vehiclePos: Vec3Tuple = [veh.position[0], veh.position[1], veh.position[2]];
+        this.crowd.requestMoveTo(bot.handle, vehiclePos);
+        const distance = Math.hypot(
+          vehiclePos[0] - botPosition[0],
+          vehiclePos[2] - botPosition[2],
+        );
+        if (distance <= this.vehicleProfile.enterDistance) {
+          bot.vehicleStage = 'entering_vehicle';
+          bot.fsmTicks = 0;
+          // Emit the enter packet via the side-channel on the intent.
+          return {
+            ...footIntent,
+            buttons: 0, // stop moving — animation takes over
+            mode: 'entering_vehicle',
+            vehicleAction: 'enter',
+            vehicleId,
+          };
+        }
+        // Timeout guard: we've been walking toward this vehicle for too
+        // long (60s at 60 Hz). Give up.
+        if (bot.fsmTicks > 60 * 60) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        return { ...footIntent, mode: 'walking_to_vehicle' };
+      }
+
+      case 'entering_vehicle': {
+        const vehicleId = bot.reservedVehicleId;
+        if (vehicleId === null) {
+          bot.vehicleStage = 'on_foot';
+          return null;
+        }
+        if (isInVehicle) {
+          // Server confirmed the seat. Transition to driving.
+          const crowd = this.ensureVehicleCrowd();
+          const veh = host.vehicles.get(vehicleId);
+          const spawn: Vec3Tuple = veh
+            ? [veh.position[0], veh.position[1], veh.position[2]]
+            : botPosition;
+          // Spawn a vehicle-crowd agent for this bot and hand it the
+          // vehicle filter (turn-aware cost).
+          bot.vehicleHandle = crowd.addBot(spawn, {
+            radius: this.vehicleProfile.agentRadius,
+            height: this.vehicleProfile.agentHeight,
+            maxSpeed: this.vehicleProfile.cruiseSpeed,
+            queryFilter: this.vehicleQueryFilter ?? DEFAULT_QUERY_FILTER,
+          });
+          bot.vehicleStage = 'driving';
+          bot.fsmTicks = 0;
+          // Kick off the drive toward the pending destination.
+          if (bot.pendingDestination) {
+            crowd.requestMoveTo(bot.vehicleHandle, bot.pendingDestination);
+          }
+          return {
+            ...footIntent,
+            buttons: 0,
+            mode: 'driving',
+          };
+        }
+        // Wait a few ticks for the server to ack. If it never comes, bail.
+        if (bot.fsmTicks > 120) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        return { ...footIntent, buttons: 0, mode: 'entering_vehicle' };
+      }
+
+      case 'driving': {
+        const vehicleId = bot.reservedVehicleId;
+        if (vehicleId === null || !bot.vehicleHandle || !this.vehicleCrowd) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ true);
+          return null;
+        }
+        const veh = host.vehicles.get(vehicleId);
+        if (!veh || veh.driverId !== bot.id) {
+          // We were bumped out or the vehicle despawned.
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        // Re-ask for the destination every tick — cheap, and the foot
+        // brain may have picked a moving target (e.g. harass).
+        if (bot.pendingDestination) {
+          this.vehicleCrowd.requestMoveTo(bot.vehicleHandle, bot.pendingDestination);
+        }
+        const vehicleAgent = this.vehicleCrowd.getAgent(bot.vehicleHandle.id);
+        const chassisQuat: [number, number, number, number] = [
+          veh.quaternion[0],
+          veh.quaternion[1],
+          veh.quaternion[2],
+          veh.quaternion[3],
+        ];
+        const desired: Vec3Tuple = vehicleAgent
+          ? [
+              vehicleAgent.desiredVelocity[0],
+              vehicleAgent.desiredVelocity[1],
+              vehicleAgent.desiredVelocity[2],
+            ]
+          : [0, 0, 0];
+        // Check for "arrived": within 2× enterDistance of the target.
+        const destination = bot.pendingDestination;
+        const arrived = destination
+          ? Math.hypot(
+              destination[0] - veh.position[0],
+              destination[2] - veh.position[2],
+            ) < Math.max(4, this.vehicleProfile.enterDistance * 2)
+          : false;
+        if (arrived) {
+          bot.vehicleStage = 'exiting_vehicle';
+          bot.fsmTicks = 0;
+          return {
+            ...footIntent,
+            buttons: 0,
+            mode: 'exiting_vehicle',
+            vehicleAction: 'exit',
+            vehicleId,
+          };
+        }
+        // Timeout guard: if we've been trying to drive for 90 s and
+        // haven't arrived, bail out — probably stuck.
+        if (bot.fsmTicks > 60 * 90) {
+          bot.vehicleStage = 'exiting_vehicle';
+          bot.fsmTicks = 0;
+          return {
+            ...footIntent,
+            buttons: 0,
+            mode: 'exiting_vehicle',
+            vehicleAction: 'exit',
+            vehicleId,
+          };
+        }
+        return vehicleAgentStateToIntent(desired, chassisQuat, {
+          yaw: footIntent.yaw,
+          pitch: footIntent.pitch,
+          mode: 'driving',
+          targetPlayerId: footIntent.targetPlayerId,
+          vehicleId,
+          firePrimary: false,
+          vehicleAction: null,
+        });
+      }
+
+      case 'exiting_vehicle': {
+        if (!isInVehicle) {
+          // Server confirmed the dismount. Clean up vehicle state.
+          this.releaseBotVehicleResources(bot);
+          bot.vehicleStage = 'on_foot';
+          bot.fsmTicks = 0;
+          return null;
+        }
+        if (bot.fsmTicks > 120) {
+          // Stuck mid-dismount? Force-reset local state. The server will
+          // eventually catch up via its own ack loop.
+          this.releaseBotVehicleResources(bot);
+          bot.vehicleStage = 'on_foot';
+          bot.fsmTicks = 0;
+          return null;
+        }
+        return { ...footIntent, buttons: 0, mode: 'exiting_vehicle' };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Picks the best vehicle for a walk-vs-drive comparison. Returns
+   * `null` if walking is preferred (or no vehicle is tractable). Scans
+   * every unreserved, undriven vehicle in `host.vehicles` and keeps
+   * the one with the lowest estimated total travel time.
+   */
+  private planVehicleRoute(
+    bot: PracticeBot,
+    botPosition: Vec3Tuple,
+    destination: Vec3Tuple,
+  ): { vehicleId: number; vehiclePosition: Vec3Tuple } | null {
+    if (!this.host) return null;
+    // Walk baseline: foot path length / walkable speed. If the foot
+    // path itself fails (destination unreachable on foot), we can't
+    // compare at all.
+    const walkLength = this.crowd.estimatePathLength(
+      botPosition,
+      destination,
+      DEFAULT_QUERY_FILTER,
+    );
+    if (walkLength === null) return null;
+    const walkSpeed = Math.max(1, this.maxSpeed);
+    const walkTimeSec = walkLength / walkSpeed;
+
+    const vehicleCrowd = this.ensureVehicleCrowd();
+    const vehicleFilter = this.vehicleQueryFilter ?? DEFAULT_QUERY_FILTER;
+    const profile = this.vehicleProfile;
+
+    let best: { vehicleId: number; vehiclePosition: Vec3Tuple; travelTime: number } | null = null;
+    for (const [vehicleId, state] of this.host.vehicles) {
+      // Skip vehicles already claimed by another bot or driven by anyone.
+      if (this.reservedVehicles.has(vehicleId)) continue;
+      if (state.driverId !== 0) continue;
+      const vehiclePosition: Vec3Tuple = [
+        state.position[0],
+        state.position[1],
+        state.position[2],
+      ];
+      // Leg 1: walk to the vehicle.
+      const walkToLength = this.crowd.estimatePathLength(
+        botPosition,
+        vehiclePosition,
+        DEFAULT_QUERY_FILTER,
+      );
+      if (walkToLength === null) continue;
+      // Leg 2: drive from vehicle to destination on the vehicle navmesh.
+      const driveLength = vehicleCrowd.estimatePathLength(
+        vehiclePosition,
+        destination,
+        vehicleFilter,
+      );
+      if (driveLength === null) continue;
+      const driveTime = walkToLength / walkSpeed
+        + driveLength / profile.cruiseSpeed
+        + profile.enterExitOverheadSec;
+      if (!best || driveTime < best.travelTime) {
+        best = { vehicleId, vehiclePosition, travelTime: driveTime };
+      }
+    }
+    if (!best) return null;
+    // Hysteresis — only switch to driving if it's **significantly** faster.
+    // Otherwise the bot would thrash at the walk/drive boundary.
+    if (best.travelTime > walkTimeSec * 0.75) return null;
+    return { vehicleId: best.vehicleId, vehiclePosition: best.vehiclePosition };
+  }
+
+  /**
+   * Atomic reservation: only inserts if no other bot holds the slot.
+   * Returns true on success.
+   */
+  private tryReserveVehicle(vehicleId: number, botId: number): boolean {
+    const current = this.reservedVehicles.get(vehicleId);
+    if (current !== undefined && current !== botId) return false;
+    this.reservedVehicles.set(vehicleId, botId);
+    return true;
   }
 }
 
@@ -586,6 +1092,8 @@ function makeIdleIntent(): BotIntent {
     firePrimary: false,
     mode: 'hold_anchor',
     targetPlayerId: null,
+    vehicleAction: null,
+    vehicleId: null,
   };
 }
 

--- a/client/src/bots/types.ts
+++ b/client/src/bots/types.ts
@@ -39,6 +39,15 @@ export interface BotIntent {
   firePrimary: boolean;
   mode: BotMode;
   targetPlayerId: number | null;
+  /**
+   * Side-channel request to enter or exit a vehicle this tick. Consumed by
+   * `PracticeBotRuntime`, which translates it to a `PKT_VEHICLE_ENTER` /
+   * `PKT_VEHICLE_EXIT` through the local-preview transport. Null means
+   * "no vehicle action this tick" (the common case).
+   */
+  vehicleAction?: 'enter' | 'exit' | null;
+  /** Vehicle id the action targets (only meaningful when vehicleAction != null). */
+  vehicleId?: number | null;
 }
 
 export type BotMode =
@@ -46,4 +55,33 @@ export type BotMode =
   | 'follow_target'
   | 'recover_center'
   | 'hold_anchor'
-  | 'dead';
+  | 'dead'
+  | 'walking_to_vehicle'
+  | 'entering_vehicle'
+  | 'driving'
+  | 'exiting_vehicle';
+
+/**
+ * Static physical parameters for a driven vehicle, used by the bot planner
+ * to:
+ *  - size the vehicle navmesh / crowd agent,
+ *  - bias `getCost` against turns sharper than the chassis can execute,
+ *  - estimate travel time for the "walk vs drive" planner in the brain.
+ *
+ * Units are meters / seconds everywhere. Defaults for the stock practice
+ * vehicle live in `PracticeBotRuntime`.
+ */
+export interface VehicleProfile {
+  /** Minimum turning radius (m). Turns tighter than this are heavily penalized by the vehicle `QueryFilter.getCost`. */
+  turningRadius: number;
+  /** Agent radius used when adding a vehicle-bot agent to the vehicle crowd (m). */
+  agentRadius: number;
+  /** Agent height used when adding a vehicle-bot agent to the vehicle crowd (m). */
+  agentHeight: number;
+  /** Cruise speed used when estimating drive-leg travel time (m/s). */
+  cruiseSpeed: number;
+  /** Max walk distance (m) at which a bot will consider a vehicle "reachable". */
+  enterDistance: number;
+  /** Fixed seconds added to the drive-leg estimate to account for enter + exit animations. */
+  enterExitOverheadSec: number;
+}

--- a/client/src/bots/world/buildNavMesh.ts
+++ b/client/src/bots/world/buildNavMesh.ts
@@ -17,6 +17,7 @@ import {
   getSharedPlayerNavigationProfileAsync,
   type SharedPlayerNavigationProfile,
 } from '../../wasm/sharedPhysics';
+import type { VehicleProfile } from '../types';
 import { buildWorldGeometry, type BotWorldGeometry } from './worldGeometry';
 
 export type NavMeshMode = 'solo' | 'tiled';
@@ -173,5 +174,36 @@ export async function buildBotNavMeshFromSharedProfile(
   return buildBotNavMesh(world, {
     ...options,
     navigationProfile,
+  });
+}
+
+/**
+ * Builds a second, vehicle-sized navmesh for the same world. The walkable
+ * radius is inflated to {@link VehicleProfile.agentRadius} so narrow alleys
+ * and doorways that a player can squeeze through on foot are automatically
+ * excluded — the vehicle simply can't path there.
+ *
+ * The climb height is dropped to match a car's max step-over (a wheeled
+ * chassis can't take 0.55 m curbs) and the slope angle is tightened too so
+ * drivable polygons only cover geometry a raycast-vehicle can physically
+ * traverse.
+ *
+ * Callers should not rebuild this mesh every tick — build once per world
+ * and reuse it across all vehicle-mode bots.
+ */
+export function buildVehicleBotNavMesh(
+  world: WorldDocument,
+  profile: VehicleProfile,
+  overrides: Partial<BuildBotNavMeshOptions> = {},
+): BotNavMesh {
+  const navigationProfile: SharedPlayerNavigationProfile = {
+    walkableRadius: profile.agentRadius,
+    walkableHeight: profile.agentHeight,
+    walkableClimb: 0.15,
+    walkableSlopeAngleDegrees: 25,
+  };
+  return buildBotNavMesh(world, {
+    navigationProfile,
+    ...overrides,
   });
 }

--- a/client/src/loadtest/brain.ts
+++ b/client/src/loadtest/brain.ts
@@ -16,7 +16,16 @@ export type ObservedPlayer = {
   state: PlayerStateMeters;
 };
 
-export type BotBrainMode = 'acquire_target' | 'follow_target' | 'recover_center' | 'hold_anchor' | 'dead';
+export type BotBrainMode =
+  | 'acquire_target'
+  | 'follow_target'
+  | 'recover_center'
+  | 'hold_anchor'
+  | 'dead'
+  | 'walking_to_vehicle'
+  | 'entering_vehicle'
+  | 'driving'
+  | 'exiting_vehicle';
 
 export interface BotBrainState {
   mode: BotBrainMode;

--- a/client/src/net/localPracticeClient.ts
+++ b/client/src/net/localPracticeClient.ts
@@ -4,6 +4,8 @@ import {
   type BatteryStateMeters,
   SIM_HZ,
   encodeInputBundle,
+  encodeVehicleEnterPacket,
+  encodeVehicleExitPacket,
   netPlayerStateToMeters,
   netVehicleStateToMeters,
   type BlockEditCmd,
@@ -46,6 +48,8 @@ export interface PracticeBotHost {
   disconnectBot(botId: number): boolean;
   setBotMaxSpeed(botId: number, maxSpeedMps: number | null): boolean;
   sendBotInputs(botId: number, cmds: InputCmd[]): void;
+  sendBotVehicleEnter(botId: number, vehicleId: number, seat?: number): void;
+  sendBotVehicleExit(botId: number, vehicleId: number): void;
 }
 
 export class LocalPracticeClient implements PracticeBotHost {
@@ -173,6 +177,26 @@ export class LocalPracticeClient implements PracticeBotHost {
       session.handleBotPacket(botId >>> 0, encodeInputBundle(cmds));
     } catch (error) {
       console.warn('[local-practice] bot input rejected', error);
+    }
+  }
+
+  sendBotVehicleEnter(botId: number, vehicleId: number, _seat = 0): void {
+    const session = this.session;
+    if (!session) return;
+    try {
+      session.handleBotPacket(botId >>> 0, encodeVehicleEnterPacket(vehicleId >>> 0, 0));
+    } catch (error) {
+      console.warn('[local-practice] bot vehicle enter rejected', error);
+    }
+  }
+
+  sendBotVehicleExit(botId: number, vehicleId: number): void {
+    const session = this.session;
+    if (!session) return;
+    try {
+      session.handleBotPacket(botId >>> 0, encodeVehicleExitPacket(vehicleId >>> 0));
+    } catch (error) {
+      console.warn('[local-practice] bot vehicle exit rejected', error);
     }
   }
 
@@ -380,6 +404,7 @@ export class LocalPracticeClient implements PracticeBotHost {
         yaw: meters.yaw,
         pitch: meters.pitch,
         hp: meters.hp,
+        flags: state.flags,
       });
     }
 

--- a/client/src/net/netcodeClient.ts
+++ b/client/src/net/netcodeClient.ts
@@ -41,6 +41,8 @@ export type RemotePlayer = {
   yaw: number;
   pitch: number;
   hp: number;
+  /** Latest player state flags (FLAG_DEAD, FLAG_IN_VEHICLE, ...). */
+  flags: number;
 };
 
 export type NetcodeClientConfig = {
@@ -410,6 +412,7 @@ export class NetcodeClient {
         yaw,
         pitch,
         hp: player.hp,
+        flags: player.flags,
       });
     }
 
@@ -740,6 +743,7 @@ export class NetcodeClient {
               yaw: m.yaw,
               pitch: m.pitch,
               hp: m.hp,
+              flags: ps.flags,
             });
           }
         }

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -22,6 +22,7 @@ interface PracticeBotsPanelProps {
   onUpdateNavTuning: (patch: Partial<PracticeBotNavTuning>) => void;
   onResetNavTuning: () => void;
   onToggleDebugOverlay: (value: boolean) => void;
+  onSetUseVehicles: (value: boolean) => void;
 }
 
 interface NavTuningDraft {
@@ -83,6 +84,7 @@ export function PracticeBotsPanel({
   onUpdateNavTuning,
   onResetNavTuning,
   onToggleDebugOverlay,
+  onSetUseVehicles,
 }: PracticeBotsPanelProps) {
   const [open, setOpen] = useState(false);
   const [botInfos, setBotInfos] = useState<BotDebugInfo[]>([]);
@@ -93,6 +95,7 @@ export function PracticeBotsPanel({
   const behavior = stats?.behavior ?? 'harass';
   const maxSpeed = stats?.maxSpeed ?? 3.0;
   const activeNav = navConfig;
+  const useVehicles = stats?.useVehicles ?? false;
 
   const [countSliderRef, countDragStart, countDragEnd] = useDraggableInputSync(count);
   const [countNumberRef] = useDraggableInputSync(count);
@@ -240,6 +243,18 @@ export function PracticeBotsPanel({
                 );
               })}
             </div>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            {panelLabel('Vehicles')}
+            <label className="flex flex-1 cursor-pointer items-center gap-2 text-white/[0.85]">
+              <input
+                type="checkbox"
+                checked={useVehicles}
+                onChange={(event) => onSetUseVehicles(event.target.checked)}
+                className="accent-sky-300"
+              />
+              <span>bots can drive vehicles to reach targets</span>
+            </label>
           </div>
           <div className="flex items-center gap-2 text-xs">
             {panelLabel('Debug')}

--- a/shared/src/local_session.rs
+++ b/shared/src/local_session.rs
@@ -156,15 +156,22 @@ impl LocalSession {
         true
     }
 
+    /// Push a bot's input packet. Bots use the same wire format as the
+    /// human client; supported kinds are `PKT_INPUT_BUNDLE`, `PKT_FIRE`,
+    /// `PKT_VEHICLE_ENTER`, and `PKT_VEHICLE_EXIT`. Vehicle enter/exit
+    /// routes straight through `arena.enter_vehicle` /
+    /// `arena.exit_vehicle`, which already take a generic player id.
     pub fn handle_bot_packet(&mut self, bot_id: u32, bytes: &[u8]) -> Result<(), String> {
         if bot_id == LOCAL_PLAYER_ID {
             return Err("cannot push bot input for local player id".to_string());
         }
-        let Some(runtime) = self.players.get_mut(&bot_id) else {
-            return Err(format!("unknown bot id {bot_id}"));
-        };
-        if !runtime.is_bot {
-            return Err(format!("player {bot_id} is not a bot"));
+        {
+            let Some(runtime) = self.players.get(&bot_id) else {
+                return Err(format!("unknown bot id {bot_id}"));
+            };
+            if !runtime.is_bot {
+                return Err(format!("player {bot_id} is not a bot"));
+            }
         }
         if bytes.is_empty() {
             return Err("empty bot packet".to_string());
@@ -173,7 +180,30 @@ impl LocalSession {
         match buf.get_u8() {
             PKT_INPUT_BUNDLE => {
                 let frames = decode_input_bundle_frames(&mut buf)?;
+                let runtime = self
+                    .players
+                    .get_mut(&bot_id)
+                    .expect("bot runtime existed in the check above");
                 enqueue_inputs(runtime, frames);
+                Ok(())
+            }
+            PKT_FIRE => {
+                let shot = decode_fire_cmd(&mut buf)?;
+                self.queued_shots.push((bot_id, shot));
+                Ok(())
+            }
+            PKT_VEHICLE_ENTER => {
+                let vehicle_id = decode_vehicle_enter(&mut buf)?;
+                if self.arena.vehicles.contains_key(&vehicle_id) {
+                    self.arena.enter_vehicle(bot_id, vehicle_id);
+                }
+                Ok(())
+            }
+            PKT_VEHICLE_EXIT => {
+                let vehicle_id = decode_vehicle_exit(&mut buf)?;
+                if self.arena.vehicle_of_player.get(&bot_id) == Some(&vehicle_id) {
+                    self.arena.exit_vehicle(bot_id);
+                }
                 Ok(())
             }
             other => Err(format!("unsupported bot packet kind {other}")),
@@ -1204,8 +1234,10 @@ mod tests {
             !initial_vehicle.is_empty(),
             "demo local session should expose at least one vehicle"
         );
-        let (vehicle_id, driver_id, _, _, _) = initial_vehicle[0];
-        assert_eq!(driver_id, 0, "authored vehicle should start unoccupied");
+        let (vehicle_id, _, _, _, _) = *initial_vehicle
+            .iter()
+            .find(|(_, driver, _, _, _)| *driver == 0)
+            .expect("at least one authored vehicle should start unoccupied");
 
         session
             .handle_client_packet(&encode_vehicle_enter_packet_for_test(vehicle_id))
@@ -1296,6 +1328,131 @@ mod tests {
         assert!(
             dz > 0.0,
             "bot should have moved after 10 ticks of forward input"
+        );
+    }
+
+    fn encode_vehicle_exit_packet_for_test(vehicle_id: u32) -> Vec<u8> {
+        let mut out = BytesMut::with_capacity(5);
+        out.put_u8(PKT_VEHICLE_EXIT);
+        out.put_u32_le(vehicle_id);
+        out.to_vec()
+    }
+
+    #[test]
+    fn bot_can_enter_and_drive_a_vehicle() {
+        let mut session = LocalSession::new();
+        session.connect();
+        let _ = session.drain_packets();
+        assert!(session.connect_bot(404));
+
+        // Tick once so the vehicle state is represented in a snapshot the
+        // test can inspect.
+        session.tick(1.0 / 60.0);
+        let initial_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("initial snapshot after connect_bot");
+        let initial_vehicles = decode_snapshot_vehicle_states(&initial_snapshot);
+        assert!(
+            !initial_vehicles.is_empty(),
+            "demo local preview should expose at least one authored vehicle"
+        );
+        let (vehicle_id, _, start_px, _, start_pz) = *initial_vehicles
+            .iter()
+            .find(|(_, driver, _, _, _)| *driver == 0)
+            .expect("at least one authored vehicle should start unoccupied");
+
+        // Route the enter packet through `handle_bot_packet` — this is the
+        // path `PracticeBotRuntime` uses when a bot reaches the
+        // `entering_vehicle` FSM state.
+        session
+            .handle_bot_packet(404, &encode_vehicle_enter_packet_for_test(vehicle_id))
+            .expect("bot vehicle enter should be accepted");
+        session.tick(1.0 / 60.0);
+
+        // The arena should now record the bot as the vehicle's driver, and
+        // `vehicle_of_player` should mirror that.
+        assert_eq!(
+            session.arena.vehicle_of_player.get(&404),
+            Some(&vehicle_id),
+            "bot should be seated in the vehicle after handle_bot_packet"
+        );
+        let seated_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("snapshot after bot entered vehicle");
+        let seated_vehicles = decode_snapshot_vehicle_states(&seated_snapshot);
+        let (_, seated_driver_id, _, _, _) = *seated_vehicles
+            .iter()
+            .find(|(id, _, _, _, _)| *id == vehicle_id)
+            .expect("seated vehicle should still be in the snapshot");
+        assert_eq!(
+            seated_driver_id, 404,
+            "snapshot driver_id should reflect the seated bot"
+        );
+
+        // Push a forward-throttle input bundle and tick for ~0.5 s of sim
+        // time. With `input_to_vehicle_cmd` driving the raycast vehicle,
+        // chassis-local forward (−Z) should translate the vehicle along
+        // world −Z (authored vehicle spawns unrotated in the demo world).
+        let frame = InputCmd {
+            seq: 1,
+            buttons: 0,
+            move_x: 0,
+            move_y: 127,
+            yaw: 0.0,
+            pitch: 0.0,
+        };
+        let bytes = encode_single_input_bundle(&frame);
+        session
+            .handle_bot_packet(404, &bytes)
+            .expect("bot input bundle should be accepted while driving");
+        for _ in 0..30 {
+            session.tick(1.0 / 60.0);
+        }
+        let driven_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .rev()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("snapshot after driving the vehicle");
+        let driven_vehicles = decode_snapshot_vehicle_states(&driven_snapshot);
+        let (_, _, end_px, _, end_pz) = *driven_vehicles
+            .iter()
+            .find(|(id, _, _, _, _)| *id == vehicle_id)
+            .expect("driven vehicle should still be in the snapshot");
+        let dx = (end_px - start_px).abs();
+        let dz = (end_pz - start_pz).abs();
+        assert!(
+            dx > 0 || dz > 0,
+            "bot-driven vehicle should have moved from its spawn after 30 forward ticks"
+        );
+
+        // Exit cleanly via `handle_bot_packet` and confirm the driver slot
+        // clears.
+        session
+            .handle_bot_packet(404, &encode_vehicle_exit_packet_for_test(vehicle_id))
+            .expect("bot vehicle exit should be accepted");
+        session.tick(1.0 / 60.0);
+        assert!(
+            !session.arena.vehicle_of_player.contains_key(&404),
+            "bot should no longer be seated after exit packet"
+        );
+        let exited_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("snapshot after bot exited");
+        let exited_vehicles = decode_snapshot_vehicle_states(&exited_snapshot);
+        let (_, exited_driver_id, _, _, _) = *exited_vehicles
+            .iter()
+            .find(|(id, _, _, _, _)| *id == vehicle_id)
+            .expect("exited vehicle should still be in the snapshot");
+        assert_eq!(
+            exited_driver_id, 0,
+            "vehicle should be unoccupied again after exit"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds an opt-in toggle to the Practice Bots panel that lets bots enter, drive, and exit vehicles whenever driving would reach their destination faster than walking. Built on top of the navmesh-based practice-bot runtime from `feat/bots-with-navmesh`.

## How it works

- **Walk-vs-drive planner**: for each bot's current destination, compares
  - `t_walk = footPathLength / footMaxSpeed`, and
  - `t_drive = walkToVehicleLength / footMaxSpeed + driveLength / cruiseSpeed + enterExitOverhead`.

  The drive route only wins if it's >25% faster **and** the destination is >15 m away (hysteresis).

- **Two navmeshes, two crowds**: a lazy vehicle-sized `BotCrowd` (inflated `walkableRadius = VehicleProfile.agentRadius`, tightened `walkableClimb = 0.15 m`, `walkableSlopeAngle = 25°`) is built on first `setUseVehicles(true)`. Foot bots continue to use the existing navmesh unchanged.

- **Turn-aware A\* cost**: `createVehicleQueryFilter(profile)` adds a per-edge penalty derived from the chord formula `requiredRadius ≈ segmentLen / (2·sin(θ/2))`. Corners tighter than `profile.turningRadius` get a hard multiplier so A\* routes around them; gentler corners get a mild soft penalty.

- **Per-bot vehicle FSM**: `on_foot → walking_to_vehicle → entering_vehicle → driving → exiting_vehicle`. Transitions wait for `FLAG_IN_VEHICLE` in the snapshot before switching to driving inputs, so the input bundle isn't misinterpreted mid-flight.

- **Chassis-local steering**: `vehicleAgentStateToIntent(desiredVel, chassisQuat, ...)` rotates the vehicle-crowd agent's `desiredVelocity` into chassis-local space and emits `BTN_FORWARD`/`BACK`/`LEFT`/`RIGHT` from the local heading — which is what `shared/src/movement.rs::input_to_vehicle_cmd` actually consumes (`InputCmd.yaw` is unused for vehicles).

- **Vehicle reservations**: `reservedVehicles: Map<vehicleId, botId>` prevents two bots from claiming the same car. Released on FSM exit, bot removal, and `setUseVehicles(false)`.

- **Self-obstacle fix**: `syncVehicleObstacles` now skips vehicles driven by our own bots — otherwise a driving bot would see its own chassis as a crowd obstacle. Peer bots still see it.

- **Server**: `LocalSession::handle_bot_packet` now accepts `PKT_VEHICLE_ENTER` and `PKT_VEHICLE_EXIT`, routed straight through `arena.enter_vehicle` / `arena.exit_vehicle` (which already take a generic `player_id`). `LocalPracticeClient` exposes matching `sendBotVehicleEnter` / `sendBotVehicleExit` on the `PracticeBotHost` interface.

- **UI**: new "Vehicles — bots can drive vehicles to reach targets" checkbox in `PracticeBotsPanel`, wired through `handleSetBotUseVehicles` in `App.tsx`.

## New / changed files

- **New**: `client/src/bots/agent/vehicleSteering.ts` + test, `client/src/bots/crowd/vehicleQueryFilter.ts` + test.
- **Modified**: `PracticeBotRuntime` (FSM, two crowds, planner, reservations), `BotCrowd` (`setAgentQueryFilter`, `estimatePathLength`, `createVehicleBotCrowd`), `buildNavMesh` (`buildVehicleBotNavMesh` helper), `types.ts` (`VehicleProfile`, `DEFAULT_VEHICLE_PROFILE`, `BotIntent.vehicleAction`/`vehicleId`), `LocalPracticeClient` + `PracticeBotHost` interface, `PracticeBotsPanel` + `App.tsx`, `local_session.rs` (bot vehicle packet handling).

## Defaults

`DEFAULT_VEHICLE_PROFILE`: `turningRadius=5 m`, `agentRadius=1.3 m`, `agentHeight=1.5 m`, `cruiseSpeed=12 m/s`, `enterDistance=2.5 m`, `enterExitOverheadSec=1.5 s`. Conservative — tune after playtest.

## Test plan

- [x] `vehicleSteering.test.ts` — 9 tests for `rotateVectorByQuaternionInverse` round-trip + `vehicleAgentStateToIntent` forward/back/left/right + rotated-chassis + deadband.
- [x] `vehicleQueryFilter.test.ts` — 5 tests for straight / gentle-curve / sharp-corner / long-approach / zero-length-vector cases on `computeTurnAwareCost`.
- [x] `cargo test -p vibe-land-shared` — new `bot_can_enter_and_drive_a_vehicle` test (connect_bot → `PKT_VEHICLE_ENTER` → forward input bundle translates chassis → `PKT_VEHICLE_EXIT` clears driver). All 60 shared-crate tests pass.
- [x] TypeScript typecheck clean (only pre-existing wasm-pkg / AI-SDK / RJSF errors remain).
- [ ] Manual playtest: spawn 4 bots + 4 vehicles, enable the checkbox, watch the FSM overlay, confirm they drive, steer around obstacles, arrive, and exit. Toggle off mid-run and confirm clean return to walking.

https://claude.ai/code/session_01VmjFtZuEtDr7Hf1mtx1j3E