### PR TITLE
Add vehicle driving mode to practice bots with walk-vs-drive planner

### DIFF
--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/client/benchmark/wsWorker.ts
+++ b/client/benchmark/wsWorker.ts
@@ -10,7 +10,12 @@ import {
   WEAPON_HITSCAN,
   type PlayerStateMeters,
 } from '../src/net/protocol.js';
-import { stepBotBrain, createBotBrainState, type ObservedPlayer } from '../src/loadtest/brain.js';
+import {
+  createBotBrainState,
+  disposeBotBrainState,
+  stepBotBrain,
+  type ObservedPlayer,
+} from '../src/loadtest/brain.js';
 import { PacketImpairment } from '../src/loadtest/networkModel.js';
 import {
   SeededRandom,
@@ -18,6 +23,8 @@ import {
   type LoadTestScenario,
   type NetworkProfile,
 } from '../src/loadtest/scenario.js';
+import { createBotCrowd, type BotCrowd } from '../src/bots/index.js';
+import { DEFAULT_WORLD_DOCUMENT } from '../src/world/worldDocument.js';
 import type { WebSocketWorkerResult } from '../src/benchmark/contracts.js';
 
 type BotMetrics = {
@@ -48,6 +55,7 @@ type BotState = {
   localState: PlayerStateMeters | null;
   remotePlayers: Map<number, ObservedPlayer>;
   brainState: ReturnType<typeof createBotBrainState>;
+  botCrowd: BotCrowd;
   inboundImpairment: PacketImpairment<Uint8Array>;
   outboundImpairment: PacketImpairment<Uint8Array>;
   currentTargetPlayerId: number | null;
@@ -120,6 +128,7 @@ function stopBot(state: BotState): void {
     clearInterval(state.tickHandle);
     state.tickHandle = null;
   }
+  disposeBotBrainState(state.brainState, state.botCrowd);
   state.inboundImpairment.dispose();
   state.outboundImpairment.dispose();
   state.ws?.close();
@@ -131,6 +140,7 @@ function spawnBot(
   token: string,
   scenario: LoadTestScenario,
   profile: NetworkProfile,
+  botCrowd: BotCrowd,
 ): Promise<BotState> {
   return new Promise((resolve, reject) => {
     const identity = `bench-ws-${id}`;
@@ -154,7 +164,8 @@ function spawnBot(
       metrics: makeBotMetrics(),
       localState: null,
       remotePlayers: new Map(),
-      brainState: createBotBrainState(id - 1, scenario),
+      brainState: createBotBrainState(id - 1, scenario, { crowd: botCrowd }),
+      botCrowd,
       inboundImpairment: new PacketImpairment(profile.downlink, scenario.seed + id * 17, (bytes) => {
         handlePacket(bytes);
       }),
@@ -297,6 +308,12 @@ export async function runWebSocketWorker(options: {
 
   const startMs = Date.now();
   const startedAt = new Date().toISOString();
+  const botCrowd = createBotCrowd(DEFAULT_WORLD_DOCUMENT, { maxAgentRadius: 0.6 });
+  const crowdTickHz = 30;
+  const crowdDt = 1 / crowdTickHz;
+  const crowdInterval = setInterval(() => {
+    botCrowd.step(crowdDt);
+  }, 1000 / crowdTickHz);
   const rng = new SeededRandom(scenario.seed);
   const botPromises = Array.from({ length: requestedBots }, (_, index) => {
     const profile = chooseWeightedProfile(scenario, 'websocket', rng);
@@ -305,7 +322,7 @@ export async function runWebSocketWorker(options: {
       : 0;
     return new Promise<BotState>((resolve, reject) => {
       setTimeout(() => {
-        void spawnBot(index + 1, serverHost, token, scenario, profile).then(resolve, reject);
+        void spawnBot(index + 1, serverHost, token, scenario, profile, botCrowd).then(resolve, reject);
       }, delayMs);
     });
   });
@@ -331,6 +348,7 @@ export async function runWebSocketWorker(options: {
   for (const bot of bots) {
     stopBot(bot);
   }
+  clearInterval(crowdInterval);
 
   const totals = summarizeBots(bots);
   return {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-three/drei": "^9.117.0",
         "@react-three/fiber": "^8.17.0",
+        "navcat": "^0.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "three": "^0.170.0"
@@ -2210,6 +2211,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mathcat": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/mathcat/-/mathcat-0.0.11.tgz",
+      "integrity": "sha512-HIGDmqrjy6KE4LRH9uGLdYoVl+69idwtE5OjHILnNB4IL4RE2aVNagjLAWFKWH5xlcxNH9i+AoBgRKR4VdsyFw==",
+      "license": "MIT"
+    },
     "node_modules/meshline": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
@@ -2249,6 +2256,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/navcat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/navcat/-/navcat-0.2.0.tgz",
+      "integrity": "sha512-maceGQOmkMZudHKeeUyY48hbuvcHl8M1dG6aPLQjH26/vD776GI1lWHJosqBD9NU0Zo6SxDI1cGFFtezCoCBnA==",
+      "license": "MIT",
+      "dependencies": {
+        "mathcat": "0.0.11"
+      },
+      "peerDependencies": {
+        "three": ">=0.180.0"
+      },
+      "peerDependenciesMeta": {
+        "three": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {

--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@react-three/drei": "^9.117.0",
     "@react-three/fiber": "^8.17.0",
+    "navcat": "^0.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "three": "^0.170.0"

--- a/client/simulate.ts
+++ b/client/simulate.ts
@@ -24,8 +24,15 @@ import {
   type PlayerStateMeters,
   WEAPON_HITSCAN,
 } from './src/net/protocol.js';
-import { stepBotBrain, createBotBrainState, type ObservedPlayer } from './src/loadtest/brain.js';
+import {
+  createBotBrainState,
+  disposeBotBrainState,
+  stepBotBrain,
+  type ObservedPlayer,
+} from './src/loadtest/brain.js';
 import { PacketImpairment } from './src/loadtest/networkModel.js';
+import { createBotCrowd, type BotCrowd } from './src/bots/index.js';
+import { DEFAULT_WORLD_DOCUMENT } from './src/world/worldDocument.js';
 import {
   DEFAULT_SCENARIO,
   SeededRandom,
@@ -75,6 +82,7 @@ type BotState = {
   localState: PlayerStateMeters | null;
   remotePlayers: Map<number, ObservedPlayer>;
   brainState: ReturnType<typeof createBotBrainState>;
+  botCrowd: BotCrowd;
   inboundImpairment: PacketImpairment<Uint8Array>;
   outboundImpairment: PacketImpairment<Uint8Array>;
   currentTargetPlayerId: number | null;
@@ -169,6 +177,7 @@ function spawnBot(
   scenario: LoadTestScenario,
   profile: NetworkProfile,
   statsMonitor: StatsMonitor,
+  botCrowd: BotCrowd,
 ): Promise<BotState> {
   return new Promise((resolve, reject) => {
     const identity = `bot-${id}`;
@@ -193,7 +202,8 @@ function spawnBot(
       metrics: makeBotMetrics(),
       localState: null,
       remotePlayers: new Map(),
-      brainState: createBotBrainState(id - 1, scenario),
+      brainState: createBotBrainState(id - 1, scenario, { crowd: botCrowd }),
+      botCrowd,
       inboundImpairment: new PacketImpairment(profile.downlink, scenario.seed + id * 17, (bytes) => {
         handlePacket(state, scenario, statsMonitor, bytes);
       }),
@@ -353,6 +363,7 @@ function stopBot(state: BotState): void {
     clearInterval(state.tickHandle);
     state.tickHandle = null;
   }
+  disposeBotBrainState(state.brainState, state.botCrowd);
   state.inboundImpairment.dispose();
   state.outboundImpairment.dispose();
   state.ws?.close();
@@ -433,13 +444,28 @@ async function main(): Promise<void> {
   const statsMonitor = new StatsMonitor(`ws://${SERVER_HOST}/ws/stats`);
   statsMonitor.connect();
 
+  const navBuildStarted = Date.now();
+  const botCrowd = createBotCrowd(DEFAULT_WORLD_DOCUMENT, {
+    maxAgentRadius: 0.6,
+  });
+  const navBuildMs = Date.now() - navBuildStarted;
+  console.log(
+    `Built navmesh in ${navBuildMs}ms (${botCrowd.nav.geometry.triangleCount} tris, ${botCrowd.nav.geometry.vertexCount} verts)\n`,
+  );
+
+  const crowdTickHz = 30;
+  const crowdDt = 1 / crowdTickHz;
+  const crowdInterval = setInterval(() => {
+    botCrowd.step(crowdDt);
+  }, 1000 / crowdTickHz);
+
   const rng = new SeededRandom(scenario.seed);
   const botPromises = Array.from({ length: wsBotCount }, (_, index) => {
     const profile = chooseWeightedProfile(scenario, 'websocket', rng);
     const delayMs = scenario.rampUpS > 0 ? Math.round((scenario.rampUpS * 1000 * index) / Math.max(1, wsBotCount)) : 0;
     return new Promise<BotState>((resolve, reject) => {
       setTimeout(() => {
-        void spawnBot(index + 1, scenario, profile, statsMonitor).then(resolve, reject);
+        void spawnBot(index + 1, scenario, profile, statsMonitor, botCrowd).then(resolve, reject);
       }, delayMs);
     });
   });
@@ -498,6 +524,7 @@ async function main(): Promise<void> {
     }
     cleanedUp = true;
     clearInterval(statusInterval);
+    clearInterval(crowdInterval);
     console.log('\nStopping all websocket bots...');
     for (const bot of bots) {
       stopBot(bot);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -229,6 +229,12 @@ export function App({
   const handleToggleBotDebugOverlay = useCallback((value: boolean) => {
     setPracticeBotDebugOverlay(value);
   }, []);
+  const handleSetBotUseVehicles = useCallback((value: boolean) => {
+    const runtime = practiceBotRuntimeRef.current;
+    if (!runtime) return;
+    runtime.setUseVehicles(value);
+    refreshPracticeBotStats();
+  }, [refreshPracticeBotStats]);
   // Pre-build the runtime once practice mode is active. The navmesh build
   // is synchronous so we defer it via a macrotask; the first paint stays
   // unblocked but the runtime is ready before the user can interact with
@@ -757,6 +763,7 @@ export function App({
         onSetBehavior={handleSetBotBehavior}
         onSetMaxSpeed={handleSetBotMaxSpeed}
         onToggleDebugOverlay={handleToggleBotDebugOverlay}
+        onSetUseVehicles={handleSetBotUseVehicles}
       />
       <DebugOverlay
         stats={displayStats}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -187,60 +187,82 @@ export function App({
   // drill targets aren't fighting terrain or props for visibility.
   const effectiveWorldDocument = calibrationOpen ? CALIBRATION_WORLD_DOCUMENT : worldDocument;
 
-  // Practice-mode bot runtime. Lazily constructed the first time the user
-  // spawns a bot via the panel (navmesh build takes a beat and isn't worth
-  // paying upfront for users who never enable bots).
-  const practiceBotRuntimeRef = useRef<PracticeBotRuntime | null>(null);
+  // Practice-mode bot runtime. We pre-build it asynchronously in a useEffect
+  // when practice mode connects, so the user's first slider drag isn't
+  // blocked by the (~1s) navmesh construction inside the constructor —
+  // which previously made the slider feel unresponsive.
+  const [practiceBotRuntime, setPracticeBotRuntime] = useState<PracticeBotRuntime | null>(null);
   const [practiceBotStats, setPracticeBotStats] = useState<PracticeBotStats | null>(null);
+  const [practiceBotDebugOverlay, setPracticeBotDebugOverlay] = useState(false);
   const refreshPracticeBotStats = useCallback(() => {
-    const runtime = practiceBotRuntimeRef.current;
-    setPracticeBotStats(runtime ? runtime.stats() : null);
-  }, []);
-  const ensurePracticeBotRuntime = useCallback((): PracticeBotRuntime => {
-    let runtime = practiceBotRuntimeRef.current;
-    if (!runtime) {
-      runtime = new PracticeBotRuntime(effectiveWorldDocument, { maxAgentRadius: 0.6 });
-      practiceBotRuntimeRef.current = runtime;
-    }
-    return runtime;
-  }, [effectiveWorldDocument]);
+    setPracticeBotStats((prev) => {
+      const runtime = practiceBotRuntime;
+      if (!runtime) return prev === null ? prev : null;
+      return runtime.stats();
+    });
+  }, [practiceBotRuntime]);
   const handleSetBotCount = useCallback((count: number) => {
-    if (count <= 0 && !practiceBotRuntimeRef.current) {
-      return;
-    }
-    const runtime = ensurePracticeBotRuntime();
+    const runtime = practiceBotRuntime;
+    if (!runtime) return;
     runtime.setBotCount(count);
     refreshPracticeBotStats();
-  }, [ensurePracticeBotRuntime, refreshPracticeBotStats]);
+  }, [practiceBotRuntime, refreshPracticeBotStats]);
   const handleClearBots = useCallback(() => {
-    practiceBotRuntimeRef.current?.clear();
+    practiceBotRuntime?.clear();
     refreshPracticeBotStats();
-  }, [refreshPracticeBotStats]);
+  }, [practiceBotRuntime, refreshPracticeBotStats]);
   const handleSetBotBehavior = useCallback((kind: PracticeBotBehaviorKind) => {
-    const runtime = ensurePracticeBotRuntime();
+    const runtime = practiceBotRuntime;
+    if (!runtime) return;
     runtime.setBehavior(kind);
     refreshPracticeBotStats();
-  }, [ensurePracticeBotRuntime, refreshPracticeBotStats]);
+  }, [practiceBotRuntime, refreshPracticeBotStats]);
   const handleSetBotMaxSpeed = useCallback((speed: number) => {
-    const runtime = ensurePracticeBotRuntime();
+    const runtime = practiceBotRuntime;
+    if (!runtime) return;
     runtime.setMaxSpeed(speed);
     refreshPracticeBotStats();
-  }, [ensurePracticeBotRuntime, refreshPracticeBotStats]);
-  // Tear down bots when leaving practice mode or switching worlds (calibration).
+  }, [practiceBotRuntime, refreshPracticeBotStats]);
+  const handleToggleBotDebugOverlay = useCallback((value: boolean) => {
+    setPracticeBotDebugOverlay(value);
+  }, []);
+  // Pre-build the runtime once practice mode is active. The navmesh build
+  // is synchronous so we defer it via a microtask; keeps the first paint
+  // unblocked but the runtime is ready by the time the user opens the
+  // panel.
   useEffect(() => {
     if (!practiceMode) {
-      practiceBotRuntimeRef.current?.clear();
-      practiceBotRuntimeRef.current = null;
+      if (practiceBotRuntime) {
+        practiceBotRuntime.clear();
+        practiceBotRuntime.detach();
+      }
+      setPracticeBotRuntime(null);
       setPracticeBotStats(null);
+      return;
     }
-  }, [practiceMode]);
+    let cancelled = false;
+    const handle = window.setTimeout(() => {
+      if (cancelled) return;
+      const runtime = new PracticeBotRuntime(effectiveWorldDocument, { maxAgentRadius: 0.6 });
+      setPracticeBotRuntime(runtime);
+      setPracticeBotStats(runtime.stats());
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [practiceMode, effectiveWorldDocument]);
+  // Tear down the previous runtime whenever it gets replaced (world swap,
+  // mode swap, unmount).
   useEffect(() => {
-    // Clear out bots when the active world swaps so they don't rely on a
-    // stale navmesh. The panel will re-create them on demand.
-    practiceBotRuntimeRef.current?.clear();
-    practiceBotRuntimeRef.current = null;
-    setPracticeBotStats(null);
-  }, [effectiveWorldDocument]);
+    return () => {
+      if (practiceBotRuntime) {
+        practiceBotRuntime.clear();
+        practiceBotRuntime.detach();
+      }
+    };
+  }, [practiceBotRuntime]);
 
   useEffect(() => {
     saveInputBindings(inputBindings);
@@ -728,10 +750,12 @@ export function App({
       <PracticeBotsPanel
         visible={practiceMode && connected && !calibrationOpen}
         stats={practiceBotStats}
+        debugOverlay={practiceBotDebugOverlay}
         onSetBotCount={handleSetBotCount}
         onClear={handleClearBots}
         onSetBehavior={handleSetBotBehavior}
         onSetMaxSpeed={handleSetBotMaxSpeed}
+        onToggleDebugOverlay={handleToggleBotDebugOverlay}
       />
       <DebugOverlay
         stats={displayStats}
@@ -768,7 +792,8 @@ export function App({
           renderStatsParent={renderStatsParentRef}
           showRenderStats={debugVisible}
           benchmarkAutopilot={benchmarkAutopilot}
-          practiceBots={practiceMode ? practiceBotRuntimeRef.current : null}
+          practiceBots={practiceMode ? practiceBotRuntime : null}
+          practiceBotsDebugOverlay={practiceMode && practiceBotDebugOverlay}
           localRenderSmoothingEnabled={localRenderSmoothingEnabled}
           sceneExtras={calibrationSceneExtras}
         />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -189,53 +189,58 @@ export function App({
 
   // Practice-mode bot runtime. We pre-build it asynchronously in a useEffect
   // when practice mode connects, so the user's first slider drag isn't
-  // blocked by the (~1s) navmesh construction inside the constructor —
-  // which previously made the slider feel unresponsive.
+  // blocked by the (~1s) navmesh construction inside the constructor.
+  //
+  // We keep BOTH a ref and React state pointing at the same runtime
+  // instance: the ref so event handlers can always see the latest value
+  // synchronously without waiting for React's next commit (avoids the
+  // "first interaction does nothing" race), and the state so prop
+  // changes flow into GameWorld and the bot panel naturally.
+  const practiceBotRuntimeRef = useRef<PracticeBotRuntime | null>(null);
   const [practiceBotRuntime, setPracticeBotRuntime] = useState<PracticeBotRuntime | null>(null);
   const [practiceBotStats, setPracticeBotStats] = useState<PracticeBotStats | null>(null);
   const [practiceBotDebugOverlay, setPracticeBotDebugOverlay] = useState(false);
   const refreshPracticeBotStats = useCallback(() => {
-    setPracticeBotStats((prev) => {
-      const runtime = practiceBotRuntime;
-      if (!runtime) return prev === null ? prev : null;
-      return runtime.stats();
-    });
-  }, [practiceBotRuntime]);
+    const runtime = practiceBotRuntimeRef.current;
+    setPracticeBotStats(runtime ? runtime.stats() : null);
+  }, []);
   const handleSetBotCount = useCallback((count: number) => {
-    const runtime = practiceBotRuntime;
+    const runtime = practiceBotRuntimeRef.current;
     if (!runtime) return;
     runtime.setBotCount(count);
     refreshPracticeBotStats();
-  }, [practiceBotRuntime, refreshPracticeBotStats]);
+  }, [refreshPracticeBotStats]);
   const handleClearBots = useCallback(() => {
-    practiceBotRuntime?.clear();
+    practiceBotRuntimeRef.current?.clear();
     refreshPracticeBotStats();
-  }, [practiceBotRuntime, refreshPracticeBotStats]);
+  }, [refreshPracticeBotStats]);
   const handleSetBotBehavior = useCallback((kind: PracticeBotBehaviorKind) => {
-    const runtime = practiceBotRuntime;
+    const runtime = practiceBotRuntimeRef.current;
     if (!runtime) return;
     runtime.setBehavior(kind);
     refreshPracticeBotStats();
-  }, [practiceBotRuntime, refreshPracticeBotStats]);
+  }, [refreshPracticeBotStats]);
   const handleSetBotMaxSpeed = useCallback((speed: number) => {
-    const runtime = practiceBotRuntime;
+    const runtime = practiceBotRuntimeRef.current;
     if (!runtime) return;
     runtime.setMaxSpeed(speed);
     refreshPracticeBotStats();
-  }, [practiceBotRuntime, refreshPracticeBotStats]);
+  }, [refreshPracticeBotStats]);
   const handleToggleBotDebugOverlay = useCallback((value: boolean) => {
     setPracticeBotDebugOverlay(value);
   }, []);
   // Pre-build the runtime once practice mode is active. The navmesh build
-  // is synchronous so we defer it via a microtask; keeps the first paint
-  // unblocked but the runtime is ready by the time the user opens the
-  // panel.
+  // is synchronous so we defer it via a macrotask; the first paint stays
+  // unblocked but the runtime is ready before the user can interact with
+  // any panel control.
   useEffect(() => {
     if (!practiceMode) {
-      if (practiceBotRuntime) {
-        practiceBotRuntime.clear();
-        practiceBotRuntime.detach();
+      const existing = practiceBotRuntimeRef.current;
+      if (existing) {
+        existing.clear();
+        existing.detach();
       }
+      practiceBotRuntimeRef.current = null;
       setPracticeBotRuntime(null);
       setPracticeBotStats(null);
       return;
@@ -244,25 +249,21 @@ export function App({
     const handle = window.setTimeout(() => {
       if (cancelled) return;
       const runtime = new PracticeBotRuntime(effectiveWorldDocument, { maxAgentRadius: 0.6 });
+      practiceBotRuntimeRef.current = runtime;
       setPracticeBotRuntime(runtime);
       setPracticeBotStats(runtime.stats());
     }, 0);
     return () => {
       cancelled = true;
       window.clearTimeout(handle);
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [practiceMode, effectiveWorldDocument]);
-  // Tear down the previous runtime whenever it gets replaced (world swap,
-  // mode swap, unmount).
-  useEffect(() => {
-    return () => {
-      if (practiceBotRuntime) {
-        practiceBotRuntime.clear();
-        practiceBotRuntime.detach();
+      const existing = practiceBotRuntimeRef.current;
+      if (existing) {
+        existing.clear();
+        existing.detach();
+        practiceBotRuntimeRef.current = null;
       }
     };
-  }, [practiceBotRuntime]);
+  }, [practiceMode, effectiveWorldDocument]);
 
   useEffect(() => {
     saveInputBindings(inputBindings);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,6 +31,12 @@ import {
   hasStoredInputSettings,
   updateInputSettings,
 } from './input/inputSettingsStore';
+import {
+  PracticeBotRuntime,
+  type PracticeBotBehaviorKind,
+  type PracticeBotStats,
+} from './bots';
+import { PracticeBotsPanel } from './ui/PracticeBotsPanel';
 
 type AppProps = {
   mode: GameMode;
@@ -180,6 +186,61 @@ export function App({
   // While the wizard is open, render a deliberately-empty flat world so
   // drill targets aren't fighting terrain or props for visibility.
   const effectiveWorldDocument = calibrationOpen ? CALIBRATION_WORLD_DOCUMENT : worldDocument;
+
+  // Practice-mode bot runtime. Lazily constructed the first time the user
+  // spawns a bot via the panel (navmesh build takes a beat and isn't worth
+  // paying upfront for users who never enable bots).
+  const practiceBotRuntimeRef = useRef<PracticeBotRuntime | null>(null);
+  const [practiceBotStats, setPracticeBotStats] = useState<PracticeBotStats | null>(null);
+  const refreshPracticeBotStats = useCallback(() => {
+    const runtime = practiceBotRuntimeRef.current;
+    setPracticeBotStats(runtime ? runtime.stats() : null);
+  }, []);
+  const ensurePracticeBotRuntime = useCallback((): PracticeBotRuntime => {
+    let runtime = practiceBotRuntimeRef.current;
+    if (!runtime) {
+      runtime = new PracticeBotRuntime(effectiveWorldDocument, { maxAgentRadius: 0.6 });
+      practiceBotRuntimeRef.current = runtime;
+    }
+    return runtime;
+  }, [effectiveWorldDocument]);
+  const handleSetBotCount = useCallback((count: number) => {
+    if (count <= 0 && !practiceBotRuntimeRef.current) {
+      return;
+    }
+    const runtime = ensurePracticeBotRuntime();
+    runtime.setBotCount(count);
+    refreshPracticeBotStats();
+  }, [ensurePracticeBotRuntime, refreshPracticeBotStats]);
+  const handleClearBots = useCallback(() => {
+    practiceBotRuntimeRef.current?.clear();
+    refreshPracticeBotStats();
+  }, [refreshPracticeBotStats]);
+  const handleSetBotBehavior = useCallback((kind: PracticeBotBehaviorKind) => {
+    const runtime = ensurePracticeBotRuntime();
+    runtime.setBehavior(kind);
+    refreshPracticeBotStats();
+  }, [ensurePracticeBotRuntime, refreshPracticeBotStats]);
+  const handleSetBotMaxSpeed = useCallback((speed: number) => {
+    const runtime = ensurePracticeBotRuntime();
+    runtime.setMaxSpeed(speed);
+    refreshPracticeBotStats();
+  }, [ensurePracticeBotRuntime, refreshPracticeBotStats]);
+  // Tear down bots when leaving practice mode or switching worlds (calibration).
+  useEffect(() => {
+    if (!practiceMode) {
+      practiceBotRuntimeRef.current?.clear();
+      practiceBotRuntimeRef.current = null;
+      setPracticeBotStats(null);
+    }
+  }, [practiceMode]);
+  useEffect(() => {
+    // Clear out bots when the active world swaps so they don't rely on a
+    // stale navmesh. The panel will re-create them on demand.
+    practiceBotRuntimeRef.current?.clear();
+    practiceBotRuntimeRef.current = null;
+    setPracticeBotStats(null);
+  }, [effectiveWorldDocument]);
 
   useEffect(() => {
     saveInputBindings(inputBindings);
@@ -664,6 +725,14 @@ export function App({
           onRenderSceneExtras={setCalibrationSceneExtras}
         />
       )}
+      <PracticeBotsPanel
+        visible={practiceMode && connected && !calibrationOpen}
+        stats={practiceBotStats}
+        onSetBotCount={handleSetBotCount}
+        onClear={handleClearBots}
+        onSetBehavior={handleSetBotBehavior}
+        onSetMaxSpeed={handleSetBotMaxSpeed}
+      />
       <DebugOverlay
         stats={displayStats}
         visible={debugVisible}
@@ -699,6 +768,7 @@ export function App({
           renderStatsParent={renderStatsParentRef}
           showRenderStats={debugVisible}
           benchmarkAutopilot={benchmarkAutopilot}
+          practiceBots={practiceMode ? practiceBotRuntimeRef.current : null}
           localRenderSmoothingEnabled={localRenderSmoothingEnabled}
           sceneExtras={calibrationSceneExtras}
         />

--- a/client/src/bots/agent/BotBrain.ts
+++ b/client/src/bots/agent/BotBrain.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-bot glue object. Owns:
+ *  - a {@link BotHandle} into a shared {@link BotCrowd}
+ *  - a {@link Behavior} that picks high-level move targets
+ *  - a {@link SteeringState} that translates agent velocity into buttons
+ *
+ * Call {@link BotBrain.think} once per bot each tick _after_ the host has
+ * called {@link BotCrowd.step}. `think` syncs the authoritative server
+ * position into the crowd, runs the behavior, optionally re-requests a move
+ * target, and returns a ready-to-send {@link BotIntent}.
+ */
+
+import type { BotCrowd, BotHandle } from '../crowd/BotCrowd';
+import { agentStateToIntent, createSteeringState, type SteeringOptions, type SteeringState } from './steering';
+import type { Behavior, BotBehaviorContext } from './behaviors';
+import type { BotIntent, BotSelfState, ObservedPlayer, Vec3Tuple } from '../types';
+
+export interface BotBrainOptions extends SteeringOptions {
+  /** World-space anchor passed to behaviors; defaults to initial position. */
+  anchor?: Vec3Tuple;
+  /**
+   * Minimum squared distance (meters²) a new target must differ from the
+   * last-requested one before we call `requestMoveTo` again. Cheap way to
+   * avoid spamming pathfinder with microscopic target churn.
+   * @default 0.25 (0.5 m)
+   */
+  retargetDistanceSqM?: number;
+  /**
+   * Hard ceiling on ticks between replans, even if target hasn't moved.
+   * Handles cases where a moving player drifts slowly away.
+   * @default 30
+   */
+  maxTicksBetweenReplans?: number;
+}
+
+export class BotBrain {
+  readonly handle: BotHandle;
+  readonly crowd: BotCrowd;
+  private behavior: Behavior;
+  private readonly steer: SteeringState;
+  private readonly options: BotBrainOptions;
+  private readonly anchor: Vec3Tuple;
+  private tick = 0;
+  private lastTarget: Vec3Tuple | null = null;
+  private ticksSinceReplan = 0;
+
+  constructor(
+    crowd: BotCrowd,
+    handle: BotHandle,
+    behavior: Behavior,
+    options: BotBrainOptions = {},
+  ) {
+    this.crowd = crowd;
+    this.handle = handle;
+    this.behavior = behavior;
+    this.options = options;
+    this.steer = createSteeringState();
+    const agent = crowd.getAgent(handle.id);
+    this.anchor = options.anchor ?? (agent
+      ? [agent.position[0], agent.position[1], agent.position[2]] as Vec3Tuple
+      : [0, 0, 0]);
+  }
+
+  /** Hot-swap the behavior without resetting steering state. */
+  setBehavior(behavior: Behavior): void {
+    this.behavior = behavior;
+    this.lastTarget = null;
+  }
+
+  /**
+   * Produces a {@link BotIntent} for this tick.
+   *
+   * @param self           The latest server-authoritative self state.
+   * @param remotePlayers  Latest observed remote players.
+   */
+  think(self: BotSelfState, remotePlayers: readonly ObservedPlayer[]): BotIntent {
+    this.tick += 1;
+
+    // Sync the crowd with server truth before running the behavior, so the
+    // decision is based on where we actually are.
+    this.crowd.syncBotPosition(this.handle, self.position);
+
+    const ctx: BotBehaviorContext = {
+      self,
+      remotePlayers,
+      anchor: this.anchor,
+      tick: this.tick,
+    };
+    const decision = this.behavior(ctx);
+
+    if (decision.target) {
+      const shouldReplan = this.shouldReplan(decision.target);
+      if (shouldReplan) {
+        this.crowd.requestMoveTo(this.handle, decision.target);
+        this.lastTarget = [...decision.target];
+        this.ticksSinceReplan = 0;
+      } else {
+        this.ticksSinceReplan += 1;
+      }
+    } else if (this.lastTarget !== null) {
+      this.crowd.stop(this.handle);
+      this.lastTarget = null;
+      this.ticksSinceReplan = 0;
+    }
+
+    const agent = this.crowd.getAgent(this.handle.id);
+    return agentStateToIntent(
+      agent,
+      self,
+      this.steer,
+      decision.mode,
+      decision.targetPlayerId,
+      decision.fireAim,
+      this.options,
+    );
+  }
+
+  private shouldReplan(target: Vec3Tuple): boolean {
+    if (this.lastTarget === null) return true;
+    const maxTicks = this.options.maxTicksBetweenReplans ?? 30;
+    if (this.ticksSinceReplan >= maxTicks) return true;
+    const dx = target[0] - this.lastTarget[0];
+    const dy = target[1] - this.lastTarget[1];
+    const dz = target[2] - this.lastTarget[2];
+    const distSq = dx * dx + dy * dy + dz * dz;
+    const threshold = this.options.retargetDistanceSqM ?? 0.25;
+    return distSq >= threshold;
+  }
+}

--- a/client/src/bots/agent/behaviors.ts
+++ b/client/src/bots/agent/behaviors.ts
@@ -1,0 +1,191 @@
+/**
+ * Composable behavior primitives for bots.
+ *
+ * A {@link Behavior} is a plain function that is invoked each tick with the
+ * current {@link BotBehaviorContext} and returns a {@link BehaviorDecision}
+ * describing the next high-level goal: a world-space move target, optional
+ * fire target, optional manual stop.
+ *
+ * Behaviors are designed to be composable — higher-level behaviors like
+ * `harassNearest` are just predicates that delegate to `followNearest` or
+ * `holdAnchor`.
+ *
+ * Consumers (loadtest, custom bot scripts) read the decision and call
+ * `BotCrowd.requestMoveTo` + `agentStateToIntent` themselves.
+ */
+
+import type { BotSelfState, ObservedPlayer, Vec3Tuple } from '../types';
+
+export interface BotBehaviorContext {
+  /** Self state from the latest server snapshot. */
+  self: BotSelfState;
+  /** Remote players the bot can see. */
+  remotePlayers: readonly ObservedPlayer[];
+  /** Anchor position (x, z), for patrols and fallbacks. */
+  anchor: Vec3Tuple;
+  /** Monotonically increasing tick counter. */
+  tick: number;
+}
+
+export interface BehaviorDecision {
+  /** World-space destination the bot should move toward. */
+  target: Vec3Tuple | null;
+  /** World-space point the bot should try to shoot at, or null. */
+  fireAim: Vec3Tuple | null;
+  /** Currently targeted remote player (if any) for telemetry. */
+  targetPlayerId: number | null;
+  /** High-level mode label for telemetry. */
+  mode: 'acquire_target' | 'follow_target' | 'recover_center' | 'hold_anchor' | 'dead';
+}
+
+export type Behavior = (ctx: BotBehaviorContext) => BehaviorDecision;
+
+const DEAD_DECISION: BehaviorDecision = {
+  target: null,
+  fireAim: null,
+  targetPlayerId: null,
+  mode: 'dead',
+};
+
+/**
+ * Always move toward the given static point. Useful for scripted test bots.
+ */
+export function moveTo(point: Vec3Tuple): Behavior {
+  return ({ self }) => {
+    if (self.dead) return DEAD_DECISION;
+    return {
+      target: [point[0], point[1], point[2]],
+      fireAim: null,
+      targetPlayerId: null,
+      mode: 'follow_target',
+    };
+  };
+}
+
+/** Holds a fixed anchor position. */
+export function holdAnchor(anchor?: Vec3Tuple): Behavior {
+  return ({ self, anchor: ctxAnchor }) => {
+    if (self.dead) return DEAD_DECISION;
+    const a = anchor ?? ctxAnchor;
+    return {
+      target: [a[0], self.position[1], a[2]],
+      fireAim: null,
+      targetPlayerId: null,
+      mode: 'hold_anchor',
+    };
+  };
+}
+
+export interface HarassNearestOptions {
+  /** Only acquire targets within this planar distance (meters). */
+  acquireDistanceM?: number;
+  /** If the bot wanders outside this planar radius from origin, recover. */
+  recoveryDistanceM?: number;
+  /** Within this distance, start firing at the target. */
+  fireDistanceM?: number;
+}
+
+/**
+ * Chase the nearest living remote player. If no one is in range, recover to
+ * the origin (when outside `recoveryDistanceM`) or hold the anchor.
+ *
+ * Mirrors the FSM that lived inside `loadtest/brain.ts` before the framework
+ * refactor, but with navmesh-aware steering handled upstream.
+ */
+export function harassNearest(options: HarassNearestOptions = {}): Behavior {
+  const acquire = options.acquireDistanceM ?? 40;
+  const recovery = options.recoveryDistanceM ?? 32;
+  const fireRange = options.fireDistanceM ?? 18;
+
+  return (ctx) => {
+    const { self, remotePlayers, anchor } = ctx;
+    if (self.dead) return DEAD_DECISION;
+
+    const centerDistance = Math.hypot(self.position[0], self.position[2]);
+    const fallingOff = self.position[1] < 0.5 || centerDistance > recovery;
+
+    if (fallingOff) {
+      return {
+        target: [0, self.position[1], 0],
+        fireAim: null,
+        targetPlayerId: null,
+        mode: 'recover_center',
+      };
+    }
+
+    const nearest = findNearest(self.position, remotePlayers);
+    if (nearest && nearest.distance <= acquire) {
+      const fireAim = nearest.distance <= fireRange ? nearest.player.position : null;
+      return {
+        target: [
+          nearest.player.position[0],
+          nearest.player.position[1],
+          nearest.player.position[2],
+        ],
+        fireAim,
+        targetPlayerId: nearest.player.id,
+        mode: 'follow_target',
+      };
+    }
+
+    return {
+      target: [anchor[0], self.position[1], anchor[2]],
+      fireAim: null,
+      targetPlayerId: null,
+      mode: 'hold_anchor',
+    };
+  };
+}
+
+export interface WanderOptions {
+  /** Planar radius (meters) the wander target is chosen within. */
+  radiusM?: number;
+  /** Ticks between picking new wander targets. */
+  retargetEveryTicks?: number;
+}
+
+/**
+ * Picks a random walkable-looking point every N ticks and strolls toward it.
+ */
+export function wander(options: WanderOptions = {}): Behavior {
+  const radius = options.radiusM ?? 25;
+  const retarget = options.retargetEveryTicks ?? 120;
+  const state = { target: null as Vec3Tuple | null, lastTick: -Infinity };
+  return (ctx) => {
+    if (ctx.self.dead) return DEAD_DECISION;
+    if (state.target === null || ctx.tick - state.lastTick >= retarget) {
+      const a = (ctx.tick * 0.73 + ctx.self.position[0] * 0.11) % (Math.PI * 2);
+      const r = radius * (0.3 + 0.7 * (((ctx.tick * 2654435761) >>> 0) % 1000) / 1000);
+      state.target = [
+        ctx.anchor[0] + Math.cos(a) * r,
+        ctx.self.position[1],
+        ctx.anchor[2] + Math.sin(a) * r,
+      ];
+      state.lastTick = ctx.tick;
+    }
+    return {
+      target: state.target,
+      fireAim: null,
+      targetPlayerId: null,
+      mode: 'hold_anchor',
+    };
+  };
+}
+
+function findNearest(
+  self: Vec3Tuple,
+  players: readonly ObservedPlayer[],
+): { player: ObservedPlayer; distance: number } | null {
+  let best: { player: ObservedPlayer; distance: number } | null = null;
+  for (const player of players) {
+    if (player.isDead) continue;
+    const distance = Math.hypot(
+      player.position[0] - self[0],
+      player.position[2] - self[2],
+    );
+    if (!best || distance < best.distance) {
+      best = { player, distance };
+    }
+  }
+  return best;
+}

--- a/client/src/bots/agent/steering.test.ts
+++ b/client/src/bots/agent/steering.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { BTN_FORWARD, BTN_SPRINT } from '../../net/protocol';
+import type { BotSelfState } from '../types';
+import { agentStateToIntent, createSteeringState } from './steering';
+
+function selfAt(x: number, z: number, onGround = true): BotSelfState {
+  return {
+    position: [x, 1, z],
+    velocity: [0, 0, 0],
+    yaw: 0,
+    pitch: 0,
+    onGround,
+    dead: false,
+  };
+}
+
+function fakeAgent(desiredVelocity: [number, number, number]) {
+  return {
+    desiredVelocity,
+    velocity: [0, 0, 0],
+    position: [0, 0, 0],
+  } as unknown as Parameters<typeof agentStateToIntent>[0];
+}
+
+describe('agentStateToIntent', () => {
+  it('holds BTN_FORWARD when the agent wants to move at walking speed', () => {
+    const state = createSteeringState();
+    const intent = agentStateToIntent(
+      fakeAgent([2, 0, 0]),
+      selfAt(0, 0),
+      state,
+      'follow_target',
+      null,
+      null,
+    );
+    expect(intent.buttons & BTN_FORWARD).toBe(BTN_FORWARD);
+    expect(intent.buttons & BTN_SPRINT).toBe(0);
+  });
+
+  it('adds BTN_SPRINT when the desired speed exceeds the sprint threshold', () => {
+    const state = createSteeringState();
+    const intent = agentStateToIntent(
+      fakeAgent([5, 0, 0]),
+      selfAt(0, 0),
+      state,
+      'follow_target',
+      null,
+      null,
+    );
+    expect(intent.buttons & BTN_FORWARD).toBe(BTN_FORWARD);
+    expect(intent.buttons & BTN_SPRINT).toBe(BTN_SPRINT);
+  });
+
+  it('yaw faces desired velocity direction in XZ', () => {
+    const state = createSteeringState();
+    const intent = agentStateToIntent(
+      fakeAgent([0, 0, 3]),
+      selfAt(0, 0),
+      state,
+      'follow_target',
+      null,
+      null,
+    );
+    // atan2(0, 3) = 0 (facing +Z)
+    expect(Math.abs(intent.yaw)).toBeLessThan(1e-6);
+  });
+
+  it('fire aim overrides yaw and sets firePrimary', () => {
+    const state = createSteeringState();
+    const intent = agentStateToIntent(
+      fakeAgent([0, 0, 0]),
+      selfAt(0, 0),
+      state,
+      'follow_target',
+      7,
+      [5, 1, 0],
+    );
+    expect(intent.firePrimary).toBe(true);
+    // Target is +X direction → yaw = atan2(5, 0) = π/2
+    expect(intent.yaw).toBeCloseTo(Math.PI / 2, 2);
+    expect(intent.targetPlayerId).toBe(7);
+  });
+
+  it('emits no buttons when dead', () => {
+    const state = createSteeringState();
+    const intent = agentStateToIntent(
+      fakeAgent([5, 0, 0]),
+      { ...selfAt(0, 0), dead: true },
+      state,
+      'dead',
+      null,
+      null,
+    );
+    expect(intent.buttons).toBe(0);
+    expect(intent.mode).toBe('dead');
+  });
+});

--- a/client/src/bots/agent/steering.test.ts
+++ b/client/src/bots/agent/steering.test.ts
@@ -37,10 +37,10 @@ describe('agentStateToIntent', () => {
     expect(intent.buttons & BTN_SPRINT).toBe(0);
   });
 
-  it('adds BTN_SPRINT when the desired speed exceeds the sprint threshold', () => {
+  it('never emits BTN_SPRINT (bot speed is controlled by the WASM override)', () => {
     const state = createSteeringState();
     const intent = agentStateToIntent(
-      fakeAgent([5, 0, 0]),
+      fakeAgent([9, 0, 0]),
       selfAt(0, 0),
       state,
       'follow_target',
@@ -48,7 +48,7 @@ describe('agentStateToIntent', () => {
       null,
     );
     expect(intent.buttons & BTN_FORWARD).toBe(BTN_FORWARD);
-    expect(intent.buttons & BTN_SPRINT).toBe(BTN_SPRINT);
+    expect(intent.buttons & BTN_SPRINT).toBe(0);
   });
 
   it('yaw faces desired velocity direction in XZ', () => {

--- a/client/src/bots/agent/steering.ts
+++ b/client/src/bots/agent/steering.ts
@@ -10,7 +10,6 @@ import { crowd } from 'navcat/blocks';
 import {
   BTN_FORWARD,
   BTN_JUMP,
-  BTN_SPRINT,
 } from '../../net/protocol';
 
 type Agent = crowd.Agent;
@@ -19,7 +18,11 @@ import type { BotIntent, BotMode, BotSelfState, Vec3Tuple } from '../types';
 export interface SteeringOptions {
   /** Minimum desired speed before we hold BTN_FORWARD (m/s). */
   minMoveSpeed?: number;
-  /** Desired speed above which BTN_SPRINT is held (m/s). */
+  /**
+   * @deprecated Kept for back-compat. Bots no longer emit BTN_SPRINT —
+   * their speed is controlled by a per-player override inside the WASM
+   * session, not by the walk/sprint button tiers.
+   */
   sprintSpeed?: number;
   /** If desiredVelocity magnitude is below this and we're not at target, count as stuck. */
   stuckSpeed?: number;
@@ -92,9 +95,12 @@ export function agentStateToIntent(
   if (desiredSpeedPlanar > opts.minMoveSpeed) {
     buttons |= BTN_FORWARD;
   }
-  if (desiredSpeedPlanar > opts.sprintSpeed) {
-    buttons |= BTN_SPRINT;
-  }
+  // Note: we intentionally do not emit BTN_SPRINT for bots. Bot movement
+  // speed is controlled by a per-player override inside the WASM session
+  // (see `PracticeBotRuntime.setMaxSpeed` and
+  // `shared/src/local_session.rs::set_bot_max_speed`). Emitting SPRINT
+  // here would make the KCC pick `sprint_speed` instead of respecting the
+  // override.
 
   // Stuck detection: agent wants to move but isn't (stuck on a ledge / step).
   const actualSpeed = Math.hypot(self.velocity[0], self.velocity[2]);

--- a/client/src/bots/agent/steering.ts
+++ b/client/src/bots/agent/steering.ts
@@ -1,0 +1,133 @@
+/**
+ * Translates a navcat crowd agent's planned motion into concrete game
+ * commands: aim yaw, held buttons, and (optionally) fire intent.
+ *
+ * This is the glue between navcat (which thinks in continuous velocities) and
+ * the game protocol (which thinks in discrete button bitmasks).
+ */
+
+import { crowd } from 'navcat/blocks';
+import {
+  BTN_FORWARD,
+  BTN_JUMP,
+  BTN_SPRINT,
+} from '../../net/protocol';
+
+type Agent = crowd.Agent;
+import type { BotIntent, BotMode, BotSelfState, Vec3Tuple } from '../types';
+
+export interface SteeringOptions {
+  /** Minimum desired speed before we hold BTN_FORWARD (m/s). */
+  minMoveSpeed?: number;
+  /** Desired speed above which BTN_SPRINT is held (m/s). */
+  sprintSpeed?: number;
+  /** If desiredVelocity magnitude is below this and we're not at target, count as stuck. */
+  stuckSpeed?: number;
+  /** Consecutive stuck ticks before emitting a jump. */
+  stuckTicksBeforeJump?: number;
+  /** Ticks to wait between jumps. */
+  jumpCooldownTicks?: number;
+}
+
+export interface SteeringState {
+  stuckTicks: number;
+  jumpCooldownTicks: number;
+  lastYaw: number;
+}
+
+export function createSteeringState(): SteeringState {
+  return { stuckTicks: 0, jumpCooldownTicks: 0, lastYaw: 0 };
+}
+
+const DEFAULT_OPTIONS = Object.freeze<Required<SteeringOptions>>({
+  minMoveSpeed: 0.4,
+  sprintSpeed: 4.0,
+  stuckSpeed: 0.15,
+  stuckTicksBeforeJump: 18,
+  jumpCooldownTicks: 30,
+});
+
+/**
+ * Produces a {@link BotIntent} for the current tick.
+ *
+ * @param agent           The navcat agent (latest `crowd.update` state).
+ * @param self            Server-reported self state (position, onGround, etc.).
+ * @param state           Per-bot steering state (persists across calls).
+ * @param mode            High-level behavior label (passed through to intent).
+ * @param targetPlayerId  Currently targeted remote player, if any.
+ * @param fireAim         World-space point the bot should fire at, or null.
+ * @param options         Tunables; defaults are sensible.
+ */
+export function agentStateToIntent(
+  agent: Agent | undefined,
+  self: BotSelfState,
+  state: SteeringState,
+  mode: BotMode,
+  targetPlayerId: number | null,
+  fireAim: Vec3Tuple | null,
+  options: SteeringOptions = {},
+): BotIntent {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  // Dead: idle, no buttons.
+  if (self.dead || mode === 'dead') {
+    state.stuckTicks = 0;
+    state.jumpCooldownTicks = Math.max(0, state.jumpCooldownTicks - 1);
+    return { buttons: 0, yaw: self.yaw, pitch: 0, firePrimary: false, mode: 'dead', targetPlayerId: null };
+  }
+
+  let buttons = 0;
+  let yaw = state.lastYaw || self.yaw || 0;
+  let pitch = 0;
+
+  const desiredVel: Vec3Tuple = agent
+    ? [agent.desiredVelocity[0], agent.desiredVelocity[1], agent.desiredVelocity[2]]
+    : [0, 0, 0];
+  const desiredSpeedPlanar = Math.hypot(desiredVel[0], desiredVel[2]);
+
+  if (desiredSpeedPlanar > 0.01) {
+    yaw = Math.atan2(desiredVel[0], desiredVel[2]);
+  }
+
+  if (desiredSpeedPlanar > opts.minMoveSpeed) {
+    buttons |= BTN_FORWARD;
+  }
+  if (desiredSpeedPlanar > opts.sprintSpeed) {
+    buttons |= BTN_SPRINT;
+  }
+
+  // Stuck detection: agent wants to move but isn't (stuck on a ledge / step).
+  const actualSpeed = Math.hypot(self.velocity[0], self.velocity[2]);
+  if (desiredSpeedPlanar > opts.minMoveSpeed && actualSpeed < opts.stuckSpeed) {
+    state.stuckTicks += 1;
+  } else {
+    state.stuckTicks = 0;
+  }
+
+  state.jumpCooldownTicks = Math.max(0, state.jumpCooldownTicks - 1);
+  if (
+    self.onGround
+    && state.jumpCooldownTicks === 0
+    && state.stuckTicks >= opts.stuckTicksBeforeJump
+  ) {
+    buttons |= BTN_JUMP;
+    state.jumpCooldownTicks = opts.jumpCooldownTicks;
+    state.stuckTicks = 0;
+  }
+
+  let firePrimary = false;
+  if (fireAim) {
+    const fx = fireAim[0] - self.position[0];
+    const fy = fireAim[1] - self.position[1];
+    const fz = fireAim[2] - self.position[2];
+    const planar = Math.hypot(fx, fz);
+    if (planar > 0.001 || Math.abs(fy) > 0.001) {
+      yaw = planar > 0.001 ? Math.atan2(fx, fz) : yaw;
+      pitch = Math.atan2(-fy, Math.max(planar, 0.0001));
+      firePrimary = true;
+    }
+  }
+
+  state.lastYaw = yaw;
+  return { buttons, yaw, pitch, firePrimary, mode, targetPlayerId };
+}

--- a/client/src/bots/agent/vehicleSteering.test.ts
+++ b/client/src/bots/agent/vehicleSteering.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  rotateVectorByQuaternionInverse,
+  vehicleAgentStateToIntent,
+  type Quaternion,
+} from './vehicleSteering';
+import {
+  BTN_BACK,
+  BTN_FORWARD,
+  BTN_LEFT,
+  BTN_RIGHT,
+} from '../../net/sharedConstants';
+
+const IDENTITY: Quaternion = [0, 0, 0, 1];
+
+/** Unit quaternion rotating `angle` radians around the world +Y axis. */
+function quatY(angle: number): Quaternion {
+  const h = angle * 0.5;
+  return [0, Math.sin(h), 0, Math.cos(h)];
+}
+
+const PASSTHROUGH = Object.freeze({
+  yaw: 0.25,
+  pitch: -0.1,
+  mode: 'driving' as const,
+  targetPlayerId: null,
+  vehicleId: 7,
+  firePrimary: false,
+  vehicleAction: null,
+});
+
+describe('rotateVectorByQuaternionInverse', () => {
+  it('returns the original vector for the identity quaternion', () => {
+    const v: [number, number, number] = [1.5, -2, 3.25];
+    const out = rotateVectorByQuaternionInverse(v, IDENTITY);
+    expect(out[0]).toBeCloseTo(1.5);
+    expect(out[1]).toBeCloseTo(-2);
+    expect(out[2]).toBeCloseTo(3.25);
+  });
+
+  it('inverts a +90° yaw rotation around Y', () => {
+    // The chassis is yawed +90° (facing −X in world). Rotating (−1, 0, 0)
+    // back into chassis-local should give (0, 0, −1) — "forward" in the
+    // chassis frame.
+    const q = quatY(Math.PI / 2);
+    const world: [number, number, number] = [-1, 0, 0];
+    const local = rotateVectorByQuaternionInverse(world, q);
+    expect(local[0]).toBeCloseTo(0, 5);
+    expect(local[1]).toBeCloseTo(0, 5);
+    expect(local[2]).toBeCloseTo(-1, 5);
+  });
+
+  it('is its own inverse with a forward rotation', () => {
+    // Rotating a vector by q and then by q^-1 should round-trip.
+    const q: Quaternion = [0.2, 0.3, 0.1, Math.sqrt(1 - 0.04 - 0.09 - 0.01)];
+    const v: [number, number, number] = [2, 0.5, -1.5];
+    // forwardRotate(v, q) = inverse-rotate(v, conjugate(q))
+    const conj: Quaternion = [-q[0], -q[1], -q[2], q[3]];
+    const rotated = rotateVectorByQuaternionInverse(v, conj);
+    const roundTripped = rotateVectorByQuaternionInverse(rotated, q);
+    expect(roundTripped[0]).toBeCloseTo(2, 5);
+    expect(roundTripped[1]).toBeCloseTo(0.5, 5);
+    expect(roundTripped[2]).toBeCloseTo(-1.5, 5);
+  });
+});
+
+describe('vehicleAgentStateToIntent', () => {
+  it('emits BTN_FORWARD only for a target directly ahead', () => {
+    // Chassis-local forward is −Z, so a world velocity of (0, 0, −10)
+    // is straight ahead when the quaternion is identity.
+    const intent = vehicleAgentStateToIntent([0, 0, -10], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeFalsy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+    expect(intent.buttons & BTN_BACK).toBeFalsy();
+  });
+
+  it('emits forward + right for a target ahead-right of the chassis', () => {
+    // Desired velocity in world space points +X/−Z → local heading ~+45°.
+    const intent = vehicleAgentStateToIntent([5, 0, -5], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_RIGHT).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeFalsy();
+    expect(intent.buttons & BTN_BACK).toBeFalsy();
+  });
+
+  it('emits forward + left for a target ahead-left of the chassis', () => {
+    const intent = vehicleAgentStateToIntent([-5, 0, -5], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeTruthy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+    expect(intent.buttons & BTN_BACK).toBeFalsy();
+  });
+
+  it('reverses and counter-steers when the target is directly behind', () => {
+    // Desired velocity is +Z world-space; chassis-local heading ~180°
+    // (fully behind). We expect reverse, and since the target is
+    // "straight back" the heading is exactly π so we fall just inside
+    // the BTN_BACK arm with no steer (heading magnitude on threshold).
+    const intent = vehicleAgentStateToIntent([0, 0, 10], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_BACK).toBeTruthy();
+    expect(intent.buttons & BTN_FORWARD).toBeFalsy();
+  });
+
+  it('reverses + opposite-steer for a target behind and to the right', () => {
+    // Behind-right in world space → atan2(x, forward) where forward = −(−z)
+    // is positive.  With local x ≈ +1 and local forward ≈ −0.17 the
+    // heading lands around +1.74 rad (≈100°), just outside the forward
+    // arc (100°). We should reverse and steer LEFT to swing the nose.
+    const intent = vehicleAgentStateToIntent([10, 0, 1.8], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons & BTN_BACK).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeTruthy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+  });
+
+  it('honors a yawed chassis — target directly ahead of a rotated car', () => {
+    // Car is yawed +90° around Y. Its local forward in world space is
+    // therefore along the rotated −Z axis → world +X direction. A world
+    // velocity of (+1, 0, 0) should register as "dead ahead".
+    //
+    // NOTE: rotation sign convention — quatY(+π/2) yaws in the
+    // right-handed sense around +Y, which maps chassis −Z to world… well,
+    // the test asserts the output, whichever way it turns out: we just
+    // need to confirm the code picks BTN_FORWARD and no steer when the
+    // world velocity matches whatever "forward" the chassis resolves to.
+    const chassis = quatY(Math.PI / 2);
+    // To find the correct world-space "ahead" for this chassis, rotate
+    // the local forward (0,0,-1) by the chassis quaternion. We can reuse
+    // `rotateVectorByQuaternionInverse` by passing the conjugate, which
+    // gives a forward rotation.
+    const conj: Quaternion = [-chassis[0], -chassis[1], -chassis[2], chassis[3]];
+    const worldForward = rotateVectorByQuaternionInverse([0, 0, -1], conj);
+    // Scale to a real speed.
+    const worldVel: [number, number, number] = [
+      worldForward[0] * 10,
+      worldForward[1] * 10,
+      worldForward[2] * 10,
+    ];
+    const intent = vehicleAgentStateToIntent(worldVel, chassis, PASSTHROUGH);
+    expect(intent.buttons & BTN_FORWARD).toBeTruthy();
+    expect(intent.buttons & BTN_LEFT).toBeFalsy();
+    expect(intent.buttons & BTN_RIGHT).toBeFalsy();
+  });
+
+  it('emits no drive buttons when desired velocity is below the deadband', () => {
+    const intent = vehicleAgentStateToIntent([0, 0, -0.1], IDENTITY, PASSTHROUGH);
+    expect(intent.buttons).toBe(0);
+    // Passthrough fields are still forwarded unchanged.
+    expect(intent.yaw).toBeCloseTo(PASSTHROUGH.yaw);
+    expect(intent.pitch).toBeCloseTo(PASSTHROUGH.pitch);
+    expect(intent.vehicleId).toBe(PASSTHROUGH.vehicleId);
+  });
+
+  it('passes vehicleId/vehicleAction through to the returned intent', () => {
+    const intent = vehicleAgentStateToIntent([0, 0, -3], IDENTITY, {
+      ...PASSTHROUGH,
+      vehicleAction: 'exit',
+    });
+    expect(intent.vehicleAction).toBe('exit');
+    expect(intent.vehicleId).toBe(PASSTHROUGH.vehicleId);
+    expect(intent.mode).toBe('driving');
+  });
+});

--- a/client/src/bots/agent/vehicleSteering.ts
+++ b/client/src/bots/agent/vehicleSteering.ts
@@ -1,0 +1,187 @@
+/**
+ * Translates a vehicle-mode crowd agent's planned motion into concrete
+ * driving commands: throttle / reverse / steer bits on a {@link BotIntent}.
+ *
+ * The navcat crowd plans in world-space velocities; the server's
+ * `input_to_vehicle_cmd` in `shared/src/movement.rs:31` interprets
+ * `move_y`/`move_x` (or the equivalent button bits) in the vehicle's local
+ * frame:
+ *   - `move_y > 0` → throttle → chassis drives along its local **−Z** axis
+ *     (Rapier raycast-vehicle convention; see `vehicle_wheel_params`).
+ *   - `move_x > 0` → steer right in the vehicle's forward direction.
+ *
+ * So to go from "desired world velocity" → "buttons", we rotate the
+ * world-space desired velocity into chassis-local coordinates via the
+ * **inverse** of the chassis quaternion and look at the resulting (x, z):
+ *
+ *   localForward = −localZ  // "ahead" direction in chassis frame
+ *   localRight   =  localX  // "right" direction in chassis frame
+ *   heading      = atan2(localRight, localForward)   // 0 = ahead, +π/2 = right
+ *
+ * - Small |heading|: press BTN_FORWARD, maybe nudge LEFT / RIGHT to stay on
+ *   the crowd's desired bearing.
+ * - Target in the frontal arc but off-axis: forward + hard steer.
+ * - Target behind: reverse (BTN_BACK) and counter-steer, which pivots the
+ *   nose around. Good enough to unstick the bot on a bad approach; proper
+ *   3-point turns are out of scope.
+ *
+ * This is a pure function — no side effects, no globals — so it's
+ * trivially unit-testable and can be reused from a Node load test or a
+ * browser preview alike.
+ */
+
+import type { crowd as navcatCrowd } from 'navcat/blocks';
+
+import {
+  BTN_BACK,
+  BTN_FORWARD,
+  BTN_LEFT,
+  BTN_RIGHT,
+} from '../../net/sharedConstants';
+import type { BotIntent, BotMode, Vec3Tuple } from '../types';
+
+type Agent = navcatCrowd.Agent;
+
+/** Chassis orientation quaternion in `[x, y, z, w]` order (match `VehicleStateMeters`). */
+export type Quaternion = readonly [number, number, number, number];
+
+export interface VehicleSteeringOptions {
+  /**
+   * Minimum desired planar speed (m/s) before we start pressing any
+   * drive button. Below this the bot just coasts — avoids jittering
+   * throttle on a waypoint we've essentially already hit.
+   */
+  minDesiredSpeed?: number;
+  /**
+   * Half-width (radians) of the "dead ahead" zone where we won't emit
+   * left/right steer bits at all. Outside the deadband we commit to a
+   * discrete LEFT or RIGHT.
+   */
+  steerDeadband?: number;
+  /**
+   * Half-angle (radians, from +local forward) of the frontal arc where
+   * we throttle forward. Outside this arc the target is "behind" and we
+   * reverse. Default 100° → forward arc is ±100° (forward-biased — we
+   * only reverse when the target is clearly to the rear).
+   */
+  forwardArc?: number;
+}
+
+const DEFAULTS = Object.freeze<Required<VehicleSteeringOptions>>({
+  minDesiredSpeed: 0.5,
+  steerDeadband: 0.08, // ~4.6°
+  forwardArc: (100 * Math.PI) / 180,
+});
+
+/** Rotates `v` by the **inverse** of unit quaternion `q` (i.e. into `q`'s local frame). */
+export function rotateVectorByQuaternionInverse(v: Vec3Tuple, q: Quaternion): Vec3Tuple {
+  const [qx, qy, qz, qw] = q;
+  // Conjugate (inverse for a unit quaternion):
+  const ix = -qx;
+  const iy = -qy;
+  const iz = -qz;
+  // v' = q* v q (pure-quaternion multiplication, expanded).
+  // Using the Rodrigues-style form:
+  //   t = 2 * (q.xyz × v)
+  //   v' = v + q.w * t + q.xyz × t
+  const tx = 2 * (iy * v[2] - iz * v[1]);
+  const ty = 2 * (iz * v[0] - ix * v[2]);
+  const tz = 2 * (ix * v[1] - iy * v[0]);
+  return [
+    v[0] + qw * tx + (iy * tz - iz * ty),
+    v[1] + qw * ty + (iz * tx - ix * tz),
+    v[2] + qw * tz + (ix * ty - iy * tx),
+  ];
+}
+
+/**
+ * Pure conversion: given the crowd's desired velocity and the chassis
+ * orientation, emit a {@link BotIntent} with the right drive buttons set.
+ *
+ * `yaw` and `pitch` in the returned intent are passed through unchanged
+ * from the caller — `input_to_vehicle_cmd` in `shared/src/movement.rs`
+ * ignores them, but snapshot code still echoes them back to observers, so
+ * we keep the bot's head aimed wherever the caller wants.
+ */
+export function vehicleAgentStateToIntent(
+  desiredVelocity: Vec3Tuple,
+  chassisQuaternion: Quaternion,
+  passthrough: {
+    yaw: number;
+    pitch: number;
+    mode: BotMode;
+    targetPlayerId: number | null;
+    vehicleId: number;
+    firePrimary?: boolean;
+    vehicleAction?: 'enter' | 'exit' | null;
+  },
+  options: VehicleSteeringOptions = {},
+): BotIntent {
+  const opts = { ...DEFAULTS, ...options };
+
+  const planarSpeed = Math.hypot(desiredVelocity[0], desiredVelocity[2]);
+  let buttons = 0;
+
+  if (planarSpeed >= opts.minDesiredSpeed) {
+    const local = rotateVectorByQuaternionInverse(desiredVelocity, chassisQuaternion);
+    // Chassis local forward is −Z (see Rapier sign convention in
+    // `vehicle_wheel_params`). +X is right.
+    const forward = -local[2];
+    const right = local[0];
+    // 0 = straight ahead, +π/2 = full right, ±π = directly behind.
+    const heading = Math.atan2(right, forward);
+    const absHeading = Math.abs(heading);
+
+    if (absHeading <= opts.forwardArc) {
+      // Target is in the frontal arc: drive forward, steer toward it.
+      buttons |= BTN_FORWARD;
+      if (heading > opts.steerDeadband) {
+        buttons |= BTN_RIGHT;
+      } else if (heading < -opts.steerDeadband) {
+        buttons |= BTN_LEFT;
+      }
+    } else {
+      // Target is behind: reverse, and steer the **opposite** way so the
+      // nose swings around toward the target. (When reversing, pressing
+      // RIGHT steers the front wheels right, which in turn pivots the
+      // rear-end right and the nose left — so we invert here.)
+      buttons |= BTN_BACK;
+      if (heading > opts.steerDeadband) {
+        buttons |= BTN_LEFT;
+      } else if (heading < -opts.steerDeadband) {
+        buttons |= BTN_RIGHT;
+      }
+    }
+  }
+
+  return {
+    buttons,
+    yaw: passthrough.yaw,
+    pitch: passthrough.pitch,
+    firePrimary: passthrough.firePrimary ?? false,
+    mode: passthrough.mode,
+    targetPlayerId: passthrough.targetPlayerId,
+    vehicleAction: passthrough.vehicleAction ?? null,
+    vehicleId: passthrough.vehicleId,
+  };
+}
+
+/**
+ * Convenience wrapper that pulls `desiredVelocity` off a navcat agent.
+ * Returns `undefined` if the agent is missing (caller should synthesize
+ * an idle intent in that case).
+ */
+export function vehicleAgentToIntent(
+  agent: Agent | undefined,
+  chassisQuaternion: Quaternion,
+  passthrough: Parameters<typeof vehicleAgentStateToIntent>[2],
+  options: VehicleSteeringOptions = {},
+): BotIntent | undefined {
+  if (!agent) return undefined;
+  const desired: Vec3Tuple = [
+    agent.desiredVelocity[0],
+    agent.desiredVelocity[1],
+    agent.desiredVelocity[2],
+  ];
+  return vehicleAgentStateToIntent(desired, chassisQuaternion, passthrough, options);
+}

--- a/client/src/bots/crowd/BotCrowd.test.ts
+++ b/client/src/bots/crowd/BotCrowd.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_WORLD_DOCUMENT } from '../../world/worldDocument';
+import { createBotCrowd } from './BotCrowd';
+
+describe('BotCrowd', () => {
+  it('adds and removes bots', () => {
+    const crowd = createBotCrowd(DEFAULT_WORLD_DOCUMENT);
+    const handle = crowd.addBot([0, 5, 0]);
+    expect(handle.id).toBeTruthy();
+    expect(crowd.getAgent(handle.id)).toBeDefined();
+    expect(crowd.removeBot(handle)).toBe(true);
+    expect(crowd.getAgent(handle.id)).toBeUndefined();
+  });
+
+  it('accepts a move target on the mesh and eventually steers toward it', () => {
+    const crowd = createBotCrowd(DEFAULT_WORLD_DOCUMENT);
+    const handle = crowd.addBot([0, 5, 0]);
+    const target: [number, number, number] = [6, 5, 6];
+    const ok = crowd.requestMoveTo(handle, target);
+    expect(ok).toBe(true);
+    // Advance a handful of simulated seconds so the corridor is populated.
+    for (let i = 0; i < 30; i += 1) {
+      crowd.step(1 / 30);
+    }
+    const agent = crowd.getAgent(handle.id);
+    expect(agent).toBeDefined();
+    // A valid path either produces a non-empty corridor or at least a valid
+    // desired velocity pointing roughly toward +X (since target is +X,+Z).
+    const corridorLength = agent!.corridor.path.length;
+    const desiredLen = Math.hypot(agent!.desiredVelocity[0], agent!.desiredVelocity[2]);
+    expect(corridorLength + desiredLen).toBeGreaterThan(0);
+  });
+
+  it('syncBotPosition updates the agent position', () => {
+    const crowd = createBotCrowd(DEFAULT_WORLD_DOCUMENT);
+    const handle = crowd.addBot([0, 5, 0]);
+    crowd.syncBotPosition(handle, [3, 5, 3]);
+    const agent = crowd.getAgent(handle.id);
+    expect(agent).toBeDefined();
+    // Snapped to the nearest walkable polygon — but planar X/Z should be in
+    // the neighborhood of what we requested.
+    expect(Math.abs(agent!.position[0] - 3)).toBeLessThan(2);
+    expect(Math.abs(agent!.position[2] - 3)).toBeLessThan(2);
+  });
+
+  it('findRandomWalkable returns a point on the mesh', () => {
+    const crowd = createBotCrowd(DEFAULT_WORLD_DOCUMENT);
+    const point = crowd.findRandomWalkable();
+    expect(point).not.toBeNull();
+    expect(point).toHaveLength(3);
+  });
+});

--- a/client/src/bots/crowd/BotCrowd.ts
+++ b/client/src/bots/crowd/BotCrowd.ts
@@ -1,0 +1,243 @@
+/**
+ * High-level wrapper around a navcat crowd. One {@link BotCrowd} owns a
+ * single shared navmesh and a navcat {@link crowd.Crowd}; each connected bot
+ * is one agent inside it.
+ *
+ * The wrapper exists so callers never have to reach into `navcat`'s imperative
+ * crowd API directly — they get `addBot`, `removeBot`, `requestMoveTo`, etc.,
+ * and all the navmesh housekeeping (nearest-poly lookups, position syncing,
+ * bounds clamping) is centralized here.
+ */
+
+import { crowd } from 'navcat/blocks';
+
+type AgentParams = crowd.AgentParams;
+type Crowd = crowd.Crowd;
+import {
+  createFindNearestPolyResult,
+  DEFAULT_QUERY_FILTER,
+  findNearestPoly,
+  findRandomPoint,
+  type NavMesh,
+  type NodeRef,
+  type Vec3,
+} from 'navcat';
+
+import type { WorldDocument } from '../../world/worldDocument';
+import type { Vec3Tuple } from '../types';
+import {
+  buildBotNavMesh,
+  type BotNavMesh,
+  type BuildBotNavMeshOptions,
+} from '../world/buildNavMesh';
+
+export interface BotCrowdOptions extends BuildBotNavMeshOptions {
+  /**
+   * The largest agent radius that will be added to this crowd. navcat uses
+   * this to size internal placement half-extents and neighbor grids; pick a
+   * value at least as large as your biggest agent.
+   * @default 0.6
+   */
+  maxAgentRadius?: number;
+  /**
+   * Half-extents used when snapping positions to the nearest walkable polygon.
+   * Larger values tolerate bigger mismatches between the server's character
+   * position and the navmesh surface (useful for terrain heightfields where
+   * the KCC stands slightly above the triangle mesh).
+   * @default [2, 4, 2]
+   */
+  snapHalfExtents?: Vec3Tuple;
+}
+
+export interface BotHandle {
+  /** String id used by navcat for this agent. */
+  readonly id: string;
+  /** Currently applied target position, if any. */
+  targetPosition: Vec3Tuple | null;
+}
+
+const DEFAULT_SNAP_HALF_EXTENTS: Vec3Tuple = [2, 4, 2];
+
+const DEFAULT_AGENT_PARAMS: Omit<AgentParams, 'queryFilter'> = {
+  radius: 0.45,
+  height: 1.7,
+  maxAcceleration: 25.0,
+  maxSpeed: 7.0,
+  collisionQueryRange: 4,
+  separationWeight: 1.0,
+  updateFlags:
+    crowd.CrowdUpdateFlags.ANTICIPATE_TURNS
+    | crowd.CrowdUpdateFlags.OBSTACLE_AVOIDANCE
+    | crowd.CrowdUpdateFlags.SEPARATION
+    | crowd.CrowdUpdateFlags.OPTIMIZE_VIS
+    | crowd.CrowdUpdateFlags.OPTIMIZE_TOPO,
+  obstacleAvoidance: crowd.DEFAULT_OBSTACLE_AVOIDANCE_PARAMS,
+  autoTraverseOffMeshConnections: true,
+};
+
+/**
+ * Wrapper around a navcat crowd. Thread-hostile — create one per Node worker
+ * or per browser tab and reuse it for the lifetime of the bot swarm.
+ */
+export class BotCrowd {
+  readonly nav: BotNavMesh;
+  readonly crowd: Crowd;
+  private readonly handles = new Map<string, BotHandle>();
+  private readonly snapHalfExtents: Vec3Tuple;
+  private readonly tmpNearest = createFindNearestPolyResult();
+
+  constructor(nav: BotNavMesh, crowdInstance: Crowd, snapHalfExtents: Vec3Tuple) {
+    this.nav = nav;
+    this.crowd = crowdInstance;
+    this.snapHalfExtents = snapHalfExtents;
+  }
+
+  /** The underlying navcat NavMesh (for raw queries). */
+  get navMesh(): NavMesh {
+    return this.nav.navMesh;
+  }
+
+  /**
+   * Adds a new bot to the crowd and returns its handle.
+   *
+   * The supplied `initialPosition` is snapped to the nearest walkable
+   * polygon; if no polygon is reachable the agent is still created at the
+   * raw position and will be in the INVALID state until moved onto the mesh.
+   */
+  addBot(initialPosition: Vec3Tuple, params?: Partial<AgentParams>): BotHandle {
+    const snap = this.findNearestWalkable(initialPosition);
+    const position: Vec3 = snap ? snap.position : ([...initialPosition] as Vec3);
+    const agentParams: AgentParams = {
+      ...DEFAULT_AGENT_PARAMS,
+      ...params,
+      queryFilter: params?.queryFilter ?? DEFAULT_QUERY_FILTER,
+    };
+    const id = crowd.addAgent(this.crowd, this.nav.navMesh, position, agentParams);
+    const handle: BotHandle = { id, targetPosition: null };
+    this.handles.set(id, handle);
+    return handle;
+  }
+
+  /** Removes a bot by handle or id. */
+  removeBot(botOrId: BotHandle | string): boolean {
+    const id = typeof botOrId === 'string' ? botOrId : botOrId.id;
+    const removed = crowd.removeAgent(this.crowd, id);
+    if (removed) this.handles.delete(id);
+    return removed;
+  }
+
+  /** Look up a previously added handle by id. */
+  getHandle(id: string): BotHandle | undefined {
+    return this.handles.get(id);
+  }
+
+  /** Read the navcat agent object for direct inspection (position, etc.). */
+  getAgent(id: string) {
+    return this.crowd.agents[id];
+  }
+
+  /**
+   * Snaps a world-space target to the nearest walkable polygon and requests
+   * that the agent plan a path to it. Returns true on success.
+   */
+  requestMoveTo(botOrId: BotHandle | string, target: Vec3Tuple): boolean {
+    const handle = typeof botOrId === 'string' ? this.handles.get(botOrId) : botOrId;
+    if (!handle) return false;
+    const nearest = this.findNearestWalkable(target);
+    if (!nearest) return false;
+    handle.targetPosition = [nearest.position[0], nearest.position[1], nearest.position[2]];
+    return crowd.requestMoveTarget(
+      this.crowd,
+      handle.id,
+      nearest.nodeRef,
+      nearest.position,
+    );
+  }
+
+  /** Clears the agent's current move target (agent will stop). */
+  stop(botOrId: BotHandle | string): boolean {
+    const handle = typeof botOrId === 'string' ? this.handles.get(botOrId) : botOrId;
+    if (!handle) return false;
+    handle.targetPosition = null;
+    return crowd.resetMoveTarget(this.crowd, handle.id);
+  }
+
+  /**
+   * Updates the agent's internal position so subsequent planning uses the
+   * server-authoritative location. Without this the crowd happily predicts
+   * but drifts off the network truth.
+   */
+  syncBotPosition(botOrId: BotHandle | string, serverPosition: Vec3Tuple): void {
+    const handle = typeof botOrId === 'string' ? this.handles.get(botOrId) : botOrId;
+    if (!handle) return;
+    const agent = this.crowd.agents[handle.id];
+    if (!agent) return;
+    // Snap to mesh so the corridor/poly refs stay consistent.
+    const nearest = this.findNearestWalkable(serverPosition);
+    const target: Vec3 = nearest ? nearest.position : ([...serverPosition] as Vec3);
+    agent.position[0] = target[0];
+    agent.position[1] = target[1];
+    agent.position[2] = target[2];
+  }
+
+  /**
+   * Advances the crowd simulation by `dt` seconds. Call this once per tick,
+   * not once per bot.
+   */
+  step(dt: number): void {
+    crowd.update(this.crowd, this.nav.navMesh, dt);
+  }
+
+  /** Returns true if the bot is within `threshold` meters of its target. */
+  isAtTarget(botOrId: BotHandle | string, threshold: number): boolean {
+    const id = typeof botOrId === 'string' ? botOrId : botOrId.id;
+    return crowd.isAgentAtTarget(this.crowd, id, threshold);
+  }
+
+  /**
+   * Finds the nearest walkable polygon to a world-space position. Returns
+   * `null` if nothing is reachable within {@link snapHalfExtents}.
+   */
+  findNearestWalkable(position: Vec3Tuple): { nodeRef: NodeRef; position: Vec3 } | null {
+    const center: Vec3 = [position[0], position[1], position[2]];
+    findNearestPoly(
+      this.tmpNearest,
+      this.nav.navMesh,
+      center,
+      this.snapHalfExtents as Vec3,
+      DEFAULT_QUERY_FILTER,
+    );
+    if (!this.tmpNearest.success) return null;
+    // Copy so callers can't mutate our scratch buffer.
+    return {
+      nodeRef: this.tmpNearest.nodeRef,
+      position: [
+        this.tmpNearest.position[0],
+        this.tmpNearest.position[1],
+        this.tmpNearest.position[2],
+      ] as Vec3,
+    };
+  }
+
+  /**
+   * Returns a random walkable point anywhere on the navmesh, or `null` if the
+   * mesh is empty.
+   */
+  findRandomWalkable(rand: () => number = Math.random): Vec3Tuple | null {
+    const result = findRandomPoint(this.nav.navMesh, DEFAULT_QUERY_FILTER, rand);
+    if (!result.success) return null;
+    return [result.position[0], result.position[1], result.position[2]];
+  }
+}
+
+/**
+ * Convenience constructor: builds the navmesh and a ready-to-use BotCrowd in
+ * one call.
+ */
+export function createBotCrowd(world: WorldDocument, options: BotCrowdOptions = {}): BotCrowd {
+  const nav = buildBotNavMesh(world, options);
+  const maxAgentRadius = options.maxAgentRadius ?? 0.6;
+  const crowdInstance = crowd.create(maxAgentRadius);
+  const snap = options.snapHalfExtents ?? DEFAULT_SNAP_HALF_EXTENTS;
+  return new BotCrowd(nav, crowdInstance, snap);
+}

--- a/client/src/bots/crowd/BotCrowd.ts
+++ b/client/src/bots/crowd/BotCrowd.ts
@@ -126,6 +126,64 @@ export class BotCrowd {
     return removed;
   }
 
+  /**
+   * Adds a **static pseudo-agent** to the crowd for use as a dynamic
+   * obstacle (e.g. a vehicle that can roll into the bots' pathing space).
+   * The returned string id is a raw navcat agent id — pass it back to
+   * {@link setObstacleAgentPose} / {@link removeObstacleAgent}.
+   *
+   * The pseudo-agent has `maxSpeed = 0` and `updateFlags = 0`, so navcat
+   * won't try to move it; it exists solely so real bot agents' separation
+   * + obstacle-avoidance logic routes around it.
+   */
+  addObstacleAgent(position: Vec3Tuple, radius: number, height: number): string {
+    const snap = this.findNearestWalkable(position);
+    const initial: Vec3 = snap
+      ? ([snap.position[0], snap.position[1], snap.position[2]] as Vec3)
+      : ([position[0], position[1], position[2]] as Vec3);
+    const params: AgentParams = {
+      radius,
+      height,
+      maxAcceleration: 0,
+      maxSpeed: 0,
+      collisionQueryRange: 0,
+      separationWeight: 0,
+      updateFlags: 0,
+      queryFilter: DEFAULT_QUERY_FILTER,
+      obstacleAvoidance: crowd.DEFAULT_OBSTACLE_AVOIDANCE_PARAMS,
+      autoTraverseOffMeshConnections: false,
+    };
+    return crowd.addAgent(this.crowd, this.nav.navMesh, initial, params);
+  }
+
+  /**
+   * Updates a pseudo-agent's world position (and optional velocity for
+   * anticipatory avoidance). Safe to call every tick. Returns false if
+   * the id is unknown.
+   */
+  setObstacleAgentPose(
+    agentId: string,
+    position: Vec3Tuple,
+    velocity?: Vec3Tuple,
+  ): boolean {
+    const agent = this.crowd.agents[agentId];
+    if (!agent) return false;
+    agent.position[0] = position[0];
+    agent.position[1] = position[1];
+    agent.position[2] = position[2];
+    if (velocity) {
+      agent.velocity[0] = velocity[0];
+      agent.velocity[1] = velocity[1];
+      agent.velocity[2] = velocity[2];
+    }
+    return true;
+  }
+
+  /** Removes a previously added obstacle pseudo-agent. */
+  removeObstacleAgent(agentId: string): boolean {
+    return crowd.removeAgent(this.crowd, agentId);
+  }
+
   /** Look up a previously added handle by id. */
   getHandle(id: string): BotHandle | undefined {
     return this.handles.get(id);
@@ -236,7 +294,11 @@ export class BotCrowd {
  */
 export function createBotCrowd(world: WorldDocument, options: BotCrowdOptions = {}): BotCrowd {
   const nav = buildBotNavMesh(world, options);
-  const maxAgentRadius = options.maxAgentRadius ?? 0.6;
+  // Default `maxAgentRadius` is sized for vehicle-scale obstacles (the
+  // biggest thing we register via `addObstacleAgent`). Bots themselves are
+  // smaller (≈0.45), but navcat uses this value to pre-size its neighbor
+  // lookup so the largest possible agent still fits.
+  const maxAgentRadius = options.maxAgentRadius ?? 2.5;
   const crowdInstance = crowd.create(maxAgentRadius);
   const snap = options.snapHalfExtents ?? DEFAULT_SNAP_HALF_EXTENTS;
   return new BotCrowd(nav, crowdInstance, snap);

--- a/client/src/bots/crowd/BotCrowd.ts
+++ b/client/src/bots/crowd/BotCrowd.ts
@@ -17,16 +17,20 @@ import {
   createFindNearestPolyResult,
   DEFAULT_QUERY_FILTER,
   findNearestPoly,
+  findPath,
   findRandomPoint,
+  FindPathResultFlags,
   type NavMesh,
   type NodeRef,
+  type QueryFilter,
   type Vec3,
 } from 'navcat';
 
 import type { WorldDocument } from '../../world/worldDocument';
-import type { Vec3Tuple } from '../types';
+import type { Vec3Tuple, VehicleProfile } from '../types';
 import {
   buildBotNavMesh,
+  buildVehicleBotNavMesh,
   type BotNavMesh,
   type BuildBotNavMeshOptions,
 } from '../world/buildNavMesh';
@@ -286,6 +290,56 @@ export class BotCrowd {
     if (!result.success) return null;
     return [result.position[0], result.position[1], result.position[2]];
   }
+
+  /**
+   * Overrides the query filter on a previously-added agent. Used by the
+   * vehicle FSM when a bot switches between foot and vehicle mode so A*
+   * recosts the remaining corridor through the lens of the new chassis.
+   *
+   * Returns false if the agent id is unknown.
+   */
+  setAgentQueryFilter(agentOrHandleId: string | BotHandle, filter: QueryFilter): boolean {
+    const id = typeof agentOrHandleId === 'string' ? agentOrHandleId : agentOrHandleId.id;
+    const agent = this.crowd.agents[id];
+    if (!agent) return false;
+    agent.queryFilter = filter;
+    return true;
+  }
+
+  /**
+   * One-shot path query — runs navcat's {@link findPath} with the given
+   * filter and sums Euclidean distances between straight-path points.
+   * Returns `null` if the path is partial or fails (caller should treat
+   * that as "unreachable for this transport mode").
+   *
+   * This is the core of the walk-vs-drive comparison in the bot brain:
+   * divide the returned length by the relevant cruise speed and you get
+   * a travel-time estimate. The `filter`'s `getCost` influence is *not*
+   * reflected in the returned length (A* uses it for corridor selection,
+   * but we measure the physical distance of the resulting corridor).
+   */
+  estimatePathLength(start: Vec3Tuple, end: Vec3Tuple, filter: QueryFilter): number | null {
+    const startVec: Vec3 = [start[0], start[1], start[2]];
+    const endVec: Vec3 = [end[0], end[1], end[2]];
+    const halfExtents: Vec3 = [
+      this.snapHalfExtents[0],
+      this.snapHalfExtents[1],
+      this.snapHalfExtents[2],
+    ];
+    const result = findPath(this.nav.navMesh, startVec, endVec, halfExtents, filter);
+    if (!result.success) return null;
+    // Reject partial paths — the caller wants an all-or-nothing answer.
+    if ((result.flags & FindPathResultFlags.PARTIAL_PATH) !== 0) return null;
+    const pts = result.path;
+    if (pts.length < 2) return 0;
+    let total = 0;
+    for (let i = 1; i < pts.length; i += 1) {
+      const a = pts[i - 1].position;
+      const b = pts[i].position;
+      total += Math.hypot(b[0] - a[0], b[1] - a[1], b[2] - a[2]);
+    }
+    return total;
+  }
 }
 
 /**
@@ -301,5 +355,33 @@ export function createBotCrowd(world: WorldDocument, options: BotCrowdOptions = 
   const maxAgentRadius = options.maxAgentRadius ?? 2.5;
   const crowdInstance = crowd.create(maxAgentRadius);
   const snap = options.snapHalfExtents ?? DEFAULT_SNAP_HALF_EXTENTS;
+  return new BotCrowd(nav, crowdInstance, snap);
+}
+
+/**
+ * Builds a {@link BotCrowd} backed by a **vehicle-sized** navmesh.
+ *
+ * Geometry is produced by {@link buildVehicleBotNavMesh}, which inflates
+ * `walkableRadius` to the profile's chassis radius and tightens the
+ * climb + slope limits. The resulting crowd uses a larger
+ * `maxAgentRadius` (at least `profile.agentRadius + 0.3`) so navcat's
+ * neighbor grid is sized correctly for the wider agents.
+ *
+ * Use this alongside the existing foot crowd in {@link PracticeBotRuntime}
+ * so each bot can switch between the two depending on whether it's on
+ * foot or seated in a vehicle.
+ */
+export function createVehicleBotCrowd(
+  world: WorldDocument,
+  profile: VehicleProfile,
+  options: BotCrowdOptions = {},
+): BotCrowd {
+  const nav = buildVehicleBotNavMesh(world, profile, options);
+  const maxAgentRadius = Math.max(options.maxAgentRadius ?? 0, profile.agentRadius + 0.3, 2.5);
+  const crowdInstance = crowd.create(maxAgentRadius);
+  // Wider snap extents — the vehicle mesh sits a bit higher off the
+  // terrain after erosion, so the foot-tier `[2, 4, 2]` sometimes misses
+  // the closest poly for a vehicle spawn point right on the asphalt.
+  const snap: Vec3Tuple = options.snapHalfExtents ?? [3, 6, 3];
   return new BotCrowd(nav, crowdInstance, snap);
 }

--- a/client/src/bots/crowd/vehicleQueryFilter.test.ts
+++ b/client/src/bots/crowd/vehicleQueryFilter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeTurnAwareCost,
+  SOFT_TURN_WEIGHT,
+  TIGHT_TURN_PENALTY_BIAS,
+  TIGHT_TURN_PENALTY_SCALE,
+} from './vehicleQueryFilter';
+
+type V3 = readonly [number, number, number];
+
+describe('computeTurnAwareCost', () => {
+  const turningRadius = 5;
+
+  it('returns the raw Euclidean cost on a straight segment', () => {
+    // pa → center → pb are collinear. θ=0 so sinHalf≈0 → early return.
+    const pa: V3 = [0, 0, 0];
+    const center: V3 = [0, 0, 5];
+    const pb: V3 = [0, 0, 10];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    expect(cost).toBeCloseTo(10, 5);
+  });
+
+  it('applies a small soft penalty on a gentle curve', () => {
+    // Symmetric V that threads a wide corner — segmentLen well above the
+    // turning radius limit so we should hit the soft-cost branch only.
+    const pa: V3 = [0, 0, 0];
+    const center: V3 = [0, 0, 20];
+    const pb: V3 = [4, 0, 40];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    const base = Math.hypot(4, 0, 40);
+    // Soft weight scales θ/π ∈ [0, 1] by SOFT_TURN_WEIGHT=0.3.
+    expect(cost).toBeGreaterThan(base);
+    expect(cost).toBeLessThan(base * (1 + SOFT_TURN_WEIGHT));
+  });
+
+  it('applies the hard penalty on a sharp 90° corner', () => {
+    // pa approaches from −Z, pb exits along +X through a tight corner.
+    // Short segments keep segmentLen below what a 5 m turning radius
+    // can physically execute.
+    const pa: V3 = [0, 0, -2];
+    const center: V3 = [0, 0, 0];
+    const pb: V3 = [2, 0, 0];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    const base = Math.hypot(2 - 0, 0, 0 - (-2));
+    // Hard-penalty branch: base * 100 + 50.
+    expect(cost).toBeCloseTo(
+      base * TIGHT_TURN_PENALTY_SCALE + TIGHT_TURN_PENALTY_BIAS,
+      5,
+    );
+  });
+
+  it('does not apply the hard penalty when segments are long enough for the chassis', () => {
+    // Same 90° bend, but with 20 m approach/exit — requiredRadius ≈ 20/sin(45°)
+    // ≈ 28.3 m, well above turningRadius=5.
+    const pa: V3 = [0, 0, -20];
+    const center: V3 = [0, 0, 0];
+    const pb: V3 = [20, 0, 0];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    const base = Math.hypot(20, 0, 20);
+    // Should land in the soft branch — roughly base + 15% (θ=π/2).
+    expect(cost).toBeGreaterThan(base);
+    expect(cost).toBeLessThan(base * (1 + SOFT_TURN_WEIGHT));
+  });
+
+  it('is safe on a zero-length approach or exit vector', () => {
+    // pa === center → inLen=0 → should not produce NaN; falls back to base.
+    const pa: V3 = [5, 0, 0];
+    const center: V3 = [5, 0, 0];
+    const pb: V3 = [10, 0, 0];
+    const cost = computeTurnAwareCost(pa, pb, center, turningRadius);
+    expect(cost).toBeCloseTo(5, 5);
+  });
+});

--- a/client/src/bots/crowd/vehicleQueryFilter.ts
+++ b/client/src/bots/crowd/vehicleQueryFilter.ts
@@ -1,0 +1,150 @@
+/**
+ * Vehicle-aware navcat {@link QueryFilter}.
+ *
+ * Unlike `DEFAULT_QUERY_FILTER` (which costs an edge solely by Euclidean
+ * distance), this filter adds a **turn penalty** derived from the agent's
+ * minimum turning radius. A path that threads a sharp right-angle corner
+ * is heavily discouraged vs. a gentle curve the chassis can physically
+ * execute at cruise speed.
+ *
+ * The filter is attached to vehicle-mode agents via `AgentParams.queryFilter`
+ * in {@link BotCrowd}. Foot agents continue to use `DEFAULT_QUERY_FILTER`.
+ *
+ * ## How the turn penalty works
+ *
+ * For each A* edge call, navcat passes `(pa, pb, navMesh, prevRef, curRef,
+ * nextRef)` where `pa` is the portal crossing from the previous node into
+ * the current node, and `pb` is the portal crossing out of the current
+ * node toward the next node. We approximate the local path direction
+ * change by:
+ *
+ *   in  = centroid(curRef) - pa
+ *   out = pb - centroid(curRef)
+ *
+ * and compute the angle θ between those two. We then estimate the radius
+ * of the arc the vehicle would have to sweep through the node from the
+ * classic chord formula:
+ *
+ *   requiredRadius ≈ segmentLen / (2 · sin(θ/2))
+ *
+ * where `segmentLen = |in| + |out|`. If `requiredRadius < turningRadius`,
+ * the edge gets a large penalty so A* routes around that corner. Gentle
+ * curves (small θ) get a very small penalty; straight segments cost
+ * exactly `|pb - pa|`, matching `DEFAULT_QUERY_FILTER` so the planner
+ * still produces sensible distance-first paths on open terrain.
+ */
+
+import {
+  DEFAULT_QUERY_FILTER,
+  getTileAndPolyByRef,
+  type NavMesh,
+  type NodeRef,
+  type QueryFilter,
+  type Vec3,
+} from 'navcat';
+
+import type { VehicleProfile } from '../types';
+
+/** Hard failure threshold applied to corners the vehicle can't physically take. */
+export const TIGHT_TURN_PENALTY_SCALE = 100;
+export const TIGHT_TURN_PENALTY_BIAS = 50;
+/** Mild preference for smoother paths on tractable corners. */
+export const SOFT_TURN_WEIGHT = 0.3;
+
+/**
+ * Core of the turn-aware A* cost, broken out as a pure function for
+ * unit-test access. Given the portal crossing positions (`pa` into the
+ * current node, `pb` out) and the centroid of the current node, returns
+ * the cost A* should apply to the edge.
+ *
+ * All positions are 3D world-space; turn angle is measured in the XZ
+ * plane (Y is up).
+ */
+export function computeTurnAwareCost(
+  pa: readonly [number, number, number],
+  pb: readonly [number, number, number],
+  center: readonly [number, number, number],
+  turningRadius: number,
+): number {
+  const dx = pb[0] - pa[0];
+  const dy = pb[1] - pa[1];
+  const dz = pb[2] - pa[2];
+  const baseCost = Math.hypot(dx, dy, dz);
+
+  const inx = center[0] - pa[0];
+  const inz = center[2] - pa[2];
+  const outx = pb[0] - center[0];
+  const outz = pb[2] - center[2];
+  const inLen = Math.hypot(inx, inz);
+  const outLen = Math.hypot(outx, outz);
+  if (inLen < 1e-4 || outLen < 1e-4) return baseCost;
+
+  const cosTheta = (inx * outx + inz * outz) / (inLen * outLen);
+  const clamped = cosTheta < -1 ? -1 : cosTheta > 1 ? 1 : cosTheta;
+  const theta = Math.acos(clamped); // 0..π
+
+  const halfTheta = theta * 0.5;
+  const sinHalf = Math.sin(halfTheta);
+  if (sinHalf < 1e-4) return baseCost; // straight segment
+
+  const segmentLen = inLen + outLen;
+  const requiredRadius = segmentLen / (2 * sinHalf);
+
+  if (requiredRadius < turningRadius) {
+    return baseCost * TIGHT_TURN_PENALTY_SCALE + TIGHT_TURN_PENALTY_BIAS;
+  }
+  return baseCost * (1 + SOFT_TURN_WEIGHT * (theta / Math.PI));
+}
+
+/**
+ * Builds a `QueryFilter` suitable for a vehicle-mode crowd agent. The
+ * returned filter closes over `profile.turningRadius` — pass a fresh one
+ * if the profile changes.
+ */
+export function createVehicleQueryFilter(profile: VehicleProfile): QueryFilter {
+  return {
+    passFilter(nodeRef: NodeRef, navMesh: NavMesh): boolean {
+      // Delegate area/flag checks to the default filter. The vehicle
+      // navmesh was built with a larger walkable-radius erosion, so the
+      // narrow passages are already absent from the tile set — we don't
+      // need a second layer of area filtering here.
+      return DEFAULT_QUERY_FILTER.passFilter(nodeRef, navMesh);
+    },
+    getCost(
+      pa: Vec3,
+      pb: Vec3,
+      navMesh: NavMesh,
+      prevRef: NodeRef | undefined,
+      curRef: NodeRef,
+      nextRef: NodeRef | undefined,
+    ): number {
+      const baseCost = Math.hypot(pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]);
+      // Edge of the corridor (start or end): no turn context available.
+      if (prevRef === undefined || nextRef === undefined) return baseCost;
+      const center = getPolyCentroid(navMesh, curRef);
+      if (!center) return baseCost;
+      return computeTurnAwareCost(pa, pb, center, profile.turningRadius);
+    },
+  };
+}
+
+/** Computes the XZ-plane centroid of a polygon given its node reference. */
+function getPolyCentroid(navMesh: NavMesh, ref: NodeRef): Vec3 | null {
+  const result = getTileAndPolyByRef(ref, navMesh);
+  if (!result.success) return null;
+  const { tile, poly } = result;
+  const vertexIndices = poly.vertices;
+  const count = vertexIndices.length;
+  if (count === 0) return null;
+  let cx = 0;
+  let cy = 0;
+  let cz = 0;
+  for (let i = 0; i < count; i += 1) {
+    const base = vertexIndices[i] * 3;
+    cx += tile.vertices[base];
+    cy += tile.vertices[base + 1];
+    cz += tile.vertices[base + 2];
+  }
+  const inv = 1 / count;
+  return [cx * inv, cy * inv, cz * inv] as Vec3;
+}

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -30,9 +30,18 @@ export {
 export {
   BotCrowd,
   createBotCrowd,
+  createVehicleBotCrowd,
   type BotCrowdOptions,
   type BotHandle,
 } from './crowd/BotCrowd';
+export { createVehicleQueryFilter } from './crowd/vehicleQueryFilter';
+export {
+  vehicleAgentStateToIntent,
+  vehicleAgentToIntent,
+  rotateVectorByQuaternionInverse,
+  type Quaternion,
+  type VehicleSteeringOptions,
+} from './agent/vehicleSteering';
 export { BotBrain, type BotBrainOptions } from './agent/BotBrain';
 export {
   agentStateToIntent,
@@ -54,10 +63,12 @@ export type {
   BotSelfState,
   ObservedPlayer,
   Vec3Tuple,
+  VehicleProfile,
 } from './types';
 export {
   PracticeBotRuntime,
   PRACTICE_BOT_ID_BASE,
+  DEFAULT_VEHICLE_PROFILE,
   type BotDebugInfo,
   type BotObstacleDebugInfo,
   type LocalSelfAccessor,

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -59,6 +59,7 @@ export {
   PracticeBotRuntime,
   PRACTICE_BOT_ID_BASE,
   type BotDebugInfo,
+  type BotObstacleDebugInfo,
   type LocalSelfAccessor,
   type LocalSelfSnapshot,
   type PracticeBotBehaviorKind,

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -1,0 +1,57 @@
+/**
+ * @module bots
+ *
+ * First-class bot automation framework built on top of
+ * [navcat](https://github.com/isaac-mason/navcat).
+ *
+ * Basic usage:
+ *
+ * ```ts
+ * import { createBotCrowd, BotBrain, behaviors } from '@/bots';
+ *
+ * const crowd = createBotCrowd(world);
+ * const handle = crowd.addBot(spawnPoint);
+ * const brain = new BotBrain(crowd, handle, behaviors.harassNearest());
+ *
+ * // per tick:
+ * crowd.step(dt);
+ * const intent = brain.think(selfState, remotePlayers);
+ * transport.sendInput(buildInputFromButtons(seq, 0, intent.buttons, intent.yaw, intent.pitch));
+ * ```
+ */
+
+export { buildWorldGeometry, type BotWorldGeometry } from './world/worldGeometry';
+export {
+  buildBotNavMesh,
+  type BotNavMesh,
+  type BuildBotNavMeshOptions,
+  type NavMeshMode,
+} from './world/buildNavMesh';
+export {
+  BotCrowd,
+  createBotCrowd,
+  type BotCrowdOptions,
+  type BotHandle,
+} from './crowd/BotCrowd';
+export { BotBrain, type BotBrainOptions } from './agent/BotBrain';
+export {
+  agentStateToIntent,
+  createSteeringState,
+  type SteeringOptions,
+  type SteeringState,
+} from './agent/steering';
+export * as behaviors from './agent/behaviors';
+export type {
+  Behavior,
+  BehaviorDecision,
+  BotBehaviorContext,
+  HarassNearestOptions,
+  WanderOptions,
+} from './agent/behaviors';
+export type {
+  BotIntent,
+  BotMode,
+  BotSelfState,
+  ObservedPlayer,
+  Vec3Tuple,
+} from './types';

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -55,3 +55,10 @@ export type {
   ObservedPlayer,
   Vec3Tuple,
 } from './types';
+export {
+  PracticeBotRuntime,
+  type LocalPlayerInput,
+  type PracticeBotBehaviorKind,
+  type PracticeBotRuntimeOptions,
+  type PracticeBotStats,
+} from './practice/PracticeBotRuntime';

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -58,6 +58,7 @@ export type {
 export {
   PracticeBotRuntime,
   PRACTICE_BOT_ID_BASE,
+  type BotDebugInfo,
   type LocalSelfAccessor,
   type LocalSelfSnapshot,
   type PracticeBotBehaviorKind,

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -57,7 +57,9 @@ export type {
 } from './types';
 export {
   PracticeBotRuntime,
-  type LocalPlayerInput,
+  PRACTICE_BOT_ID_BASE,
+  type LocalSelfAccessor,
+  type LocalSelfSnapshot,
   type PracticeBotBehaviorKind,
   type PracticeBotRuntimeOptions,
   type PracticeBotStats,

--- a/client/src/bots/practice/PracticeBotRuntime.test.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_WORLD_DOCUMENT } from '../../world/worldDocument';
+import { PracticeBotRuntime } from './PracticeBotRuntime';
+
+describe('PracticeBotRuntime', () => {
+  it('spawns bots and exposes them as remote players', () => {
+    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
+    runtime.setBotCount(3);
+    expect(runtime.count).toBe(3);
+    expect(runtime.remotePlayers.size).toBe(3);
+    for (const rp of runtime.remotePlayers.values()) {
+      expect(rp.position).toHaveLength(3);
+      expect(rp.hp).toBeGreaterThan(0);
+    }
+  });
+
+  it('update() advances bot positions without throwing when no target is given', () => {
+    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
+    runtime.setBotCount(2);
+    const initial = Array.from(runtime.remotePlayers.values()).map((rp) =>
+      [...rp.position] as [number, number, number],
+    );
+    for (let i = 0; i < 20; i += 1) {
+      runtime.update(1 / 30, null);
+    }
+    const after = Array.from(runtime.remotePlayers.values()).map((rp) => rp.position);
+    // At least one bot should have been updated in place.
+    expect(after.length).toBe(initial.length);
+  });
+
+  it('chase behavior with a local target produces non-zero desired velocity eventually', () => {
+    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
+    runtime.setBehavior('harass');
+    runtime.setBotCount(1);
+    const bot = Array.from(runtime.remotePlayers.values())[0];
+    const target: [number, number, number] = [bot.position[0] + 8, bot.position[1], bot.position[2] + 8];
+    for (let i = 0; i < 30; i += 1) {
+      runtime.update(1 / 30, { id: 1, position: target, dead: false });
+    }
+    // After a few frames of chasing, the bot should have moved from its spawn
+    // OR produced a non-zero desired velocity on the underlying agent.
+    const handle = Array.from(runtime.remotePlayers.keys())[0];
+    expect(handle).toBeDefined();
+  });
+
+  it('setBotCount shrinks and clears correctly', () => {
+    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
+    runtime.setBotCount(4);
+    expect(runtime.count).toBe(4);
+    runtime.setBotCount(1);
+    expect(runtime.count).toBe(1);
+    expect(runtime.remotePlayers.size).toBe(1);
+    runtime.clear();
+    expect(runtime.count).toBe(0);
+    expect(runtime.remotePlayers.size).toBe(0);
+  });
+
+  it('setMaxSpeed updates all existing bots', () => {
+    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
+    runtime.setBotCount(2);
+    runtime.setMaxSpeed(8);
+    expect(runtime.stats().maxSpeed).toBe(8);
+    // Bots should reflect the new speed.
+    for (const id of runtime.remotePlayers.keys()) {
+      // We can't easily peek at the raw agent without exposing it — but the
+      // stats mirror the speed applied to new agents, which is what matters.
+      expect(id).toBeGreaterThan(0);
+    }
+  });
+});

--- a/client/src/bots/practice/PracticeBotRuntime.test.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.test.ts
@@ -2,45 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_WORLD_DOCUMENT } from '../../world/worldDocument';
 import { PracticeBotRuntime } from './PracticeBotRuntime';
 
-describe('PracticeBotRuntime', () => {
-  it('spawns bots and exposes them as remote players', () => {
+// The runtime is designed to attach to a live NetcodeClient + LocalPreviewTransport.
+// Those require WASM + DOM-style timers, so we test only the lifecycle paths
+// that work in isolation (crowd spawning, behavior swaps, max speed, clear).
+// End-to-end bot-in-scene behavior is covered by smoke-running the session.
+
+describe('PracticeBotRuntime (detached)', () => {
+  it('spawns bots into the crowd without a session', () => {
     const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
     runtime.setBotCount(3);
     expect(runtime.count).toBe(3);
-    expect(runtime.remotePlayers.size).toBe(3);
-    for (const rp of runtime.remotePlayers.values()) {
-      expect(rp.position).toHaveLength(3);
-      expect(rp.hp).toBeGreaterThan(0);
-    }
-  });
-
-  it('update() advances bot positions without throwing when no target is given', () => {
-    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
-    runtime.setBotCount(2);
-    const initial = Array.from(runtime.remotePlayers.values()).map((rp) =>
-      [...rp.position] as [number, number, number],
-    );
-    for (let i = 0; i < 20; i += 1) {
-      runtime.update(1 / 30, null);
-    }
-    const after = Array.from(runtime.remotePlayers.values()).map((rp) => rp.position);
-    // At least one bot should have been updated in place.
-    expect(after.length).toBe(initial.length);
-  });
-
-  it('chase behavior with a local target produces non-zero desired velocity eventually', () => {
-    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
-    runtime.setBehavior('harass');
-    runtime.setBotCount(1);
-    const bot = Array.from(runtime.remotePlayers.values())[0];
-    const target: [number, number, number] = [bot.position[0] + 8, bot.position[1], bot.position[2] + 8];
-    for (let i = 0; i < 30; i += 1) {
-      runtime.update(1 / 30, { id: 1, position: target, dead: false });
-    }
-    // After a few frames of chasing, the bot should have moved from its spawn
-    // OR produced a non-zero desired velocity on the underlying agent.
-    const handle = Array.from(runtime.remotePlayers.keys())[0];
-    expect(handle).toBeDefined();
+    expect(runtime.stats().bots).toBe(3);
+    expect(runtime.stats().running).toBe(false);
   });
 
   it('setBotCount shrinks and clears correctly', () => {
@@ -49,22 +22,35 @@ describe('PracticeBotRuntime', () => {
     expect(runtime.count).toBe(4);
     runtime.setBotCount(1);
     expect(runtime.count).toBe(1);
-    expect(runtime.remotePlayers.size).toBe(1);
     runtime.clear();
     expect(runtime.count).toBe(0);
-    expect(runtime.remotePlayers.size).toBe(0);
   });
 
-  it('setMaxSpeed updates all existing bots', () => {
+  it('setBehavior reassigns all existing bots', () => {
+    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT, { initialBehavior: 'harass' });
+    runtime.setBotCount(2);
+    runtime.setBehavior('wander');
+    expect(runtime.stats().behavior).toBe('wander');
+    runtime.setBehavior('hold');
+    expect(runtime.stats().behavior).toBe('hold');
+  });
+
+  it('setMaxSpeed clamps and applies to existing agents', () => {
     const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
     runtime.setBotCount(2);
-    runtime.setMaxSpeed(8);
-    expect(runtime.stats().maxSpeed).toBe(8);
-    // Bots should reflect the new speed.
-    for (const id of runtime.remotePlayers.keys()) {
-      // We can't easily peek at the raw agent without exposing it — but the
-      // stats mirror the speed applied to new agents, which is what matters.
-      expect(id).toBeGreaterThan(0);
-    }
+    runtime.setMaxSpeed(9);
+    expect(runtime.stats().maxSpeed).toBe(9);
+    runtime.setMaxSpeed(100);
+    expect(runtime.stats().maxSpeed).toBeLessThanOrEqual(12);
+    runtime.setMaxSpeed(0);
+    expect(runtime.stats().maxSpeed).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('detach is a no-op when never attached', () => {
+    const runtime = new PracticeBotRuntime(DEFAULT_WORLD_DOCUMENT);
+    runtime.setBotCount(1);
+    runtime.detach();
+    expect(runtime.count).toBe(1);
+    expect(runtime.stats().running).toBe(false);
   });
 });

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -1,25 +1,49 @@
 /**
- * PracticeBotRuntime — spawns and ticks bots entirely client-side for
- * /practice (single-player) mode.
+ * PracticeBotRuntime — spawns bots as **real players** inside the
+ * `LocalPreviewSession` WASM world and drives them with navcat.
  *
- * Unlike the loadtest runners, practice bots do **not** connect to a server
- * or pass through any WASM physics. Their motion is simulated purely by a
- * shared {@link BotCrowd} (navcat crowd) and then projected as synthetic
- * "remote players" into the {@link GameWorld} render loop, so they appear
- * alongside the local human as regular capsule meshes.
+ * Pipeline per tick:
+ *   1. Read each bot's authoritative position from the NetcodeClient's
+ *      `remotePlayers` map (which is populated by snapshots emitted from
+ *      the WASM session — bots are regular players there).
+ *   2. `syncBotPosition` that into the shared navcat {@link BotCrowd}.
+ *   3. `crowd.step(dt)` advances pathfinding + obstacle avoidance for every
+ *      bot in one pass.
+ *   4. For each bot, run its {@link BotBrain} which turns `agent.desiredVelocity`
+ *      into a {@link BotIntent} (buttons + yaw + pitch).
+ *   5. Encode the intent as an {@link InputCmd} and hand it to
+ *      {@link LocalPreviewTransport.sendBotInputs}, which routes it into the
+ *      WASM session's per-bot `PlayerRuntime`. The KCC then integrates the
+ *      bot's capsule like any other player — collisions, step height,
+ *      gravity, everything.
  *
- * The public surface intentionally mimics the shape of a
- * {@link RemotePlayer} map so that {@link GameWorld} can iterate it with the
- * same loops it already uses for network-driven remotes.
+ * Because bots are real players, they appear in snapshots like any remote
+ * and GameWorld renders them with its existing remote-player code path.
+ * Hit detection is handled by the session's multi-player hitscan.
  */
 
+import type { NetcodeClient } from '../../net/netcodeClient';
+import type { LocalPreviewTransport } from '../../net/localPreviewTransport';
 import type { WorldDocument } from '../../world/worldDocument';
-import type { RemotePlayer } from '../../scene/useGameConnection';
+import { buildInputFromButtons } from '../../scene/inputBuilder';
+import { FLAG_DEAD } from '../../net/protocol';
+
+/**
+ * Accessor for the local (human) player's authoritative state. The
+ * runtime calls this every tick so bot brains know who to chase. Return
+ * `null` if the local player state isn't available yet (pre-welcome).
+ */
+export type LocalSelfAccessor = () => LocalSelfSnapshot | null;
+
+export interface LocalSelfSnapshot {
+  id: number;
+  position: [number, number, number];
+  dead: boolean;
+}
 import { BotBrain } from '../agent/BotBrain';
 import {
   harassNearest,
   holdAnchor,
-  moveTo,
   wander,
   type Behavior,
 } from '../agent/behaviors';
@@ -31,23 +55,24 @@ import type {
   Vec3Tuple,
 } from '../types';
 
-/** Starting id for practice bots. Chosen to sit well above any real player id. */
-const PRACTICE_BOT_ID_BASE = 1_000_000;
+/** Starting id for practice bots. Kept well above any realistic player id. */
+export const PRACTICE_BOT_ID_BASE = 1_000_000;
 
-/** Behaviors exposed to the practice UI. */
+/** Behaviors exposed by the practice UI. */
 export type PracticeBotBehaviorKind = 'harass' | 'wander' | 'hold';
 
 export interface PracticeBotRuntimeOptions {
   /**
-   * Max radius of any bot added to the crowd. Must be >= the largest bot
-   * radius; leaving it at the default covers the stock `harassNearest`
-   * bots.
+   * Largest agent radius the crowd will accept. Defaults to 0.6 — covers
+   * the stock harass bots comfortably.
    */
   maxAgentRadius?: number;
-  /** Behavior to use for freshly spawned bots (defaults to `'harass'`). */
+  /** Behavior used for newly spawned bots. */
   initialBehavior?: PracticeBotBehaviorKind;
-  /** Max speed (m/s) each bot's crowd agent will travel. */
+  /** Max speed (m/s) applied to every bot's navcat agent. */
   maxSpeed?: number;
+  /** Frequency at which we tick bot logic + push inputs (Hz). */
+  tickHz?: number;
 }
 
 export interface PracticeBotStats {
@@ -55,6 +80,8 @@ export interface PracticeBotStats {
   behavior: PracticeBotBehaviorKind;
   maxSpeed: number;
   navTriangles: number;
+  /** True while the runtime is actively ticking (session connected). */
+  running: boolean;
 }
 
 interface PracticeBot {
@@ -62,33 +89,31 @@ interface PracticeBot {
   handle: BotHandle;
   brain: BotBrain;
   behaviorKind: PracticeBotBehaviorKind;
-  /** Mirrors the RemotePlayer shape GameWorld renders. */
-  render: RemotePlayer;
-  /** Last intent from the brain (for stats / debug). */
+  seq: number;
   lastIntent: BotIntent;
 }
 
 const DEFAULT_BEHAVIOR: PracticeBotBehaviorKind = 'harass';
 const DEFAULT_MAX_SPEED = 5.5;
+const DEFAULT_TICK_HZ = 60;
 
 /**
- * Runtime for practice-mode bots. Owns a single shared navcat crowd and one
- * {@link BotBrain} per bot. Call {@link update} once per render frame from
- * GameWorld.
+ * Runtime for practice-mode bots that spawns them as full players in the
+ * local WASM session and pilots them via navcat.
  */
 export class PracticeBotRuntime {
   readonly crowd: BotCrowd;
-  /**
-   * Map of bot-id → {@link RemotePlayer}, structurally identical to the real
-   * `state.remotePlayers` map that GameWorld iterates. Safe to expose as a
-   * live reference — GameWorld reads it every frame.
-   */
-  readonly remotePlayers: Map<number, RemotePlayer> = new Map();
-
   private readonly bots = new Map<number, PracticeBot>();
   private nextId = PRACTICE_BOT_ID_BASE;
   private behaviorKind: PracticeBotBehaviorKind;
   private maxSpeed: number;
+  private readonly tickHz: number;
+  private client: NetcodeClient | null = null;
+  private transport: LocalPreviewTransport | null = null;
+  private getSelf: LocalSelfAccessor | null = null;
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+  private lastTickMs = 0;
+  private running = false;
 
   constructor(world: WorldDocument, options: PracticeBotRuntimeOptions = {}) {
     this.crowd = createBotCrowd(world, {
@@ -96,6 +121,53 @@ export class PracticeBotRuntime {
     });
     this.behaviorKind = options.initialBehavior ?? DEFAULT_BEHAVIOR;
     this.maxSpeed = options.maxSpeed ?? DEFAULT_MAX_SPEED;
+    this.tickHz = options.tickHz ?? DEFAULT_TICK_HZ;
+  }
+
+  /**
+   * Attach the runtime to a live {@link NetcodeClient}. The runtime will
+   * push bot inputs through the client's {@link LocalPreviewTransport} and
+   * read bot positions from `client.remotePlayers`. `getSelf` must return
+   * the human's current position — typically read from the connection
+   * state updated in `onLocalSnapshot`.
+   *
+   * Call {@link detach} when the session tears down.
+   */
+  attach(client: NetcodeClient, getSelf: LocalSelfAccessor): void {
+    if (this.client === client && this.getSelf === getSelf) return;
+    this.detach();
+    this.client = client;
+    this.getSelf = getSelf;
+    const transport = client.getLocalPreviewTransport();
+    if (!transport) {
+      // Not a practice session — nothing to do. Bots won't spawn.
+      return;
+    }
+    this.transport = transport;
+    // Re-spawn any already-tracked bots against the new session.
+    for (const bot of this.bots.values()) {
+      this.transport.connectBot(bot.id);
+    }
+    this.running = true;
+    this.lastTickMs = performance.now();
+    this.tickHandle = setInterval(() => this.tick(), 1000 / this.tickHz);
+  }
+
+  /** Detach from the current session and stop ticking. */
+  detach(): void {
+    this.running = false;
+    if (this.tickHandle !== null) {
+      clearInterval(this.tickHandle);
+      this.tickHandle = null;
+    }
+    if (this.transport) {
+      for (const bot of this.bots.values()) {
+        this.transport.disconnectBot(bot.id);
+      }
+    }
+    this.transport = null;
+    this.client = null;
+    this.getSelf = null;
   }
 
   /** Number of active bots. */
@@ -109,10 +181,10 @@ export class PracticeBotRuntime {
       behavior: this.behaviorKind,
       maxSpeed: this.maxSpeed,
       navTriangles: this.crowd.nav.geometry.triangleCount,
+      running: this.running,
     };
   }
 
-  /** Set the behavior used for newly added bots and reapply it to existing ones. */
   setBehavior(kind: PracticeBotBehaviorKind): void {
     if (kind === this.behaviorKind) return;
     this.behaviorKind = kind;
@@ -122,7 +194,6 @@ export class PracticeBotRuntime {
     }
   }
 
-  /** Set the max move speed for all (current and future) bots. */
   setMaxSpeed(speed: number): void {
     const clamped = Math.max(0.5, Math.min(12, speed));
     this.maxSpeed = clamped;
@@ -133,14 +204,13 @@ export class PracticeBotRuntime {
   }
 
   /**
-   * Ensures exactly `target` bots are active. Bots are spawned at randomly
-   * sampled walkable points near `spawnNear` (falling back to the world
-   * origin if sampling fails). Extra bots are removed from the tail.
+   * Ensures exactly `target` bots are alive. New bots are spawned at
+   * random walkable points; extras are removed from the tail.
    */
-  setBotCount(target: number, spawnNear?: Vec3Tuple): void {
+  setBotCount(target: number): void {
     const clamped = Math.max(0, Math.min(32, Math.floor(target)));
     while (this.bots.size < clamped) {
-      this.spawnBot(spawnNear);
+      this.spawnBot();
     }
     if (this.bots.size > clamped) {
       const ids = Array.from(this.bots.keys());
@@ -151,8 +221,8 @@ export class PracticeBotRuntime {
   }
 
   /** Spawn a single bot. Returns its id. */
-  spawnBot(spawnNear?: Vec3Tuple): number {
-    const spawn = this.chooseSpawnPoint(spawnNear);
+  spawnBot(): number {
+    const spawn = this.crowd.findRandomWalkable() ?? [0, 2, 0];
     const handle = this.crowd.addBot(spawn);
     const agent = this.crowd.getAgent(handle.id);
     if (agent) agent.maxSpeed = this.maxSpeed;
@@ -161,29 +231,15 @@ export class PracticeBotRuntime {
     const brain = new BotBrain(this.crowd, handle, makeBehavior(this.behaviorKind), {
       anchor: spawn,
     });
-    const render: RemotePlayer = {
-      id,
-      position: [spawn[0], spawn[1], spawn[2]],
-      yaw: 0,
-      pitch: 0,
-      hp: 100,
-    };
     this.bots.set(id, {
       id,
       handle,
       brain,
       behaviorKind: this.behaviorKind,
-      render,
-      lastIntent: {
-        buttons: 0,
-        yaw: 0,
-        pitch: 0,
-        firePrimary: false,
-        mode: 'hold_anchor',
-        targetPlayerId: null,
-      },
+      seq: 0,
+      lastIntent: makeIdleIntent(),
     });
-    this.remotePlayers.set(id, render);
+    this.transport?.connectBot(id);
     return id;
   }
 
@@ -193,7 +249,7 @@ export class PracticeBotRuntime {
     if (!bot) return false;
     this.crowd.removeBot(bot.handle);
     this.bots.delete(id);
-    this.remotePlayers.delete(id);
+    this.transport?.disconnectBot(id);
     return true;
   }
 
@@ -201,33 +257,49 @@ export class PracticeBotRuntime {
   clear(): void {
     for (const bot of this.bots.values()) {
       this.crowd.removeBot(bot.handle);
+      this.transport?.disconnectBot(bot.id);
     }
     this.bots.clear();
-    this.remotePlayers.clear();
   }
 
-  /**
-   * Advances the crowd by `dt` and updates every bot's render state.
-   *
-   * @param dt           Delta since last update (seconds). Clamped internally.
-   * @param localPlayer  Current self state of the human player — used as the
-   *                     target for `harass` behavior and as observed-player
-   *                     input for every bot's brain.
-   */
-  update(dt: number, localPlayer: LocalPlayerInput | null): void {
+  /** Internal tick — runs every `1 / tickHz` seconds when attached. */
+  private tick(): void {
+    if (!this.running || !this.client || !this.transport) return;
     if (this.bots.size === 0) return;
-    const clampedDt = Math.max(0.001, Math.min(0.1, dt));
-    this.crowd.step(clampedDt);
+    const nowMs = performance.now();
+    const dt = Math.min(0.25, Math.max(0.001, (nowMs - this.lastTickMs) / 1000));
+    this.lastTickMs = nowMs;
 
-    const observed: ObservedPlayer[] = localPlayer
+    const client = this.client;
+    const localFlags = client.localPlayerFlags;
+    const localHp = client.localPlayerHp;
+    const selfSnapshot = this.getSelf?.() ?? null;
+    const localIsDead = selfSnapshot?.dead ?? ((localFlags & FLAG_DEAD) !== 0 || localHp <= 0);
+    const observed: ObservedPlayer[] = selfSnapshot
       ? [
           {
-            id: localPlayer.id,
-            position: [...localPlayer.position],
-            isDead: localPlayer.dead,
+            id: selfSnapshot.id,
+            position: [
+              selfSnapshot.position[0],
+              selfSnapshot.position[1],
+              selfSnapshot.position[2],
+            ],
+            isDead: localIsDead,
           },
         ]
       : [];
+
+    // Sync every bot's authoritative position from the latest snapshot
+    // *before* stepping the crowd, so navmesh planning uses real physics
+    // positions rather than the crowd's internal dead-reckoning.
+    for (const bot of this.bots.values()) {
+      const remote = client.remotePlayers.get(bot.id);
+      if (remote) {
+        this.crowd.syncBotPosition(bot.handle, remote.position);
+      }
+    }
+
+    this.crowd.step(dt);
 
     const selfTemplate: BotSelfState = {
       position: [0, 0, 0],
@@ -239,51 +311,52 @@ export class PracticeBotRuntime {
     };
 
     for (const bot of this.bots.values()) {
-      const agent = this.crowd.getAgent(bot.handle.id);
-      if (!agent) continue;
-      selfTemplate.position[0] = agent.position[0];
-      selfTemplate.position[1] = agent.position[1];
-      selfTemplate.position[2] = agent.position[2];
-      selfTemplate.velocity[0] = agent.velocity[0];
-      selfTemplate.velocity[1] = agent.velocity[1];
-      selfTemplate.velocity[2] = agent.velocity[2];
-      selfTemplate.yaw = bot.render.yaw;
-      selfTemplate.pitch = bot.render.pitch;
-      selfTemplate.onGround = true;
-      selfTemplate.dead = false;
-      bot.lastIntent = bot.brain.think(selfTemplate, observed);
-      // Use the agent position (authoritative from crowd) as the bot's
-      // rendered position, not self.position (which was the previous tick's
-      // position).
-      bot.render.position[0] = agent.position[0];
-      bot.render.position[1] = agent.position[1];
-      bot.render.position[2] = agent.position[2];
-      bot.render.yaw = bot.lastIntent.yaw;
-      bot.render.pitch = bot.lastIntent.pitch;
-    }
-  }
-
-  private chooseSpawnPoint(spawnNear?: Vec3Tuple): Vec3Tuple {
-    if (spawnNear) {
-      const snap = this.crowd.findNearestWalkable(spawnNear);
-      if (snap) {
-        return [snap.position[0] + jitter(), snap.position[1], snap.position[2] + jitter()];
+      const remote = client.remotePlayers.get(bot.id);
+      if (!remote) {
+        // Bot has no snapshot yet (just spawned) — skip this frame.
+        continue;
       }
+      const agent = this.crowd.getAgent(bot.handle.id);
+      selfTemplate.position[0] = remote.position[0];
+      selfTemplate.position[1] = remote.position[1];
+      selfTemplate.position[2] = remote.position[2];
+      if (agent) {
+        selfTemplate.velocity[0] = agent.velocity[0];
+        selfTemplate.velocity[1] = agent.velocity[1];
+        selfTemplate.velocity[2] = agent.velocity[2];
+      } else {
+        selfTemplate.velocity[0] = 0;
+        selfTemplate.velocity[1] = 0;
+        selfTemplate.velocity[2] = 0;
+      }
+      selfTemplate.yaw = remote.yaw;
+      selfTemplate.pitch = remote.pitch;
+      selfTemplate.onGround = true;
+      selfTemplate.dead = remote.hp <= 0;
+
+      bot.lastIntent = bot.brain.think(selfTemplate, observed);
+      bot.seq = (bot.seq + 1) & 0xffff;
+      const cmd = buildInputFromButtons(
+        bot.seq,
+        0,
+        bot.lastIntent.buttons,
+        bot.lastIntent.yaw,
+        bot.lastIntent.pitch,
+      );
+      this.transport.sendBotInputs(bot.id, [cmd]);
     }
-    const random = this.crowd.findRandomWalkable();
-    if (random) return random;
-    return [0, 2, 0];
   }
 }
 
-export interface LocalPlayerInput {
-  id: number;
-  position: Vec3Tuple;
-  dead: boolean;
-}
-
-function jitter(): number {
-  return (Math.random() - 0.5) * 2;
+function makeIdleIntent(): BotIntent {
+  return {
+    buttons: 0,
+    yaw: 0,
+    pitch: 0,
+    firePrimary: false,
+    mode: 'hold_anchor',
+    targetPlayerId: null,
+  };
 }
 
 function makeBehavior(kind: PracticeBotBehaviorKind): Behavior {
@@ -295,12 +368,12 @@ function makeBehavior(kind: PracticeBotBehaviorKind): Behavior {
     case 'harass':
     default:
       return harassNearest({
-        acquireDistanceM: 60,
-        recoveryDistanceM: 80,
+        acquireDistanceM: 80,
+        recoveryDistanceM: 120,
         fireDistanceM: 0,
       });
   }
 }
 
-// Convenience factories for callers that want a single-shot behavior.
-export { moveTo, harassNearest, wander, holdAnchor };
+// Keep FLAG_DEAD referenced so TS doesn't flag the import.
+void FLAG_DEAD;

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -1,0 +1,306 @@
+/**
+ * PracticeBotRuntime — spawns and ticks bots entirely client-side for
+ * /practice (single-player) mode.
+ *
+ * Unlike the loadtest runners, practice bots do **not** connect to a server
+ * or pass through any WASM physics. Their motion is simulated purely by a
+ * shared {@link BotCrowd} (navcat crowd) and then projected as synthetic
+ * "remote players" into the {@link GameWorld} render loop, so they appear
+ * alongside the local human as regular capsule meshes.
+ *
+ * The public surface intentionally mimics the shape of a
+ * {@link RemotePlayer} map so that {@link GameWorld} can iterate it with the
+ * same loops it already uses for network-driven remotes.
+ */
+
+import type { WorldDocument } from '../../world/worldDocument';
+import type { RemotePlayer } from '../../scene/useGameConnection';
+import { BotBrain } from '../agent/BotBrain';
+import {
+  harassNearest,
+  holdAnchor,
+  moveTo,
+  wander,
+  type Behavior,
+} from '../agent/behaviors';
+import { BotCrowd, createBotCrowd, type BotHandle } from '../crowd/BotCrowd';
+import type {
+  BotIntent,
+  BotSelfState,
+  ObservedPlayer,
+  Vec3Tuple,
+} from '../types';
+
+/** Starting id for practice bots. Chosen to sit well above any real player id. */
+const PRACTICE_BOT_ID_BASE = 1_000_000;
+
+/** Behaviors exposed to the practice UI. */
+export type PracticeBotBehaviorKind = 'harass' | 'wander' | 'hold';
+
+export interface PracticeBotRuntimeOptions {
+  /**
+   * Max radius of any bot added to the crowd. Must be >= the largest bot
+   * radius; leaving it at the default covers the stock `harassNearest`
+   * bots.
+   */
+  maxAgentRadius?: number;
+  /** Behavior to use for freshly spawned bots (defaults to `'harass'`). */
+  initialBehavior?: PracticeBotBehaviorKind;
+  /** Max speed (m/s) each bot's crowd agent will travel. */
+  maxSpeed?: number;
+}
+
+export interface PracticeBotStats {
+  bots: number;
+  behavior: PracticeBotBehaviorKind;
+  maxSpeed: number;
+  navTriangles: number;
+}
+
+interface PracticeBot {
+  id: number;
+  handle: BotHandle;
+  brain: BotBrain;
+  behaviorKind: PracticeBotBehaviorKind;
+  /** Mirrors the RemotePlayer shape GameWorld renders. */
+  render: RemotePlayer;
+  /** Last intent from the brain (for stats / debug). */
+  lastIntent: BotIntent;
+}
+
+const DEFAULT_BEHAVIOR: PracticeBotBehaviorKind = 'harass';
+const DEFAULT_MAX_SPEED = 5.5;
+
+/**
+ * Runtime for practice-mode bots. Owns a single shared navcat crowd and one
+ * {@link BotBrain} per bot. Call {@link update} once per render frame from
+ * GameWorld.
+ */
+export class PracticeBotRuntime {
+  readonly crowd: BotCrowd;
+  /**
+   * Map of bot-id → {@link RemotePlayer}, structurally identical to the real
+   * `state.remotePlayers` map that GameWorld iterates. Safe to expose as a
+   * live reference — GameWorld reads it every frame.
+   */
+  readonly remotePlayers: Map<number, RemotePlayer> = new Map();
+
+  private readonly bots = new Map<number, PracticeBot>();
+  private nextId = PRACTICE_BOT_ID_BASE;
+  private behaviorKind: PracticeBotBehaviorKind;
+  private maxSpeed: number;
+
+  constructor(world: WorldDocument, options: PracticeBotRuntimeOptions = {}) {
+    this.crowd = createBotCrowd(world, {
+      maxAgentRadius: options.maxAgentRadius ?? 0.6,
+    });
+    this.behaviorKind = options.initialBehavior ?? DEFAULT_BEHAVIOR;
+    this.maxSpeed = options.maxSpeed ?? DEFAULT_MAX_SPEED;
+  }
+
+  /** Number of active bots. */
+  get count(): number {
+    return this.bots.size;
+  }
+
+  stats(): PracticeBotStats {
+    return {
+      bots: this.bots.size,
+      behavior: this.behaviorKind,
+      maxSpeed: this.maxSpeed,
+      navTriangles: this.crowd.nav.geometry.triangleCount,
+    };
+  }
+
+  /** Set the behavior used for newly added bots and reapply it to existing ones. */
+  setBehavior(kind: PracticeBotBehaviorKind): void {
+    if (kind === this.behaviorKind) return;
+    this.behaviorKind = kind;
+    for (const bot of this.bots.values()) {
+      bot.brain.setBehavior(makeBehavior(kind));
+      bot.behaviorKind = kind;
+    }
+  }
+
+  /** Set the max move speed for all (current and future) bots. */
+  setMaxSpeed(speed: number): void {
+    const clamped = Math.max(0.5, Math.min(12, speed));
+    this.maxSpeed = clamped;
+    for (const bot of this.bots.values()) {
+      const agent = this.crowd.getAgent(bot.handle.id);
+      if (agent) agent.maxSpeed = clamped;
+    }
+  }
+
+  /**
+   * Ensures exactly `target` bots are active. Bots are spawned at randomly
+   * sampled walkable points near `spawnNear` (falling back to the world
+   * origin if sampling fails). Extra bots are removed from the tail.
+   */
+  setBotCount(target: number, spawnNear?: Vec3Tuple): void {
+    const clamped = Math.max(0, Math.min(32, Math.floor(target)));
+    while (this.bots.size < clamped) {
+      this.spawnBot(spawnNear);
+    }
+    if (this.bots.size > clamped) {
+      const ids = Array.from(this.bots.keys());
+      for (let i = clamped; i < ids.length; i += 1) {
+        this.removeBot(ids[i]);
+      }
+    }
+  }
+
+  /** Spawn a single bot. Returns its id. */
+  spawnBot(spawnNear?: Vec3Tuple): number {
+    const spawn = this.chooseSpawnPoint(spawnNear);
+    const handle = this.crowd.addBot(spawn);
+    const agent = this.crowd.getAgent(handle.id);
+    if (agent) agent.maxSpeed = this.maxSpeed;
+    const id = this.nextId;
+    this.nextId += 1;
+    const brain = new BotBrain(this.crowd, handle, makeBehavior(this.behaviorKind), {
+      anchor: spawn,
+    });
+    const render: RemotePlayer = {
+      id,
+      position: [spawn[0], spawn[1], spawn[2]],
+      yaw: 0,
+      pitch: 0,
+      hp: 100,
+    };
+    this.bots.set(id, {
+      id,
+      handle,
+      brain,
+      behaviorKind: this.behaviorKind,
+      render,
+      lastIntent: {
+        buttons: 0,
+        yaw: 0,
+        pitch: 0,
+        firePrimary: false,
+        mode: 'hold_anchor',
+        targetPlayerId: null,
+      },
+    });
+    this.remotePlayers.set(id, render);
+    return id;
+  }
+
+  /** Remove a single bot by id. */
+  removeBot(id: number): boolean {
+    const bot = this.bots.get(id);
+    if (!bot) return false;
+    this.crowd.removeBot(bot.handle);
+    this.bots.delete(id);
+    this.remotePlayers.delete(id);
+    return true;
+  }
+
+  /** Remove every bot. */
+  clear(): void {
+    for (const bot of this.bots.values()) {
+      this.crowd.removeBot(bot.handle);
+    }
+    this.bots.clear();
+    this.remotePlayers.clear();
+  }
+
+  /**
+   * Advances the crowd by `dt` and updates every bot's render state.
+   *
+   * @param dt           Delta since last update (seconds). Clamped internally.
+   * @param localPlayer  Current self state of the human player — used as the
+   *                     target for `harass` behavior and as observed-player
+   *                     input for every bot's brain.
+   */
+  update(dt: number, localPlayer: LocalPlayerInput | null): void {
+    if (this.bots.size === 0) return;
+    const clampedDt = Math.max(0.001, Math.min(0.1, dt));
+    this.crowd.step(clampedDt);
+
+    const observed: ObservedPlayer[] = localPlayer
+      ? [
+          {
+            id: localPlayer.id,
+            position: [...localPlayer.position],
+            isDead: localPlayer.dead,
+          },
+        ]
+      : [];
+
+    const selfTemplate: BotSelfState = {
+      position: [0, 0, 0],
+      velocity: [0, 0, 0],
+      yaw: 0,
+      pitch: 0,
+      onGround: true,
+      dead: false,
+    };
+
+    for (const bot of this.bots.values()) {
+      const agent = this.crowd.getAgent(bot.handle.id);
+      if (!agent) continue;
+      selfTemplate.position[0] = agent.position[0];
+      selfTemplate.position[1] = agent.position[1];
+      selfTemplate.position[2] = agent.position[2];
+      selfTemplate.velocity[0] = agent.velocity[0];
+      selfTemplate.velocity[1] = agent.velocity[1];
+      selfTemplate.velocity[2] = agent.velocity[2];
+      selfTemplate.yaw = bot.render.yaw;
+      selfTemplate.pitch = bot.render.pitch;
+      selfTemplate.onGround = true;
+      selfTemplate.dead = false;
+      bot.lastIntent = bot.brain.think(selfTemplate, observed);
+      // Use the agent position (authoritative from crowd) as the bot's
+      // rendered position, not self.position (which was the previous tick's
+      // position).
+      bot.render.position[0] = agent.position[0];
+      bot.render.position[1] = agent.position[1];
+      bot.render.position[2] = agent.position[2];
+      bot.render.yaw = bot.lastIntent.yaw;
+      bot.render.pitch = bot.lastIntent.pitch;
+    }
+  }
+
+  private chooseSpawnPoint(spawnNear?: Vec3Tuple): Vec3Tuple {
+    if (spawnNear) {
+      const snap = this.crowd.findNearestWalkable(spawnNear);
+      if (snap) {
+        return [snap.position[0] + jitter(), snap.position[1], snap.position[2] + jitter()];
+      }
+    }
+    const random = this.crowd.findRandomWalkable();
+    if (random) return random;
+    return [0, 2, 0];
+  }
+}
+
+export interface LocalPlayerInput {
+  id: number;
+  position: Vec3Tuple;
+  dead: boolean;
+}
+
+function jitter(): number {
+  return (Math.random() - 0.5) * 2;
+}
+
+function makeBehavior(kind: PracticeBotBehaviorKind): Behavior {
+  switch (kind) {
+    case 'wander':
+      return wander({ radiusM: 18 });
+    case 'hold':
+      return holdAnchor();
+    case 'harass':
+    default:
+      return harassNearest({
+        acquireDistanceM: 60,
+        recoveryDistanceM: 80,
+        fireDistanceM: 0,
+      });
+  }
+}
+
+// Convenience factories for callers that want a single-shot behavior.
+export { moveTo, harassNearest, wander, holdAnchor };

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -94,7 +94,11 @@ interface PracticeBot {
 }
 
 const DEFAULT_BEHAVIOR: PracticeBotBehaviorKind = 'harass';
-const DEFAULT_MAX_SPEED = 5.5;
+// Default at a brisk jog. The KCC's human walk speed is 6.0 m/s and
+// sprint is 8.5 m/s; 3.0 m/s feels like a slow bot you can actually look
+// at, and the slider goes up from there. See the speed override flow in
+// `shared/src/simulation.rs::update_player_motion`.
+const DEFAULT_MAX_SPEED = 3.0;
 const DEFAULT_TICK_HZ = 60;
 
 /**
@@ -144,9 +148,11 @@ export class PracticeBotRuntime {
       return;
     }
     this.transport = transport;
-    // Re-spawn any already-tracked bots against the new session.
+    // Re-spawn any already-tracked bots against the new session and
+    // re-apply the current max-speed override so the KCC uses it.
     for (const bot of this.bots.values()) {
       this.transport.connectBot(bot.id);
+      this.transport.setBotMaxSpeed(bot.id, this.maxSpeed);
     }
     this.running = true;
     this.lastTickMs = performance.now();
@@ -198,8 +204,14 @@ export class PracticeBotRuntime {
     const clamped = Math.max(0.5, Math.min(12, speed));
     this.maxSpeed = clamped;
     for (const bot of this.bots.values()) {
+      // Keep navcat's crowd planner in sync so desiredVelocity never
+      // exceeds the KCC cap (avoids oscillation where the crowd asks for
+      // faster-than-attainable motion and the agent looks stuttery).
       const agent = this.crowd.getAgent(bot.handle.id);
       if (agent) agent.maxSpeed = clamped;
+      // Real source of truth for how fast the bot moves on the server:
+      // the per-player override inside LocalPreviewSession.
+      this.transport?.setBotMaxSpeed(bot.id, clamped);
     }
   }
 
@@ -239,7 +251,12 @@ export class PracticeBotRuntime {
       seq: 0,
       lastIntent: makeIdleIntent(),
     });
-    this.transport?.connectBot(id);
+    if (this.transport) {
+      this.transport.connectBot(id);
+      // Push the current max-speed override so the bot's KCC moves at
+      // whatever speed the user has on the slider right now.
+      this.transport.setBotMaxSpeed(id, this.maxSpeed);
+    }
     return id;
   }
 

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -27,7 +27,11 @@ import type { LocalPreviewTransport } from '../../net/localPreviewTransport';
 import type { WorldDocument } from '../../world/worldDocument';
 import { buildInputFromButtons } from '../../scene/inputBuilder';
 import { FLAG_DEAD } from '../../net/protocol';
+import { FLAG_IN_VEHICLE } from '../../net/sharedConstants';
 import { pathCorridor } from 'navcat/blocks';
+import { DEFAULT_QUERY_FILTER } from 'navcat';
+import { createVehicleQueryFilter } from '../crowd/vehicleQueryFilter';
+import { vehicleAgentStateToIntent } from '../agent/vehicleSteering';
 
 /**
  * Accessor for the local (human) player's authoritative state. The
@@ -48,13 +52,19 @@ import {
   wander,
   type Behavior,
 } from '../agent/behaviors';
-import { BotCrowd, createBotCrowd, type BotHandle } from '../crowd/BotCrowd';
+import {
+  BotCrowd,
+  createBotCrowd,
+  createVehicleBotCrowd,
+  type BotHandle,
+} from '../crowd/BotCrowd';
 import type {
   BotIntent,
   BotMode,
   BotSelfState,
   ObservedPlayer,
   Vec3Tuple,
+  VehicleProfile,
 } from '../types';
 
 /** Starting id for practice bots. Kept well above any realistic player id. */
@@ -75,7 +85,33 @@ export interface PracticeBotRuntimeOptions {
   maxSpeed?: number;
   /** Frequency at which we tick bot logic + push inputs (Hz). */
   tickHz?: number;
+  /** Whether bots start with vehicle mode enabled. */
+  useVehicles?: boolean;
+  /** Override the default vehicle profile used by the walk-vs-drive planner. */
+  vehicleProfile?: VehicleProfile;
 }
+
+/**
+ * Stock {@link VehicleProfile} for the default practice-mode vehicle (the
+ * small Rapier raycast car). Values are intentionally conservative — tune
+ * `turningRadius` and `cruiseSpeed` after playtesting.
+ *
+ * - `turningRadius`: at `VEHICLE_MAX_STEER_RAD = 0.5 rad` and a 1.8 m
+ *   wheelbase, the kinematic lower bound is ≈ 1.8 / tan(0.5) ≈ 3.3 m. We
+ *   bump to 5 m to account for the raycast-vehicle's drift and the fact
+ *   that A* costs use centroids, not wheelbase geometry.
+ * - `cruiseSpeed`: empirical — the chassis reaches ~14 m/s on a straight
+ *   with the default engine force. 12 m/s leaves margin for the car
+ *   actually *exiting* a corner.
+ */
+export const DEFAULT_VEHICLE_PROFILE: VehicleProfile = Object.freeze({
+  turningRadius: 5,
+  agentRadius: 1.3,
+  agentHeight: 1.5,
+  cruiseSpeed: 12,
+  enterDistance: 2.5,
+  enterExitOverheadSec: 1.5,
+});
 
 export interface PracticeBotStats {
   bots: number;
@@ -84,7 +120,23 @@ export interface PracticeBotStats {
   navTriangles: number;
   /** True while the runtime is actively ticking (session connected). */
   running: boolean;
+  /** Whether the vehicle-aware planner is currently enabled. */
+  useVehicles: boolean;
+  /** Number of vehicle-sized tris in the lazy vehicle navmesh, 0 if unbuilt. */
+  vehicleNavTriangles: number;
 }
+
+/**
+ * Per-bot vehicle FSM stage. Mirrors {@link BotMode} but lives in the
+ * runtime because the decision involves cross-bot resources (vehicle
+ * reservations, two crowds) that a `Behavior` shouldn't see.
+ */
+type VehicleFsmStage =
+  | 'on_foot'
+  | 'walking_to_vehicle'
+  | 'entering_vehicle'
+  | 'driving'
+  | 'exiting_vehicle';
 
 /**
  * Snapshot of an obstacle (currently: vehicle) that the bot crowd
@@ -129,6 +181,10 @@ export interface BotDebugInfo {
   maxSpeed: number;
   /** Whether the brain wanted to fire on the last tick. */
   firePrimary: boolean;
+  /** Vehicle FSM stage — `'on_foot'` for walking bots. */
+  vehicleStage: VehicleFsmStage;
+  /** Vehicle id this bot is currently reserving / driving, or null. */
+  reservedVehicleId: number | null;
 }
 
 interface PracticeBot {
@@ -138,6 +194,23 @@ interface PracticeBot {
   behaviorKind: PracticeBotBehaviorKind;
   seq: number;
   lastIntent: BotIntent;
+  /**
+   * Current vehicle FSM stage. Driven by `tickVehicleFsm`; `on_foot` is
+   * the ground state whenever `useVehicles` is false.
+   */
+  vehicleStage: VehicleFsmStage;
+  /** Vehicle id this bot has reserved, or null. */
+  reservedVehicleId: number | null;
+  /** Handle into the vehicle-sized crowd while `vehicleStage === 'driving'`. */
+  vehicleHandle: BotHandle | null;
+  /**
+   * Last destination the brain asked for (foot-mode target). We cache it
+   * so the vehicle FSM can continue the journey on the vehicle navmesh
+   * after entering a car.
+   */
+  pendingDestination: Vec3Tuple | null;
+  /** Tick count since the last FSM transition — used for timeouts. */
+  fsmTicks: number;
 }
 
 const DEFAULT_BEHAVIOR: PracticeBotBehaviorKind = 'harass';
@@ -179,14 +252,38 @@ export class PracticeBotRuntime {
    * without them being baked into the static navmesh.
    */
   private readonly vehicleObstacleAgents = new Map<number, string>();
+  private readonly world: WorldDocument;
+  private readonly maxAgentRadius: number;
+  /** Whether the walk-vs-drive planner is active. */
+  private useVehicles: boolean;
+  /** Static physical profile of the vehicle the bots would drive. */
+  private readonly vehicleProfile: VehicleProfile;
+  /**
+   * Lazy second crowd built on the first call to `setUseVehicles(true)`.
+   * The underlying navmesh has a larger walkable radius so narrow
+   * passages that a player can squeeze through are excluded. Bots only
+   * inhabit it while driving.
+   */
+  private vehicleCrowd: BotCrowd | null = null;
+  /** navcat QueryFilter paired with the vehicle crowd. Built lazily alongside it. */
+  private vehicleQueryFilter: ReturnType<typeof createVehicleQueryFilter> | null = null;
+  /**
+   * Reservation map — prevents two bots racing for the same car.
+   * Key: vehicleId. Value: botId holding the reservation.
+   */
+  private readonly reservedVehicles = new Map<number, number>();
 
   constructor(world: WorldDocument, options: PracticeBotRuntimeOptions = {}) {
+    this.world = world;
+    this.maxAgentRadius = options.maxAgentRadius ?? 0.6;
     this.crowd = createBotCrowd(world, {
-      maxAgentRadius: options.maxAgentRadius ?? 0.6,
+      maxAgentRadius: this.maxAgentRadius,
     });
     this.behaviorKind = options.initialBehavior ?? DEFAULT_BEHAVIOR;
     this.maxSpeed = options.maxSpeed ?? DEFAULT_MAX_SPEED;
     this.tickHz = options.tickHz ?? DEFAULT_TICK_HZ;
+    this.useVehicles = options.useVehicles ?? false;
+    this.vehicleProfile = options.vehicleProfile ?? DEFAULT_VEHICLE_PROFILE;
   }
 
   /**
@@ -238,6 +335,16 @@ export class PracticeBotRuntime {
       this.crowd.removeObstacleAgent(agentId);
     }
     this.vehicleObstacleAgents.clear();
+    // Snap every bot back to on-foot mode and drop reservations — the
+    // WASM session is disappearing, so sending exit packets would be
+    // routed into a void. We just release local state.
+    for (const bot of this.bots.values()) {
+      this.releaseBotVehicleResources(bot);
+      bot.vehicleStage = 'on_foot';
+      bot.pendingDestination = null;
+      bot.fsmTicks = 0;
+    }
+    this.reservedVehicles.clear();
     this.transport = null;
     this.client = null;
     this.getSelf = null;
@@ -255,7 +362,35 @@ export class PracticeBotRuntime {
       maxSpeed: this.maxSpeed,
       navTriangles: this.crowd.nav.geometry.triangleCount,
       running: this.running,
+      useVehicles: this.useVehicles,
+      vehicleNavTriangles: this.vehicleCrowd?.nav.geometry.triangleCount ?? 0,
     };
+  }
+
+  /**
+   * Enable or disable the walk-vs-drive planner. On first enable, builds
+   * the second (vehicle-sized) navmesh + crowd lazily; on disable, cleanly
+   * resets every bot back to `on_foot` and drops all vehicle reservations.
+   */
+  setUseVehicles(value: boolean): void {
+    if (value === this.useVehicles) return;
+    this.useVehicles = value;
+    if (value) {
+      this.ensureVehicleCrowd();
+    } else {
+      // Unwind every bot's FSM to a clean on-foot state.
+      for (const bot of this.bots.values()) {
+        this.resetBotToFoot(bot, /* sendExitPacket */ true);
+      }
+      this.reservedVehicles.clear();
+    }
+  }
+
+  private ensureVehicleCrowd(): BotCrowd {
+    if (this.vehicleCrowd) return this.vehicleCrowd;
+    this.vehicleCrowd = createVehicleBotCrowd(this.world, this.vehicleProfile);
+    this.vehicleQueryFilter = createVehicleQueryFilter(this.vehicleProfile);
+    return this.vehicleCrowd;
   }
 
   setBehavior(kind: PracticeBotBehaviorKind): void {
@@ -317,6 +452,11 @@ export class PracticeBotRuntime {
       behaviorKind: this.behaviorKind,
       seq: 0,
       lastIntent: makeIdleIntent(),
+      vehicleStage: 'on_foot',
+      reservedVehicleId: null,
+      vehicleHandle: null,
+      pendingDestination: null,
+      fsmTicks: 0,
     });
     if (this.transport) {
       this.transport.connectBot(id);
@@ -331,6 +471,7 @@ export class PracticeBotRuntime {
   removeBot(id: number): boolean {
     const bot = this.bots.get(id);
     if (!bot) return false;
+    this.releaseBotVehicleResources(bot);
     this.crowd.removeBot(bot.handle);
     this.bots.delete(id);
     this.transport?.disconnectBot(id);
@@ -340,14 +481,46 @@ export class PracticeBotRuntime {
   /** Remove every bot. */
   clear(): void {
     for (const bot of this.bots.values()) {
+      this.releaseBotVehicleResources(bot);
       this.crowd.removeBot(bot.handle);
       this.transport?.disconnectBot(bot.id);
     }
     this.bots.clear();
+    this.reservedVehicles.clear();
     for (const agentId of this.vehicleObstacleAgents.values()) {
       this.crowd.removeObstacleAgent(agentId);
     }
     this.vehicleObstacleAgents.clear();
+  }
+
+  /** Drop a bot's vehicle-crowd handle and release its reservation, if any. */
+  private releaseBotVehicleResources(bot: PracticeBot): void {
+    if (bot.vehicleHandle && this.vehicleCrowd) {
+      this.vehicleCrowd.removeBot(bot.vehicleHandle);
+      bot.vehicleHandle = null;
+    }
+    if (bot.reservedVehicleId !== null) {
+      const current = this.reservedVehicles.get(bot.reservedVehicleId);
+      if (current === bot.id) {
+        this.reservedVehicles.delete(bot.reservedVehicleId);
+      }
+      bot.reservedVehicleId = null;
+    }
+  }
+
+  /**
+   * Forcibly reset a bot's FSM to `on_foot`. If the bot is currently
+   * seated, we optionally push an exit packet so the server releases its
+   * vehicle slot. Used on `setUseVehicles(false)` and on bot removal.
+   */
+  private resetBotToFoot(bot: PracticeBot, sendExitPacket: boolean): void {
+    if (sendExitPacket && bot.vehicleStage === 'driving' && bot.reservedVehicleId !== null && this.transport) {
+      this.transport.sendBotVehicleExit(bot.id, bot.reservedVehicleId);
+    }
+    this.releaseBotVehicleResources(bot);
+    bot.vehicleStage = 'on_foot';
+    bot.pendingDestination = null;
+    bot.fsmTicks = 0;
   }
 
   /**
@@ -376,10 +549,24 @@ export class PracticeBotRuntime {
    * Mirror `client.vehicles` into the crowd as stationary pseudo-agents so
    * bots see them as obstacles. Call this at the top of every `tick()`
    * just before `crowd.step`.
+   *
+   * A vehicle currently being driven by one of **our** bots is skipped —
+   * otherwise the bot's own chassis would register as an obstacle in the
+   * foot crowd and distort the walk-vs-drive cost comparison for peer
+   * bots. Vehicles driven by **other** bots (and the human) still appear
+   * as obstacles so bots route around them on foot.
    */
   private syncVehicleObstacles(client: NetcodeClient): void {
     const seen = new Set<number>();
+    // Build the "self-driven" set once per tick — cheap for <=32 bots.
+    const selfDriven = new Set<number>();
+    for (const bot of this.bots.values()) {
+      if (bot.vehicleStage === 'driving' && bot.reservedVehicleId !== null) {
+        selfDriven.add(bot.reservedVehicleId);
+      }
+    }
     for (const [vehicleId, state] of client.vehicles) {
+      if (selfDriven.has(vehicleId)) continue;
       seen.add(vehicleId);
       const position: Vec3Tuple = [
         state.position[0],
@@ -403,7 +590,8 @@ export class PracticeBotRuntime {
       this.crowd.setObstacleAgentPose(agentId, position, velocity);
     }
     // Drop pseudo-agents for vehicles that have since disappeared
-    // (despawned or the session swapped worlds).
+    // (despawned or the session swapped worlds) **or** that we just
+    // claimed as a self-driven car this frame.
     for (const [vehicleId, agentId] of this.vehicleObstacleAgents) {
       if (!seen.has(vehicleId)) {
         this.crowd.removeObstacleAgent(agentId);
@@ -478,6 +666,8 @@ export class PracticeBotRuntime {
         targetPlayerId: bot.lastIntent.targetPlayerId,
         maxSpeed: this.maxSpeed,
         firePrimary: bot.lastIntent.firePrimary,
+        vehicleStage: bot.vehicleStage,
+        reservedVehicleId: bot.reservedVehicleId,
       });
     }
     return out;
@@ -512,11 +702,28 @@ export class PracticeBotRuntime {
 
     // Sync every bot's authoritative position from the latest snapshot
     // *before* stepping the crowd, so navmesh planning uses real physics
-    // positions rather than the crowd's internal dead-reckoning.
+    // positions rather than the crowd's internal dead-reckoning. For
+    // bots currently driving, sync their vehicle-crowd agent to the
+    // vehicle's chassis position instead.
     for (const bot of this.bots.values()) {
       const remote = client.remotePlayers.get(bot.id);
       if (remote) {
         this.crowd.syncBotPosition(bot.handle, remote.position);
+      }
+      if (
+        bot.vehicleStage === 'driving'
+        && bot.vehicleHandle
+        && bot.reservedVehicleId !== null
+        && this.vehicleCrowd
+      ) {
+        const veh = client.vehicles.get(bot.reservedVehicleId);
+        if (veh) {
+          this.vehicleCrowd.syncBotPosition(bot.vehicleHandle, [
+            veh.position[0],
+            veh.position[1],
+            veh.position[2],
+          ]);
+        }
       }
     }
 
@@ -528,6 +735,9 @@ export class PracticeBotRuntime {
     this.syncVehicleObstacles(client);
 
     this.crowd.step(dt);
+    if (this.vehicleCrowd) {
+      this.vehicleCrowd.step(dt);
+    }
 
     const selfTemplate: BotSelfState = {
       position: [0, 0, 0],
@@ -562,17 +772,353 @@ export class PracticeBotRuntime {
       selfTemplate.onGround = true;
       selfTemplate.dead = remote.hp <= 0;
 
-      bot.lastIntent = bot.brain.think(selfTemplate, observed);
+      // Foot brain always runs — it tells us the "natural" destination
+      // the behavior wants right now. The vehicle FSM may override the
+      // final intent (e.g. while driving we emit vehicle-steering bits
+      // instead of the walking buttons the brain computed).
+      const footIntent = bot.brain.think(selfTemplate, observed);
+      bot.pendingDestination = bot.handle.targetPosition
+        ? [
+            bot.handle.targetPosition[0],
+            bot.handle.targetPosition[1],
+            bot.handle.targetPosition[2],
+          ]
+        : null;
+
+      let intent = footIntent;
+      if (this.useVehicles) {
+        intent = this.tickVehicleFsm(bot, remote, footIntent) ?? footIntent;
+      }
+      bot.lastIntent = intent;
       bot.seq = (bot.seq + 1) & 0xffff;
       const cmd = buildInputFromButtons(
         bot.seq,
         0,
-        bot.lastIntent.buttons,
-        bot.lastIntent.yaw,
-        bot.lastIntent.pitch,
+        intent.buttons,
+        intent.yaw,
+        intent.pitch,
       );
       this.transport.sendBotInputs(bot.id, [cmd]);
+      // Side-channel: if the FSM asked us to send a vehicle enter/exit
+      // packet this tick, route it through the bot-specific transport
+      // shim. These are **in addition to** the input bundle above —
+      // handle_bot_packet dispatches on packet type, not a single stream.
+      if (intent.vehicleAction === 'enter' && intent.vehicleId != null) {
+        this.transport.sendBotVehicleEnter(bot.id, intent.vehicleId);
+      } else if (intent.vehicleAction === 'exit' && intent.vehicleId != null) {
+        this.transport.sendBotVehicleExit(bot.id, intent.vehicleId);
+      }
     }
+  }
+
+  /**
+   * Drives the per-bot vehicle FSM for one tick. Returns a new intent
+   * that should replace the walking intent produced by the brain, or
+   * `null` to fall through to the brain's default.
+   *
+   * The FSM is stateful per bot but stateless across bots — each invocation
+   * reads the bot's `vehicleStage`, does at most one transition, and
+   * emits whatever intent the new stage produces.
+   */
+  private tickVehicleFsm(
+    bot: PracticeBot,
+    remote: { position: [number, number, number]; flags: number; yaw: number; pitch: number },
+    footIntent: BotIntent,
+  ): BotIntent | null {
+    const transport = this.transport;
+    const client = this.client;
+    if (!transport || !client) return null;
+    bot.fsmTicks += 1;
+
+    const botPosition: Vec3Tuple = [remote.position[0], remote.position[1], remote.position[2]];
+    const isInVehicle = (remote.flags & FLAG_IN_VEHICLE) !== 0;
+
+    switch (bot.vehicleStage) {
+      case 'on_foot': {
+        // Decide: should we switch to the vehicle route?
+        const destination = bot.pendingDestination;
+        if (!destination) return null;
+        const planarDist = Math.hypot(
+          destination[0] - botPosition[0],
+          destination[2] - botPosition[2],
+        );
+        // Short trips: don't bother. The walk-vs-drive overhead is too
+        // high, and bots clustering near a waypoint shouldn't scramble
+        // for cars.
+        if (planarDist < 15) return null;
+        const plan = this.planVehicleRoute(bot, botPosition, destination);
+        if (!plan) return null;
+        // Reserve the chosen vehicle and transition to walking_to_vehicle.
+        if (!this.tryReserveVehicle(plan.vehicleId, bot.id)) return null;
+        bot.reservedVehicleId = plan.vehicleId;
+        bot.vehicleStage = 'walking_to_vehicle';
+        bot.fsmTicks = 0;
+        // Override the brain's destination with the vehicle position so
+        // the foot agent path-plans toward it on this tick.
+        this.crowd.requestMoveTo(bot.handle, plan.vehiclePosition);
+        return null;
+      }
+
+      case 'walking_to_vehicle': {
+        const vehicleId = bot.reservedVehicleId;
+        if (vehicleId === null) {
+          bot.vehicleStage = 'on_foot';
+          return null;
+        }
+        const veh = client.vehicles.get(vehicleId);
+        if (!veh) {
+          // Vehicle vanished — abandon and go back to walking.
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        // Another driver beat us to it (human or a bot we don't track).
+        if (veh.driverId !== 0 && veh.driverId !== bot.id) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        // Keep steering toward the vehicle — the brain's normal moveTo
+        // call doesn't know the vehicle is our real goal, so we retarget
+        // the foot agent manually every tick.
+        const vehiclePos: Vec3Tuple = [veh.position[0], veh.position[1], veh.position[2]];
+        this.crowd.requestMoveTo(bot.handle, vehiclePos);
+        const distance = Math.hypot(
+          vehiclePos[0] - botPosition[0],
+          vehiclePos[2] - botPosition[2],
+        );
+        if (distance <= this.vehicleProfile.enterDistance) {
+          bot.vehicleStage = 'entering_vehicle';
+          bot.fsmTicks = 0;
+          // Emit the enter packet via the side-channel on the intent.
+          return {
+            ...footIntent,
+            buttons: 0, // stop moving — animation takes over
+            mode: 'entering_vehicle',
+            vehicleAction: 'enter',
+            vehicleId,
+          };
+        }
+        // Timeout guard: we've been walking toward this vehicle for too
+        // long (60s at 60 Hz). Give up.
+        if (bot.fsmTicks > 60 * 60) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        return { ...footIntent, mode: 'walking_to_vehicle' };
+      }
+
+      case 'entering_vehicle': {
+        const vehicleId = bot.reservedVehicleId;
+        if (vehicleId === null) {
+          bot.vehicleStage = 'on_foot';
+          return null;
+        }
+        if (isInVehicle) {
+          // Server confirmed the seat. Transition to driving.
+          const crowd = this.ensureVehicleCrowd();
+          const veh = client.vehicles.get(vehicleId);
+          const spawn: Vec3Tuple = veh
+            ? [veh.position[0], veh.position[1], veh.position[2]]
+            : botPosition;
+          // Spawn a vehicle-crowd agent for this bot and hand it the
+          // vehicle filter (turn-aware cost).
+          bot.vehicleHandle = crowd.addBot(spawn, {
+            radius: this.vehicleProfile.agentRadius,
+            height: this.vehicleProfile.agentHeight,
+            maxSpeed: this.vehicleProfile.cruiseSpeed,
+            queryFilter: this.vehicleQueryFilter ?? DEFAULT_QUERY_FILTER,
+          });
+          bot.vehicleStage = 'driving';
+          bot.fsmTicks = 0;
+          // Kick off the drive toward the pending destination.
+          if (bot.pendingDestination) {
+            crowd.requestMoveTo(bot.vehicleHandle, bot.pendingDestination);
+          }
+          return {
+            ...footIntent,
+            buttons: 0,
+            mode: 'driving',
+          };
+        }
+        // Wait a few ticks for the server to ack. If it never comes, bail.
+        if (bot.fsmTicks > 120) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        return { ...footIntent, buttons: 0, mode: 'entering_vehicle' };
+      }
+
+      case 'driving': {
+        const vehicleId = bot.reservedVehicleId;
+        if (vehicleId === null || !bot.vehicleHandle || !this.vehicleCrowd) {
+          this.resetBotToFoot(bot, /* sendExitPacket */ true);
+          return null;
+        }
+        const veh = client.vehicles.get(vehicleId);
+        if (!veh || veh.driverId !== bot.id) {
+          // We were bumped out or the vehicle despawned.
+          this.resetBotToFoot(bot, /* sendExitPacket */ false);
+          return null;
+        }
+        // Re-ask for the destination every tick — cheap, and the foot
+        // brain may have picked a moving target (e.g. harass).
+        if (bot.pendingDestination) {
+          this.vehicleCrowd.requestMoveTo(bot.vehicleHandle, bot.pendingDestination);
+        }
+        const vehicleAgent = this.vehicleCrowd.getAgent(bot.vehicleHandle.id);
+        const chassisQuat: [number, number, number, number] = [
+          veh.quaternion[0],
+          veh.quaternion[1],
+          veh.quaternion[2],
+          veh.quaternion[3],
+        ];
+        const desired: Vec3Tuple = vehicleAgent
+          ? [
+              vehicleAgent.desiredVelocity[0],
+              vehicleAgent.desiredVelocity[1],
+              vehicleAgent.desiredVelocity[2],
+            ]
+          : [0, 0, 0];
+        // Check for "arrived": within 2× enterDistance of the target.
+        const destination = bot.pendingDestination;
+        const arrived = destination
+          ? Math.hypot(
+              destination[0] - veh.position[0],
+              destination[2] - veh.position[2],
+            ) < Math.max(4, this.vehicleProfile.enterDistance * 2)
+          : false;
+        if (arrived) {
+          bot.vehicleStage = 'exiting_vehicle';
+          bot.fsmTicks = 0;
+          return {
+            ...footIntent,
+            buttons: 0,
+            mode: 'exiting_vehicle',
+            vehicleAction: 'exit',
+            vehicleId,
+          };
+        }
+        // Timeout guard: if we've been trying to drive for 90 s and
+        // haven't arrived, bail out — probably stuck.
+        if (bot.fsmTicks > 60 * 90) {
+          bot.vehicleStage = 'exiting_vehicle';
+          bot.fsmTicks = 0;
+          return {
+            ...footIntent,
+            buttons: 0,
+            mode: 'exiting_vehicle',
+            vehicleAction: 'exit',
+            vehicleId,
+          };
+        }
+        return vehicleAgentStateToIntent(desired, chassisQuat, {
+          yaw: footIntent.yaw,
+          pitch: footIntent.pitch,
+          mode: 'driving',
+          targetPlayerId: footIntent.targetPlayerId,
+          vehicleId,
+          firePrimary: false,
+          vehicleAction: null,
+        });
+      }
+
+      case 'exiting_vehicle': {
+        if (!isInVehicle) {
+          // Server confirmed the dismount. Clean up vehicle state.
+          this.releaseBotVehicleResources(bot);
+          bot.vehicleStage = 'on_foot';
+          bot.fsmTicks = 0;
+          return null;
+        }
+        if (bot.fsmTicks > 120) {
+          // Stuck mid-dismount? Force-reset local state. The server will
+          // eventually catch up via its own ack loop.
+          this.releaseBotVehicleResources(bot);
+          bot.vehicleStage = 'on_foot';
+          bot.fsmTicks = 0;
+          return null;
+        }
+        return { ...footIntent, buttons: 0, mode: 'exiting_vehicle' };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Picks the best vehicle for a walk-vs-drive comparison. Returns
+   * `null` if walking is preferred (or no vehicle is tractable). Scans
+   * every unreserved, undriven vehicle in `client.vehicles` and keeps
+   * the one with the lowest estimated total travel time.
+   */
+  private planVehicleRoute(
+    bot: PracticeBot,
+    botPosition: Vec3Tuple,
+    destination: Vec3Tuple,
+  ): { vehicleId: number; vehiclePosition: Vec3Tuple } | null {
+    const client = this.client;
+    if (!client) return null;
+    // Walk baseline: foot path length / walkable speed. If the foot
+    // path itself fails (destination unreachable on foot), we can't
+    // compare at all.
+    const walkLength = this.crowd.estimatePathLength(
+      botPosition,
+      destination,
+      DEFAULT_QUERY_FILTER,
+    );
+    if (walkLength === null) return null;
+    const walkSpeed = Math.max(1, this.maxSpeed);
+    const walkTimeSec = walkLength / walkSpeed;
+
+    const vehicleCrowd = this.ensureVehicleCrowd();
+    const vehicleFilter = this.vehicleQueryFilter ?? DEFAULT_QUERY_FILTER;
+    const profile = this.vehicleProfile;
+
+    let best: { vehicleId: number; vehiclePosition: Vec3Tuple; travelTime: number } | null = null;
+    for (const [vehicleId, state] of client.vehicles) {
+      // Skip vehicles already claimed by another bot or driven by anyone.
+      if (this.reservedVehicles.has(vehicleId)) continue;
+      if (state.driverId !== 0) continue;
+      const vehiclePosition: Vec3Tuple = [
+        state.position[0],
+        state.position[1],
+        state.position[2],
+      ];
+      // Leg 1: walk to the vehicle.
+      const walkToLength = this.crowd.estimatePathLength(
+        botPosition,
+        vehiclePosition,
+        DEFAULT_QUERY_FILTER,
+      );
+      if (walkToLength === null) continue;
+      // Leg 2: drive from vehicle to destination on the vehicle navmesh.
+      const driveLength = vehicleCrowd.estimatePathLength(
+        vehiclePosition,
+        destination,
+        vehicleFilter,
+      );
+      if (driveLength === null) continue;
+      const driveTime = walkToLength / walkSpeed
+        + driveLength / profile.cruiseSpeed
+        + profile.enterExitOverheadSec;
+      if (!best || driveTime < best.travelTime) {
+        best = { vehicleId, vehiclePosition, travelTime: driveTime };
+      }
+    }
+    if (!best) return null;
+    // Hysteresis — only switch to driving if it's **significantly** faster.
+    // Otherwise the bot would thrash at the walk/drive boundary.
+    if (best.travelTime > walkTimeSec * 0.75) return null;
+    return { vehicleId: best.vehicleId, vehiclePosition: best.vehiclePosition };
+  }
+
+  /**
+   * Atomic reservation: only inserts if no other bot holds the slot.
+   * Returns true on success.
+   */
+  private tryReserveVehicle(vehicleId: number, botId: number): boolean {
+    const current = this.reservedVehicles.get(vehicleId);
+    if (current !== undefined && current !== botId) return false;
+    this.reservedVehicles.set(vehicleId, botId);
+    return true;
   }
 }
 
@@ -584,6 +1130,8 @@ function makeIdleIntent(): BotIntent {
     firePrimary: false,
     mode: 'hold_anchor',
     targetPlayerId: null,
+    vehicleAction: null,
+    vehicleId: null,
   };
 }
 

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -27,6 +27,7 @@ import type { LocalPreviewTransport } from '../../net/localPreviewTransport';
 import type { WorldDocument } from '../../world/worldDocument';
 import { buildInputFromButtons } from '../../scene/inputBuilder';
 import { FLAG_DEAD } from '../../net/protocol';
+import { pathCorridor } from 'navcat/blocks';
 
 /**
  * Accessor for the local (human) player's authoritative state. The
@@ -50,6 +51,7 @@ import {
 import { BotCrowd, createBotCrowd, type BotHandle } from '../crowd/BotCrowd';
 import type {
   BotIntent,
+  BotMode,
   BotSelfState,
   ObservedPlayer,
   Vec3Tuple,
@@ -82,6 +84,35 @@ export interface PracticeBotStats {
   navTriangles: number;
   /** True while the runtime is actively ticking (session connected). */
   running: boolean;
+}
+
+/**
+ * Snapshot of one bot's planning state, surfaced for the in-scene debug
+ * overlay. Pure data — no THREE / R3F dependencies so the renderer can
+ * decide how to visualize each piece.
+ */
+export interface BotDebugInfo {
+  id: number;
+  /** World-space position (server-authoritative if attached). */
+  position: Vec3Tuple;
+  /** The destination this bot is currently routing toward, if any. */
+  target: Vec3Tuple | null;
+  /** Funnel-algorithm steering corners from `position` to `target`. */
+  pathPoints: Vec3Tuple[];
+  /** Crowd's planned velocity for this tick. */
+  desiredVelocity: Vec3Tuple;
+  /** KCC-driven actual velocity from the last sync. */
+  velocity: Vec3Tuple;
+  /** Behavior label from the practice UI dropdown. */
+  behaviorKind: PracticeBotBehaviorKind;
+  /** Decision mode emitted by the brain on the last tick. */
+  mode: BotMode;
+  /** Currently targeted remote player, if any. */
+  targetPlayerId: number | null;
+  /** Configured max speed override (m/s). */
+  maxSpeed: number;
+  /** Whether the brain wanted to fire on the last tick. */
+  firePrimary: boolean;
 }
 
 interface PracticeBot {
@@ -277,6 +308,77 @@ export class PracticeBotRuntime {
       this.transport?.disconnectBot(bot.id);
     }
     this.bots.clear();
+  }
+
+  /**
+   * Per-bot diagnostics for the in-scene debug overlay. Reads navcat's
+   * crowd state (corridor, target, desired velocity) and combines it with
+   * the latest brain decision label so callers can render "what is this
+   * bot thinking" in the world.
+   *
+   * Returns an empty array if the runtime is unattached or has no bots.
+   * Cheap enough to call every render frame.
+   */
+  getBotDebugInfos(): BotDebugInfo[] {
+    if (this.bots.size === 0) return [];
+    const out: BotDebugInfo[] = [];
+    for (const bot of this.bots.values()) {
+      const agent = this.crowd.getAgent(bot.handle.id);
+      if (!agent) continue;
+      // Prefer the snapshot-driven server position if the runtime is
+      // attached (more accurate than the crowd's internal sim, since
+      // the crowd is just a planner here). Fall back to agent.position.
+      const remote = this.client?.remotePlayers.get(bot.id);
+      const position: Vec3Tuple = remote
+        ? [remote.position[0], remote.position[1], remote.position[2]]
+        : [agent.position[0], agent.position[1], agent.position[2]];
+
+      // Steering corners: navcat's path-corridor exposes a string-pulled
+      // straight path (the funnel-algorithm corners the agent is aiming
+      // at). Each corner is a world-space point along the bot's planned
+      // route to its target.
+      const corners = pathCorridor.findCorners(
+        agent.corridor,
+        this.crowd.navMesh,
+        8,
+      );
+      const pathPoints: Vec3Tuple[] = [];
+      pathPoints.push([position[0], position[1], position[2]]);
+      if (corners) {
+        for (const corner of corners) {
+          pathPoints.push([
+            corner.position[0],
+            corner.position[1],
+            corner.position[2],
+          ]);
+        }
+      }
+
+      out.push({
+        id: bot.id,
+        position,
+        target: bot.handle.targetPosition
+          ? [
+              bot.handle.targetPosition[0],
+              bot.handle.targetPosition[1],
+              bot.handle.targetPosition[2],
+            ]
+          : null,
+        pathPoints,
+        desiredVelocity: [
+          agent.desiredVelocity[0],
+          agent.desiredVelocity[1],
+          agent.desiredVelocity[2],
+        ],
+        velocity: [agent.velocity[0], agent.velocity[1], agent.velocity[2]],
+        behaviorKind: bot.behaviorKind,
+        mode: bot.lastIntent.mode,
+        targetPlayerId: bot.lastIntent.targetPlayerId,
+        maxSpeed: this.maxSpeed,
+        firePrimary: bot.lastIntent.firePrimary,
+      });
+    }
+    return out;
   }
 
   /** Internal tick — runs every `1 / tickHz` seconds when attached. */

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -87,6 +87,22 @@ export interface PracticeBotStats {
 }
 
 /**
+ * Snapshot of an obstacle (currently: vehicle) that the bot crowd
+ * treats as a navmesh-level avoider. Returned from
+ * {@link PracticeBotRuntime.getObstacleDebugInfos} so the debug overlay
+ * can draw footprints at the positions the bots are actually steering
+ * around.
+ */
+export interface BotObstacleDebugInfo {
+  kind: 'vehicle';
+  /** Source id — vehicle id in `client.vehicles`. */
+  sourceId: number;
+  position: Vec3Tuple;
+  radius: number;
+  height: number;
+}
+
+/**
  * Snapshot of one bot's planning state, surfaced for the in-scene debug
  * overlay. Pure data — no THREE / R3F dependencies so the renderer can
  * decide how to visualize each piece.
@@ -131,6 +147,13 @@ const DEFAULT_BEHAVIOR: PracticeBotBehaviorKind = 'harass';
 // `shared/src/simulation.rs::update_player_motion`.
 const DEFAULT_MAX_SPEED = 3.0;
 const DEFAULT_TICK_HZ = 60;
+// Vehicle chassis half-extents from `shared/src/movement.rs`
+// (`VEHICLE_CHASSIS_HALF_EXTENTS`). The circumscribed XZ radius is the
+// diagonal, which is what we use when registering the vehicle as a
+// navcat pseudo-agent. Slight padding (+0.2m) gives the bot a small
+// berth so it doesn't scrape the bodywork.
+const VEHICLE_OBSTACLE_RADIUS = Math.hypot(0.9, 1.8) + 0.2;
+const VEHICLE_OBSTACLE_HEIGHT = 1.2;
 
 /**
  * Runtime for practice-mode bots that spawns them as full players in the
@@ -149,6 +172,13 @@ export class PracticeBotRuntime {
   private tickHandle: ReturnType<typeof setInterval> | null = null;
   private lastTickMs = 0;
   private running = false;
+  /**
+   * Map of vehicleId → navcat agentId for stationary "pseudo-agents"
+   * that represent live vehicles to the crowd planner. Each tick we
+   * mirror `client.vehicles` into this map so bots steer around vehicles
+   * without them being baked into the static navmesh.
+   */
+  private readonly vehicleObstacleAgents = new Map<number, string>();
 
   constructor(world: WorldDocument, options: PracticeBotRuntimeOptions = {}) {
     this.crowd = createBotCrowd(world, {
@@ -202,6 +232,12 @@ export class PracticeBotRuntime {
         this.transport.disconnectBot(bot.id);
       }
     }
+    // Drop vehicle pseudo-agents — they're tied to the session whose
+    // `client.vehicles` map just went away.
+    for (const agentId of this.vehicleObstacleAgents.values()) {
+      this.crowd.removeObstacleAgent(agentId);
+    }
+    this.vehicleObstacleAgents.clear();
     this.transport = null;
     this.client = null;
     this.getSelf = null;
@@ -308,6 +344,72 @@ export class PracticeBotRuntime {
       this.transport?.disconnectBot(bot.id);
     }
     this.bots.clear();
+    for (const agentId of this.vehicleObstacleAgents.values()) {
+      this.crowd.removeObstacleAgent(agentId);
+    }
+    this.vehicleObstacleAgents.clear();
+  }
+
+  /**
+   * Returns one {@link BotObstacleDebugInfo} per live vehicle pseudo-
+   * agent, for the in-scene debug overlay. Cheap enough to call every
+   * render frame.
+   */
+  getObstacleDebugInfos(): BotObstacleDebugInfo[] {
+    if (!this.client) return [];
+    const out: BotObstacleDebugInfo[] = [];
+    for (const [vehicleId, agentId] of this.vehicleObstacleAgents) {
+      const agent = this.crowd.getAgent(agentId);
+      if (!agent) continue;
+      out.push({
+        kind: 'vehicle',
+        sourceId: vehicleId,
+        position: [agent.position[0], agent.position[1], agent.position[2]],
+        radius: agent.radius,
+        height: agent.height,
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Mirror `client.vehicles` into the crowd as stationary pseudo-agents so
+   * bots see them as obstacles. Call this at the top of every `tick()`
+   * just before `crowd.step`.
+   */
+  private syncVehicleObstacles(client: NetcodeClient): void {
+    const seen = new Set<number>();
+    for (const [vehicleId, state] of client.vehicles) {
+      seen.add(vehicleId);
+      const position: Vec3Tuple = [
+        state.position[0],
+        state.position[1],
+        state.position[2],
+      ];
+      const velocity: Vec3Tuple = [
+        state.linearVelocity[0],
+        state.linearVelocity[1],
+        state.linearVelocity[2],
+      ];
+      let agentId = this.vehicleObstacleAgents.get(vehicleId);
+      if (!agentId) {
+        agentId = this.crowd.addObstacleAgent(
+          position,
+          VEHICLE_OBSTACLE_RADIUS,
+          VEHICLE_OBSTACLE_HEIGHT,
+        );
+        this.vehicleObstacleAgents.set(vehicleId, agentId);
+      }
+      this.crowd.setObstacleAgentPose(agentId, position, velocity);
+    }
+    // Drop pseudo-agents for vehicles that have since disappeared
+    // (despawned or the session swapped worlds).
+    for (const [vehicleId, agentId] of this.vehicleObstacleAgents) {
+      if (!seen.has(vehicleId)) {
+        this.crowd.removeObstacleAgent(agentId);
+        this.vehicleObstacleAgents.delete(vehicleId);
+      }
+    }
   }
 
   /**
@@ -417,6 +519,13 @@ export class PracticeBotRuntime {
         this.crowd.syncBotPosition(bot.handle, remote.position);
       }
     }
+
+    // Mirror live vehicles into the navcat crowd as stationary pseudo-
+    // agents so real bots' separation / obstacle-avoidance routes around
+    // them. Vehicles are dynamic (they move at runtime) and therefore
+    // aren't baked into the static navmesh; without this step bots would
+    // path straight through parked cars.
+    this.syncVehicleObstacles(client);
 
     this.crowd.step(dt);
 

--- a/client/src/bots/practice/wasmIntegration.test.ts
+++ b/client/src/bots/practice/wasmIntegration.test.ts
@@ -89,6 +89,56 @@ describe('WASM bot integration', () => {
 
     transport.close();
   }, 10_000);
+
+  it('setBotMaxSpeed caps the bot velocity at the requested value', async () => {
+    const captured: ServerPacket[] = [];
+    const transport = await LocalPreviewTransport.connect({
+      onPacket: (packet) => captured.push(packet),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const BOT_ID = 1_000_202;
+    expect(transport.connectBot(BOT_ID)).toBe(true);
+    // Cap this bot at 2 m/s — well below the KCC's walk_speed of 6 m/s.
+    expect(transport.setBotMaxSpeed(BOT_ID, 2.0)).toBe(true);
+
+    // Hold BTN_FORWARD for ~1.2 simulated seconds (72 ticks at 60 Hz).
+    for (let i = 1; i <= 72; i += 1) {
+      transport.sendBotInputs(BOT_ID, [
+        buildInputFromButtons(i, 0, BTN_FORWARD, 0, 0),
+      ]);
+      if (i % 6 === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const botSnapshots = captured
+      .filter((p): p is ServerPacket & { type: 'snapshot' } => p.type === 'snapshot')
+      .filter((snap) => snap.playerStates.some((p) => p.id === BOT_ID));
+    expect(botSnapshots.length).toBeGreaterThan(2);
+
+    // Pick two snapshots ~0.5s apart and compute the observed velocity
+    // magnitude from the position delta. It should track the 2.0 m/s cap,
+    // NOT the 6.0 m/s walk speed and NOT the 8.5 m/s sprint speed.
+    const first = botSnapshots[0];
+    const last = botSnapshots[botSnapshots.length - 1];
+    const firstState = first.playerStates.find((p) => p.id === BOT_ID)!;
+    const lastState = last.playerStates.find((p) => p.id === BOT_ID)!;
+    const dtS = (last.serverTimeUs - first.serverTimeUs) / 1_000_000;
+    expect(dtS).toBeGreaterThan(0.3);
+    const dxMm = lastState.pxMm - firstState.pxMm;
+    const dzMm = lastState.pzMm - firstState.pzMm;
+    const distanceM = Math.hypot(dxMm, dzMm) / 1000;
+    const observedSpeed = distanceM / dtS;
+
+    // Allow some slack for acceleration ramp-up + KCC friction.
+    expect(observedSpeed).toBeLessThan(3.0);
+    expect(observedSpeed).toBeGreaterThan(0.5);
+
+    transport.disconnectBot(BOT_ID);
+    transport.close();
+  }, 10_000);
 });
 
 // Keep decodeServerPacket referenced so tree-shaking doesn't drop the import

--- a/client/src/bots/practice/wasmIntegration.test.ts
+++ b/client/src/bots/practice/wasmIntegration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration test for the bot ↔ WASM local session pipeline. Exercises
+ * the full Rust `connect_bot` / `handle_bot_packet` path through the TS
+ * `LocalPreviewTransport` wrapper.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initWasmForTests } from '../../wasm/testInit';
+import { LocalPreviewTransport } from '../../net/localPreviewTransport';
+import { decodeServerPacket, type NetPlayerState, type ServerPacket } from '../../net/protocol';
+import { buildInputFromButtons } from '../../scene/inputBuilder';
+import { BTN_FORWARD } from '../../net/protocol';
+
+interface SnapshotSample {
+  players: NetPlayerState[];
+}
+
+function findPlayer(snapshot: SnapshotSample, id: number): NetPlayerState | null {
+  return snapshot.players.find((p) => p.id === id) ?? null;
+}
+
+describe('WASM bot integration', () => {
+  beforeAll(() => {
+    initWasmForTests();
+  });
+
+  it('connects a bot and routes forward inputs through the KCC', async () => {
+    const captured: ServerPacket[] = [];
+    const transport = await LocalPreviewTransport.connect({
+      onPacket: (packet) => captured.push(packet),
+    });
+
+    // Wait briefly for the initial welcome + a couple of ticks.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    // Spawn a bot inside the session.
+    const BOT_ID = 1_000_101;
+    const ok = transport.connectBot(BOT_ID);
+    expect(ok).toBe(true);
+    // Duplicate rejected.
+    expect(transport.connectBot(BOT_ID)).toBe(false);
+
+    // Give the session time to emit a snapshot containing the bot.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    // Find the most recent snapshot that contains our bot.
+    const snapshots = captured.filter((p): p is ServerPacket & { type: 'snapshot' } => p.type === 'snapshot');
+    expect(snapshots.length).toBeGreaterThan(0);
+    const withBot = snapshots.find((snap) => snap.playerStates.some((p) => p.id === BOT_ID));
+    expect(withBot, 'snapshot should include the bot as a player state').toBeTruthy();
+    const initial = findPlayer({ players: withBot!.playerStates }, BOT_ID);
+    expect(initial).not.toBeNull();
+    const startZ = initial!.pzMm;
+
+    // Push a forward-walking input for the bot.
+    const cmd = buildInputFromButtons(1, 0, BTN_FORWARD, 0, 0);
+    transport.sendBotInputs(BOT_ID, [cmd]);
+
+    // Keep sending the same held-forward input so the bot accumulates
+    // velocity through several ticks.
+    for (let i = 2; i < 60; i += 1) {
+      transport.sendBotInputs(BOT_ID, [
+        buildInputFromButtons(i, 0, BTN_FORWARD, 0, 0),
+      ]);
+      if (i % 6 === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const latestSnapshots = captured.filter((p): p is ServerPacket & { type: 'snapshot' } => p.type === 'snapshot');
+    const latestWithBot = latestSnapshots
+      .slice()
+      .reverse()
+      .find((snap) => snap.playerStates.some((p) => p.id === BOT_ID));
+    expect(latestWithBot).toBeTruthy();
+    const final = findPlayer({ players: latestWithBot!.playerStates }, BOT_ID);
+    expect(final).not.toBeNull();
+
+    const movedMm = Math.abs(final!.pzMm - startZ);
+    expect(movedMm, 'bot should have moved after a second of forward input').toBeGreaterThan(50);
+
+    // Disconnect and verify the bot disappears from the next snapshot.
+    expect(transport.disconnectBot(BOT_ID)).toBe(true);
+    captured.length = 0;
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    const postSnapshots = captured.filter((p): p is ServerPacket & { type: 'snapshot' } => p.type === 'snapshot');
+    const anyBot = postSnapshots.find((snap) => snap.playerStates.some((p) => p.id === BOT_ID));
+    expect(anyBot, 'bot should not appear in snapshots after disconnect').toBeFalsy();
+
+    transport.close();
+  }, 10_000);
+});
+
+// Keep decodeServerPacket referenced so tree-shaking doesn't drop the import
+// (it's used indirectly by LocalPreviewTransport).
+void decodeServerPacket;

--- a/client/src/bots/types.ts
+++ b/client/src/bots/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared types for the bot framework.
+ *
+ * These types are intentionally decoupled from the network/protocol layer so
+ * that the bot framework can be reused from Node load-test runners (no THREE,
+ * no React) and from the browser LoadTest page alike.
+ */
+
+export type Vec3Tuple = [number, number, number];
+
+/**
+ * Observed state of a remote player from the bot's perspective.
+ *
+ * Mirrors the shape `stepBotBrain` uses today in `loadtest/brain.ts`, so
+ * existing loadtest runners don't have to reshape their snapshot data to feed
+ * it into the framework.
+ */
+export interface ObservedPlayer {
+  id: number;
+  position: Vec3Tuple;
+  isDead: boolean;
+}
+
+/**
+ * Snapshot of the bot's own state at the top of a brain tick.
+ */
+export interface BotSelfState {
+  position: Vec3Tuple;
+  velocity: Vec3Tuple;
+  yaw: number;
+  pitch: number;
+  onGround: boolean;
+  dead: boolean;
+}
+
+/**
+ * The only output a bot produces: aim + held buttons + fire intent.
+ *
+ * All consumers (simulate.ts, wsWorker.ts, LoadTest.tsx) translate this to
+ * their transport-specific `InputFrame` via `buildInputFromButtons` — see
+ * `client/src/scene/inputBuilder.ts`.
+ */
+export interface BotIntent {
+  buttons: number;
+  yaw: number;
+  pitch: number;
+  firePrimary: boolean;
+  /** For debug/telemetry. Matches existing BotBrainMode values. */
+  mode: BotMode;
+  /** Currently targeted remote player, or null. */
+  targetPlayerId: number | null;
+}
+
+export type BotMode =
+  | 'acquire_target'
+  | 'follow_target'
+  | 'recover_center'
+  | 'hold_anchor'
+  | 'dead';

--- a/client/src/bots/types.ts
+++ b/client/src/bots/types.ts
@@ -49,6 +49,15 @@ export interface BotIntent {
   mode: BotMode;
   /** Currently targeted remote player, or null. */
   targetPlayerId: number | null;
+  /**
+   * Side-channel request to enter or exit a vehicle this tick. Consumed by
+   * `PracticeBotRuntime`, which translates it to a `PKT_VEHICLE_ENTER` /
+   * `PKT_VEHICLE_EXIT` through the local-preview transport. Null means
+   * "no vehicle action this tick" (the common case).
+   */
+  vehicleAction?: 'enter' | 'exit' | null;
+  /** Vehicle id the action targets (only meaningful when vehicleAction != null). */
+  vehicleId?: number | null;
 }
 
 export type BotMode =
@@ -56,4 +65,33 @@ export type BotMode =
   | 'follow_target'
   | 'recover_center'
   | 'hold_anchor'
-  | 'dead';
+  | 'dead'
+  | 'walking_to_vehicle'
+  | 'entering_vehicle'
+  | 'driving'
+  | 'exiting_vehicle';
+
+/**
+ * Static physical parameters for a driven vehicle, used by the bot planner
+ * to:
+ *  - size the vehicle navmesh / crowd agent,
+ *  - bias `getCost` against turns sharper than the chassis can execute,
+ *  - estimate travel time for the "walk vs drive" planner in the brain.
+ *
+ * Units are meters / seconds everywhere. Defaults for the stock practice
+ * vehicle live in `PracticeBotRuntime`.
+ */
+export interface VehicleProfile {
+  /** Minimum turning radius (m). Turns tighter than this are heavily penalized by the vehicle `QueryFilter.getCost`. */
+  turningRadius: number;
+  /** Agent radius used when adding a vehicle-bot agent to the vehicle crowd (m). */
+  agentRadius: number;
+  /** Agent height used when adding a vehicle-bot agent to the vehicle crowd (m). */
+  agentHeight: number;
+  /** Cruise speed used when estimating drive-leg travel time (m/s). */
+  cruiseSpeed: number;
+  /** Max walk distance (m) at which a bot will consider a vehicle "reachable". */
+  enterDistance: number;
+  /** Fixed seconds added to the drive-leg estimate to account for enter + exit animations. */
+  enterExitOverheadSec: number;
+}

--- a/client/src/bots/world/buildNavMesh.test.ts
+++ b/client/src/bots/world/buildNavMesh.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createFindNearestPolyResult,
+  DEFAULT_QUERY_FILTER,
+  findNearestPoly,
+  type Vec3,
+} from 'navcat';
+import { DEFAULT_WORLD_DOCUMENT } from '../../world/worldDocument';
+import { buildBotNavMesh } from './buildNavMesh';
+
+describe('buildBotNavMesh', () => {
+  it('builds a navmesh with at least one tile from the default world', () => {
+    const nav = buildBotNavMesh(DEFAULT_WORLD_DOCUMENT);
+    expect(nav.mode).toBe('tiled');
+    expect(Object.keys(nav.navMesh.tiles).length).toBeGreaterThan(0);
+    expect(nav.geometry.triangleCount).toBeGreaterThan(0);
+  });
+
+  it('findNearestPoly succeeds at the world origin', () => {
+    const nav = buildBotNavMesh(DEFAULT_WORLD_DOCUMENT);
+    const result = findNearestPoly(
+      createFindNearestPolyResult(),
+      nav.navMesh,
+      [0, 5, 0] as Vec3,
+      [4, 10, 4] as Vec3,
+      DEFAULT_QUERY_FILTER,
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/client/src/bots/world/buildNavMesh.ts
+++ b/client/src/bots/world/buildNavMesh.ts
@@ -25,6 +25,7 @@ import {
 import type { NavMesh } from 'navcat';
 
 import type { WorldDocument } from '../../world/worldDocument';
+import type { VehicleProfile } from '../types';
 import { buildWorldGeometry, type BotWorldGeometry } from './worldGeometry';
 
 export type NavMeshMode = 'solo' | 'tiled';
@@ -168,4 +169,38 @@ export function buildBotNavMesh(world: WorldDocument, options: BuildBotNavMeshOp
   };
   const result = generateTiledNavMesh(navMeshInput, opts);
   return { navMesh: result.navMesh, geometry, mode, result };
+}
+
+/**
+ * Builds a second, vehicle-sized navmesh for the same world. The walkable
+ * radius is inflated to {@link VehicleProfile.agentRadius} so narrow alleys
+ * and doorways that a player can squeeze through on foot are automatically
+ * excluded — the vehicle simply can't path there.
+ *
+ * The climb height is dropped to match a car's max step-over (a wheeled
+ * chassis can't take 0.55 m curbs) and the slope angle is tightened too so
+ * drivable polygons only cover geometry a raycast-vehicle can physically
+ * traverse.
+ *
+ * Callers should not rebuild this mesh every tick — build once per world
+ * and reuse it across all vehicle-mode bots.
+ */
+export function buildVehicleBotNavMesh(
+  world: WorldDocument,
+  profile: VehicleProfile,
+  overrides: BuildBotNavMeshOptions = {},
+): BotNavMesh {
+  return buildBotNavMesh(world, {
+    // Vehicle chassis is fatter than a player capsule — use the profile
+    // radius so narrow alleys collapse out of the walkable set.
+    walkableRadius: profile.agentRadius,
+    walkableHeight: profile.agentHeight,
+    // A car can step over maybe ~15 cm; anything more is a cliff from the
+    // chassis's perspective.
+    walkableClimb: 0.15,
+    // Same constraint in rotational form — 25° is already quite steep
+    // for a wheeled vehicle.
+    walkableSlopeAngleDegrees: 25,
+    ...overrides,
+  });
 }

--- a/client/src/bots/world/buildNavMesh.ts
+++ b/client/src/bots/world/buildNavMesh.ts
@@ -1,0 +1,171 @@
+/**
+ * Wraps navcat's {@link generateSoloNavMesh} / {@link generateTiledNavMesh}
+ * with KCC-matched defaults so callers can go from a {@link WorldDocument} to
+ * a query-ready {@link NavMesh} in one line.
+ *
+ * The option defaults intentionally mirror the Rapier kinematic character
+ * controller parameters declared in `shared/src/movement.rs`:
+ * - capsule radius 0.35m
+ * - capsule height ~1.6m
+ * - step height 0.55m
+ * - walkable slope ~55°
+ *
+ * Keeping these in sync means the navmesh only exposes polygons the KCC can
+ * actually walk on.
+ */
+
+import {
+  generateSoloNavMesh,
+  generateTiledNavMesh,
+  type SoloNavMeshOptions,
+  type SoloNavMeshResult,
+  type TiledNavMeshOptions,
+  type TiledNavMeshResult,
+} from 'navcat/blocks';
+import type { NavMesh } from 'navcat';
+
+import type { WorldDocument } from '../../world/worldDocument';
+import { buildWorldGeometry, type BotWorldGeometry } from './worldGeometry';
+
+export type NavMeshMode = 'solo' | 'tiled';
+
+export interface BuildBotNavMeshOptions {
+  /** Defaults to `'tiled'` — large terrain worlds benefit from tiling. */
+  mode?: NavMeshMode;
+  /**
+   * Voxel cell size on the horizontal plane (meters).
+   * Smaller = more accurate geometry, larger = faster build.
+   */
+  cellSize?: number;
+  /** Voxel cell size vertically (meters). */
+  cellHeight?: number;
+  /** Agent collision radius (meters). */
+  walkableRadius?: number;
+  /** Agent height (meters). */
+  walkableHeight?: number;
+  /** Max step height the agent can climb (meters). */
+  walkableClimb?: number;
+  /** Max walkable slope angle (degrees). */
+  walkableSlopeAngleDegrees?: number;
+  /**
+   * Tile size in voxels (tiled mode only). Default of 64 ≈ 16m per tile at
+   * the default 0.25m cell size, which comfortably fits inside the 160m
+   * square world terrain tiles used by vibe-land worlds.
+   */
+  tileSizeVoxels?: number;
+}
+
+export interface BotNavMesh {
+  /** The underlying navcat mesh — pass this to crowd / path APIs. */
+  navMesh: NavMesh;
+  /** The triangle soup the mesh was built from. */
+  geometry: BotWorldGeometry;
+  /** Build mode that was actually used. */
+  mode: NavMeshMode;
+  /**
+   * Raw navcat build result (kept so callers that want to grab debug
+   * intermediates or rebuild tiles can get at them). Either a solo or tiled
+   * result — check `mode` to disambiguate.
+   */
+  result: SoloNavMeshResult | TiledNavMeshResult;
+}
+
+const DEFAULTS = Object.freeze({
+  mode: 'tiled' as NavMeshMode,
+  cellSize: 0.25,
+  cellHeight: 0.1,
+  walkableRadius: 0.4,
+  walkableHeight: 1.7,
+  walkableClimb: 0.55,
+  walkableSlopeAngleDegrees: 55,
+  tileSizeVoxels: 64,
+});
+
+/**
+ * Builds a navmesh for the given world document.
+ *
+ * @param world The world to build for. Typically this is the same document
+ *   the server loaded — see `shared/src/world_document.rs:9`
+ *   (`trail.world.json` is the default).
+ * @param options KCC-matched overrides. Defaults track
+ *   `shared/src/movement.rs`.
+ */
+export function buildBotNavMesh(world: WorldDocument, options: BuildBotNavMeshOptions = {}): BotNavMesh {
+  const mode: NavMeshMode = options.mode ?? DEFAULTS.mode;
+  const cellSize = options.cellSize ?? DEFAULTS.cellSize;
+  const cellHeight = options.cellHeight ?? DEFAULTS.cellHeight;
+  const walkableRadiusWorld = options.walkableRadius ?? DEFAULTS.walkableRadius;
+  const walkableHeightWorld = options.walkableHeight ?? DEFAULTS.walkableHeight;
+  const walkableClimbWorld = options.walkableClimb ?? DEFAULTS.walkableClimb;
+  const walkableSlopeAngleDegrees =
+    options.walkableSlopeAngleDegrees ?? DEFAULTS.walkableSlopeAngleDegrees;
+  const tileSizeVoxels = options.tileSizeVoxels ?? DEFAULTS.tileSizeVoxels;
+
+  const geometry = buildWorldGeometry(world);
+  const navMeshInput = {
+    positions: geometry.positions,
+    indices: geometry.indices,
+  };
+
+  const walkableRadiusVoxels = Math.max(1, Math.ceil(walkableRadiusWorld / cellSize));
+  const walkableClimbVoxels = Math.max(1, Math.ceil(walkableClimbWorld / cellHeight));
+  const walkableHeightVoxels = Math.max(1, Math.ceil(walkableHeightWorld / cellHeight));
+
+  const borderSize = walkableRadiusVoxels + 3;
+  const minRegionArea = 8;
+  const mergeRegionArea = 20;
+  const maxSimplificationError = 1.3;
+  const maxEdgeLength = 12;
+  const maxVerticesPerPoly = 5;
+  const detailSampleDistance = cellSize * 6;
+  const detailSampleMaxError = cellHeight * 1;
+
+  if (mode === 'solo') {
+    const opts: SoloNavMeshOptions = {
+      cellSize,
+      cellHeight,
+      walkableRadiusVoxels,
+      walkableRadiusWorld,
+      walkableClimbVoxels,
+      walkableClimbWorld,
+      walkableHeightVoxels,
+      walkableHeightWorld,
+      walkableSlopeAngleDegrees,
+      borderSize,
+      minRegionArea,
+      mergeRegionArea,
+      maxSimplificationError,
+      maxEdgeLength,
+      maxVerticesPerPoly,
+      detailSampleDistance,
+      detailSampleMaxError,
+    };
+    const result = generateSoloNavMesh(navMeshInput, opts);
+    return { navMesh: result.navMesh, geometry, mode, result };
+  }
+
+  const tileSizeWorld = tileSizeVoxels * cellSize;
+  const opts: TiledNavMeshOptions = {
+    cellSize,
+    cellHeight,
+    tileSizeVoxels,
+    tileSizeWorld,
+    walkableRadiusVoxels,
+    walkableRadiusWorld,
+    walkableClimbVoxels,
+    walkableClimbWorld,
+    walkableHeightVoxels,
+    walkableHeightWorld,
+    walkableSlopeAngleDegrees,
+    borderSize,
+    minRegionArea,
+    mergeRegionArea,
+    maxSimplificationError,
+    maxEdgeLength,
+    maxVerticesPerPoly,
+    detailSampleDistance,
+    detailSampleMaxError,
+  };
+  const result = generateTiledNavMesh(navMeshInput, opts);
+  return { navMesh: result.navMesh, geometry, mode, result };
+}

--- a/client/src/bots/world/worldGeometry.test.ts
+++ b/client/src/bots/world/worldGeometry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_WORLD_DOCUMENT } from '../../world/worldDocument';
+import { buildWorldGeometry } from './worldGeometry';
+
+describe('buildWorldGeometry', () => {
+  it('produces a non-empty triangle soup from the default world', () => {
+    const geom = buildWorldGeometry(DEFAULT_WORLD_DOCUMENT);
+    expect(geom.triangleCount).toBeGreaterThan(0);
+    expect(geom.vertexCount).toBeGreaterThan(0);
+    expect(geom.positions.length).toBe(geom.vertexCount * 3);
+    expect(geom.indices.length).toBe(geom.triangleCount * 3);
+  });
+
+  it('bounds encompass every emitted vertex', () => {
+    const geom = buildWorldGeometry(DEFAULT_WORLD_DOCUMENT);
+    const [minX, minY, minZ] = geom.boundsMin;
+    const [maxX, maxY, maxZ] = geom.boundsMax;
+    for (let i = 0; i < geom.vertexCount; i += 1) {
+      const x = geom.positions[i * 3];
+      const y = geom.positions[i * 3 + 1];
+      const z = geom.positions[i * 3 + 2];
+      expect(x).toBeGreaterThanOrEqual(minX);
+      expect(y).toBeGreaterThanOrEqual(minY);
+      expect(z).toBeGreaterThanOrEqual(minZ);
+      expect(x).toBeLessThanOrEqual(maxX);
+      expect(y).toBeLessThanOrEqual(maxY);
+      expect(z).toBeLessThanOrEqual(maxZ);
+    }
+  });
+
+  it('emits 12 triangles per static cuboid prop', () => {
+    const world = {
+      ...DEFAULT_WORLD_DOCUMENT,
+      terrain: {
+        ...DEFAULT_WORLD_DOCUMENT.terrain,
+        tiles: [],
+      },
+      staticProps: [
+        {
+          id: 1,
+          kind: 'cuboid' as const,
+          position: [0, 1, 0] as [number, number, number],
+          rotation: [0, 0, 0, 1] as [number, number, number, number],
+          halfExtents: [1, 1, 1] as [number, number, number],
+        },
+      ],
+      dynamicEntities: [],
+    };
+    const geom = buildWorldGeometry(world);
+    expect(geom.triangleCount).toBe(12);
+    expect(geom.vertexCount).toBe(8);
+    // Axis-aligned unit cuboid centered on [0,1,0]: bounds should be [-1,0,-1]..[1,2,1]
+    expect(geom.boundsMin).toEqual([-1, 0, -1]);
+    expect(geom.boundsMax).toEqual([1, 2, 1]);
+  });
+
+  it('indices stay within vertex range', () => {
+    const geom = buildWorldGeometry(DEFAULT_WORLD_DOCUMENT);
+    const upper = geom.vertexCount;
+    let maxIndex = -1;
+    let minIndex = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < geom.indices.length; i += 1) {
+      const idx = geom.indices[i];
+      if (idx > maxIndex) maxIndex = idx;
+      if (idx < minIndex) minIndex = idx;
+    }
+    expect(minIndex).toBeGreaterThanOrEqual(0);
+    expect(maxIndex).toBeLessThan(upper);
+  });
+});

--- a/client/src/bots/world/worldGeometry.ts
+++ b/client/src/bots/world/worldGeometry.ts
@@ -1,0 +1,255 @@
+/**
+ * Converts a {@link WorldDocument} into raw triangle geometry suitable for
+ * feeding into navcat's navmesh builders.
+ *
+ * Produces two typed arrays:
+ * - `positions`: `Float32Array` of interleaved `[x, y, z, ...]` vertex coords
+ * - `indices`:   `Uint32Array` of triangle indices (CCW when looking from +Y)
+ *
+ * Zero external dependencies (no THREE, no React) so it runs unchanged under
+ * Node for the load-test workers as well as in the browser LoadTest page.
+ */
+
+import type {
+  Quaternion,
+  StaticProp,
+  WorldDocument,
+  WorldTerrainTile,
+} from '../../world/worldDocument';
+import {
+  getTerrainTileWorldPosition,
+  sortTerrainTiles,
+} from '../../world/worldDocument';
+
+export interface BotWorldGeometry {
+  /** Interleaved xyz floats, length = vertexCount * 3. */
+  positions: Float32Array;
+  /** Triangle indices, length = triangleCount * 3. */
+  indices: Uint32Array;
+  /** Axis-aligned bounding box min corner, meters. */
+  boundsMin: [number, number, number];
+  /** Axis-aligned bounding box max corner, meters. */
+  boundsMax: [number, number, number];
+  /** Number of triangles emitted (for diagnostics / tests). */
+  triangleCount: number;
+  /** Number of unique vertices emitted (for diagnostics / tests). */
+  vertexCount: number;
+}
+
+/**
+ * Builds the combined triangle soup for terrain + static cuboid props.
+ *
+ * Dynamic entities are intentionally ignored — they move at runtime and the
+ * server-side crowd avoidance / physics handles those interactions.
+ */
+export function buildWorldGeometry(world: WorldDocument): BotWorldGeometry {
+  const tiles = sortTerrainTiles(world.terrain.tiles);
+  const tileGridSize = world.terrain.tileGridSize;
+  const vertsPerTile = tileGridSize * tileGridSize;
+  const trisPerTile = Math.max(0, (tileGridSize - 1) * (tileGridSize - 1) * 2);
+
+  const terrainVerts = tiles.length * vertsPerTile;
+  const terrainTris = tiles.length * trisPerTile;
+
+  const propCount = world.staticProps.length;
+  const propVerts = propCount * 8;
+  const propTris = propCount * 12;
+
+  const totalVerts = terrainVerts + propVerts;
+  const totalTris = terrainTris + propTris;
+
+  const positions = new Float32Array(totalVerts * 3);
+  const indices = new Uint32Array(totalTris * 3);
+
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let minZ = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  let maxZ = Number.NEGATIVE_INFINITY;
+
+  let vertexCursor = 0;
+  let indexCursor = 0;
+
+  // Terrain tiles ---------------------------------------------------------
+  for (const tile of tiles) {
+    const tileBaseVertex = vertexCursor;
+    writeTerrainTileVertices(world, tile, positions, vertexCursor);
+
+    for (let i = 0; i < vertsPerTile; i += 1) {
+      const px = positions[(tileBaseVertex + i) * 3];
+      const py = positions[(tileBaseVertex + i) * 3 + 1];
+      const pz = positions[(tileBaseVertex + i) * 3 + 2];
+      if (px < minX) minX = px;
+      if (py < minY) minY = py;
+      if (pz < minZ) minZ = pz;
+      if (px > maxX) maxX = px;
+      if (py > maxY) maxY = py;
+      if (pz > maxZ) maxZ = pz;
+    }
+
+    for (let row = 0; row < tileGridSize - 1; row += 1) {
+      for (let col = 0; col < tileGridSize - 1; col += 1) {
+        const a = tileBaseVertex + row * tileGridSize + col;
+        const b = tileBaseVertex + row * tileGridSize + col + 1;
+        const c = tileBaseVertex + (row + 1) * tileGridSize + col;
+        const d = tileBaseVertex + (row + 1) * tileGridSize + col + 1;
+
+        // Two triangles per quad, wound so normals point +Y.
+        indices[indexCursor + 0] = a;
+        indices[indexCursor + 1] = c;
+        indices[indexCursor + 2] = b;
+        indices[indexCursor + 3] = b;
+        indices[indexCursor + 4] = c;
+        indices[indexCursor + 5] = d;
+        indexCursor += 6;
+      }
+    }
+
+    vertexCursor += vertsPerTile;
+  }
+
+  // Static cuboid props ---------------------------------------------------
+  for (const prop of world.staticProps) {
+    if (prop.kind !== 'cuboid') continue;
+    const base = vertexCursor;
+    writeCuboidVertices(prop, positions, vertexCursor);
+    for (let i = 0; i < 8; i += 1) {
+      const px = positions[(base + i) * 3];
+      const py = positions[(base + i) * 3 + 1];
+      const pz = positions[(base + i) * 3 + 2];
+      if (px < minX) minX = px;
+      if (py < minY) minY = py;
+      if (pz < minZ) minZ = pz;
+      if (px > maxX) maxX = px;
+      if (py > maxY) maxY = py;
+      if (pz > maxZ) maxZ = pz;
+    }
+    writeCuboidIndices(base, indices, indexCursor);
+    vertexCursor += 8;
+    indexCursor += 36;
+  }
+
+  if (!Number.isFinite(minX)) {
+    minX = 0;
+    minY = 0;
+    minZ = 0;
+    maxX = 0;
+    maxY = 0;
+    maxZ = 0;
+  }
+
+  return {
+    positions,
+    indices,
+    boundsMin: [minX, minY, minZ],
+    boundsMax: [maxX, maxY, maxZ],
+    triangleCount: indexCursor / 3,
+    vertexCount: vertexCursor,
+  };
+}
+
+function writeTerrainTileVertices(
+  world: WorldDocument,
+  tile: WorldTerrainTile,
+  out: Float32Array,
+  baseVertex: number,
+): void {
+  const tileGridSize = world.terrain.tileGridSize;
+  for (let row = 0; row < tileGridSize; row += 1) {
+    for (let col = 0; col < tileGridSize; col += 1) {
+      const vi = row * tileGridSize + col;
+      const [wx, wz] = getTerrainTileWorldPosition(world, tile, row, col);
+      const height = tile.heights[vi] ?? 0;
+      const offset = (baseVertex + vi) * 3;
+      out[offset + 0] = wx;
+      out[offset + 1] = height;
+      out[offset + 2] = wz;
+    }
+  }
+}
+
+/**
+ * Writes the 8 corner vertices of a rotated cuboid into `out`.
+ *
+ * The 8 corners are enumerated with a 3-bit mask (x,y,z) so
+ * {@link writeCuboidIndices} below can use a fixed triangle table.
+ */
+function writeCuboidVertices(prop: StaticProp, out: Float32Array, baseVertex: number): void {
+  const [hx, hy, hz] = prop.halfExtents;
+  const [cx, cy, cz] = prop.position;
+  const q = prop.rotation;
+
+  for (let corner = 0; corner < 8; corner += 1) {
+    const sx = (corner & 1) === 0 ? -hx : hx;
+    const sy = (corner & 2) === 0 ? -hy : hy;
+    const sz = (corner & 4) === 0 ? -hz : hz;
+    const [rx, ry, rz] = rotateByQuaternion(sx, sy, sz, q);
+    const offset = (baseVertex + corner) * 3;
+    out[offset + 0] = cx + rx;
+    out[offset + 1] = cy + ry;
+    out[offset + 2] = cz + rz;
+  }
+}
+
+// Corner indexing (bit 0 = x, bit 1 = y, bit 2 = z; 0 = -, 1 = +)
+//  0: -x -y -z
+//  1: +x -y -z
+//  2: -x +y -z
+//  3: +x +y -z
+//  4: -x -y +z
+//  5: +x -y +z
+//  6: -x +y +z
+//  7: +x +y +z
+// Triangles wound CCW as seen from outside the box.
+const CUBOID_TRIANGLES: ReadonlyArray<number> = [
+  // -Z face (normal -Z): corners 0,1,2,3
+  0, 2, 1,
+  1, 2, 3,
+  // +Z face (normal +Z): corners 4,5,6,7
+  4, 5, 6,
+  5, 7, 6,
+  // -X face (normal -X): corners 0,2,4,6
+  0, 4, 2,
+  2, 4, 6,
+  // +X face (normal +X): corners 1,3,5,7
+  1, 3, 5,
+  3, 7, 5,
+  // -Y face (normal -Y): corners 0,1,4,5
+  0, 1, 4,
+  1, 5, 4,
+  // +Y face (normal +Y): corners 2,3,6,7
+  2, 6, 3,
+  3, 6, 7,
+];
+
+function writeCuboidIndices(baseVertex: number, out: Uint32Array, indexCursor: number): void {
+  for (let i = 0; i < CUBOID_TRIANGLES.length; i += 1) {
+    out[indexCursor + i] = baseVertex + CUBOID_TRIANGLES[i];
+  }
+}
+
+/**
+ * Rotates a local-space vector `(x, y, z)` by the quaternion `q = [x,y,z,w]`.
+ *
+ * Uses the standard `v' = q * v * q^-1` expansion without allocating any
+ * intermediate objects, so this function is cheap enough to call in the hot
+ * loop of {@link writeCuboidVertices}.
+ */
+function rotateByQuaternion(
+  x: number,
+  y: number,
+  z: number,
+  q: Quaternion,
+): [number, number, number] {
+  const [qx, qy, qz, qw] = q;
+  // t = 2 * (q.xyz × v)
+  const tx = 2 * (qy * z - qz * y);
+  const ty = 2 * (qz * x - qx * z);
+  const tz = 2 * (qx * y - qy * x);
+  // v' = v + qw * t + q.xyz × t
+  const rx = x + qw * tx + (qy * tz - qz * ty);
+  const ry = y + qw * ty + (qz * tx - qx * tz);
+  const rz = z + qw * tz + (qx * ty - qy * tx);
+  return [rx, ry, rz];
+}

--- a/client/src/loadtest/brain.ts
+++ b/client/src/loadtest/brain.ts
@@ -47,7 +47,14 @@ export type BotBrainMode =
   | 'follow_target'
   | 'recover_center'
   | 'hold_anchor'
-  | 'dead';
+  | 'dead'
+  // Vehicle FSM modes — only emitted by the bots-framework nav brain when
+  // vehicle mode is enabled. Loadtest runners never set these directly,
+  // but the mode field is forwarded verbatim so the type needs to match.
+  | 'walking_to_vehicle'
+  | 'entering_vehicle'
+  | 'driving'
+  | 'exiting_vehicle';
 
 export interface BotBrainState {
   mode: BotBrainMode;

--- a/client/src/loadtest/brain.ts
+++ b/client/src/loadtest/brain.ts
@@ -1,3 +1,20 @@
+/**
+ * Loadtest-facing bot brain.
+ *
+ * Historically this file owned a complete FSM (target acquisition, recover,
+ * hold anchor, fire, stuck detection). That logic now lives inside the
+ * reusable `@/bots` framework. This file is the thin shim between the
+ * loadtest runners (`simulate.ts`, `wsWorker.ts`, `LoadTest.tsx`) and the
+ * framework.
+ *
+ * Behavior matrix:
+ *   - If a {@link BotCrowd} is supplied to {@link createBotBrainState}, the
+ *     brain routes through a {@link BotBrain} with the `harassNearest`
+ *     behavior — bots plan paths through the navmesh and avoid each other.
+ *   - If no crowd is supplied (legacy + unit-test path) the brain falls back
+ *     to the original direct-steering FSM so existing tests keep passing.
+ */
+
 import {
   BTN_FORWARD,
   BTN_JUMP,
@@ -8,6 +25,15 @@ import {
   FLAG_ON_GROUND,
   type PlayerStateMeters,
 } from '../net/protocol';
+import {
+  BotBrain,
+  behaviors,
+  type BotCrowd,
+  type BotHandle,
+  type BotSelfState,
+  type ObservedPlayer as FrameworkObservedPlayer,
+  type Vec3Tuple,
+} from '../bots';
 import type { LoadTestScenario } from './scenario';
 import { anchorForBot } from './scenario';
 
@@ -16,7 +42,12 @@ export type ObservedPlayer = {
   state: PlayerStateMeters;
 };
 
-export type BotBrainMode = 'acquire_target' | 'follow_target' | 'recover_center' | 'hold_anchor' | 'dead';
+export type BotBrainMode =
+  | 'acquire_target'
+  | 'follow_target'
+  | 'recover_center'
+  | 'hold_anchor'
+  | 'dead';
 
 export interface BotBrainState {
   mode: BotBrainMode;
@@ -28,6 +59,14 @@ export interface BotBrainState {
   airborneTicks: number;
   lastPosition: [number, number, number] | null;
   targetPlayerId: number | null;
+  /**
+   * Optional navmesh-aware brain. When present, stepBotBrain delegates all
+   * movement decisions to it and only keeps {@link fireCooldownTicks} /
+   * target-id bookkeeping locally.
+   */
+  navBrain: BotBrain | null;
+  /** Handle into the shared crowd (for cleanup). */
+  navHandle: BotHandle | null;
 }
 
 export interface BotIntent {
@@ -39,10 +78,22 @@ export interface BotIntent {
   firePrimary: boolean;
 }
 
-export function createBotBrainState(botIndex: number, scenario: LoadTestScenario): BotBrainState {
-  return {
+export interface CreateBotBrainOptions {
+  /** Shared navcat crowd. When set, the brain uses navmesh pathfinding. */
+  crowd?: BotCrowd;
+  /** Optional initial spawn point override (meters). */
+  spawnPosition?: [number, number, number];
+}
+
+export function createBotBrainState(
+  botIndex: number,
+  scenario: LoadTestScenario,
+  options: CreateBotBrainOptions = {},
+): BotBrainState {
+  const anchor = anchorForBot(botIndex, scenario);
+  const state: BotBrainState = {
     mode: 'acquire_target',
-    anchor: anchorForBot(botIndex, scenario),
+    anchor,
     orbitDirection: botIndex % 2 === 0 ? 1 : -1,
     jumpCooldownTicks: 0,
     fireCooldownTicks: 0,
@@ -50,10 +101,113 @@ export function createBotBrainState(botIndex: number, scenario: LoadTestScenario
     airborneTicks: 0,
     lastPosition: null,
     targetPlayerId: null,
+    navBrain: null,
+    navHandle: null,
   };
+
+  if (options.crowd) {
+    const spawn: Vec3Tuple = options.spawnPosition ?? [anchor[0], 2.5, anchor[1]];
+    const handle = options.crowd.addBot(spawn);
+    const behavior = behaviors.harassNearest({
+      acquireDistanceM: scenario.behavior.targetAcquireDistanceM,
+      recoveryDistanceM: scenario.behavior.recoveryDistanceM,
+      fireDistanceM: scenario.behavior.fireDistanceM,
+    });
+    state.navBrain = new BotBrain(options.crowd, handle, behavior, {
+      anchor: [anchor[0], spawn[1], anchor[1]],
+      stuckTicksBeforeJump: scenario.behavior.stuckTickThreshold,
+      jumpCooldownTicks: scenario.behavior.jumpCooldownTicks,
+    });
+    state.navHandle = handle;
+  }
+
+  return state;
+}
+
+/** Removes the underlying crowd agent, if any. Call on disconnect. */
+export function disposeBotBrainState(state: BotBrainState, crowd?: BotCrowd): void {
+  if (state.navHandle && crowd) {
+    crowd.removeBot(state.navHandle);
+  }
+  state.navBrain = null;
+  state.navHandle = null;
 }
 
 export function stepBotBrain(
+  state: BotBrainState,
+  scenario: LoadTestScenario,
+  localState: PlayerStateMeters | null,
+  remotePlayers: ObservedPlayer[],
+): BotIntent {
+  if (state.navBrain) {
+    return stepWithNavBrain(state, scenario, localState, remotePlayers);
+  }
+  return stepLegacy(state, scenario, localState, remotePlayers);
+}
+
+function stepWithNavBrain(
+  state: BotBrainState,
+  scenario: LoadTestScenario,
+  localState: PlayerStateMeters | null,
+  remotePlayers: ObservedPlayer[],
+): BotIntent {
+  if (!localState) {
+    return { buttons: 0, yaw: 0, pitch: 0, mode: state.mode, targetPlayerId: null, firePrimary: false };
+  }
+  if ((localState.flags & FLAG_DEAD) !== 0) {
+    state.mode = 'dead';
+    state.targetPlayerId = null;
+    return { buttons: 0, yaw: 0, pitch: 0, mode: 'dead', targetPlayerId: null, firePrimary: false };
+  }
+
+  const self: BotSelfState = {
+    position: [...localState.position],
+    velocity: [...localState.velocity],
+    yaw: localState.yaw,
+    pitch: localState.pitch,
+    onGround: (localState.flags & FLAG_ON_GROUND) !== 0,
+    dead: false,
+  };
+
+  const observed: FrameworkObservedPlayer[] = remotePlayers.map((p) => ({
+    id: p.id,
+    position: [...p.state.position],
+    isDead: (p.state.flags & FLAG_DEAD) !== 0,
+  }));
+
+  state.fireCooldownTicks = Math.max(0, state.fireCooldownTicks - 1);
+  const intent = state.navBrain!.think(self, observed);
+
+  // Fire gating: the framework always requests fire when the behavior asks;
+  // loadtest adds a fireMode + cooldown on top.
+  let firePrimary = intent.firePrimary;
+  if (firePrimary) {
+    if (scenario.behavior.fireMode === 'off' || state.fireCooldownTicks > 0) {
+      firePrimary = false;
+    } else {
+      state.fireCooldownTicks = scenario.behavior.fireCooldownTicks;
+    }
+  }
+
+  state.mode = intent.mode;
+  state.targetPlayerId = intent.targetPlayerId;
+
+  return {
+    buttons: intent.buttons,
+    yaw: intent.yaw,
+    pitch: intent.pitch,
+    mode: intent.mode,
+    targetPlayerId: intent.targetPlayerId,
+    firePrimary,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy direct-steering FSM (used when no crowd/navmesh is available, and
+// by the existing unit tests).
+// ---------------------------------------------------------------------------
+
+function stepLegacy(
   state: BotBrainState,
   scenario: LoadTestScenario,
   localState: PlayerStateMeters | null,

--- a/client/src/net/localPreviewTransport.ts
+++ b/client/src/net/localPreviewTransport.ts
@@ -92,6 +92,47 @@ export class LocalPreviewTransport {
     this.sendRaw(encodeFirePacket(cmd));
   }
 
+  /**
+   * Spawn a bot as a real player inside the local session. Returns `true`
+   * if the bot id was accepted.
+   */
+  connectBot(botId: number): boolean {
+    if (!this.session || this.closed) return false;
+    return this.session.connectBot(botId);
+  }
+
+  /** Remove a previously spawned bot. */
+  disconnectBot(botId: number): boolean {
+    if (!this.session || this.closed) return false;
+    const removed = this.session.disconnectBot(botId);
+    this.flushPackets();
+    return removed;
+  }
+
+  /** Push an InputCmd bundle for a specific bot id. */
+  sendBotInputs(botId: number, cmds: InputCmd[]): void {
+    if (cmds.length === 0 || !this.session || this.closed) return;
+    const bytes = encodeInputBundle(cmds);
+    try {
+      this.session.handleBotPacket(botId, bytes);
+    } catch (error) {
+      console.warn('[local-preview] bot input rejected', error);
+    }
+    this.flushPackets();
+  }
+
+  /** Push a fire packet for a specific bot id. */
+  sendBotFire(botId: number, cmd: FireCmd): void {
+    if (!this.session || this.closed) return;
+    const bytes = encodeFirePacket(cmd);
+    try {
+      this.session.handleBotPacket(botId, bytes);
+    } catch (error) {
+      console.warn('[local-preview] bot fire rejected', error);
+    }
+    this.flushPackets();
+  }
+
   sendBlockEdit(cmd: BlockEditCmd): void {
     this.sendRaw(encodeBlockEditPacket(cmd));
   }

--- a/client/src/net/localPreviewTransport.ts
+++ b/client/src/net/localPreviewTransport.ts
@@ -145,6 +145,37 @@ export class LocalPreviewTransport {
     this.flushPackets();
   }
 
+  /**
+   * Seats a bot in a vehicle. The bot's WASM `PlayerRuntime` must already
+   * be connected (see {@link connectBot}). Routes through
+   * `LocalPreviewSession::handle_bot_packet`, which calls
+   * `arena.enter_vehicle` with the bot's player id. If the vehicle is
+   * already occupied, the existing driver is bumped out by the arena
+   * (matches the human path).
+   */
+  sendBotVehicleEnter(botId: number, vehicleId: number, seat = 0): void {
+    if (!this.session || this.closed) return;
+    const bytes = encodeVehicleEnterPacket(vehicleId, seat);
+    try {
+      this.session.handleBotPacket(botId, bytes);
+    } catch (error) {
+      console.warn('[local-preview] bot vehicle-enter rejected', error);
+    }
+    this.flushPackets();
+  }
+
+  /** Removes a bot from its currently occupied vehicle. No-op if not driving. */
+  sendBotVehicleExit(botId: number, vehicleId: number): void {
+    if (!this.session || this.closed) return;
+    const bytes = encodeVehicleExitPacket(vehicleId);
+    try {
+      this.session.handleBotPacket(botId, bytes);
+    } catch (error) {
+      console.warn('[local-preview] bot vehicle-exit rejected', error);
+    }
+    this.flushPackets();
+  }
+
   sendBlockEdit(cmd: BlockEditCmd): void {
     this.sendRaw(encodeBlockEditPacket(cmd));
   }

--- a/client/src/net/localPreviewTransport.ts
+++ b/client/src/net/localPreviewTransport.ts
@@ -121,6 +121,18 @@ export class LocalPreviewTransport {
     this.flushPackets();
   }
 
+  /**
+   * Override a bot's max horizontal move speed in meters/second. Pass
+   * `null` to restore the KCC's default walk/sprint tiers. Returns true
+   * if the id was a known bot.
+   */
+  setBotMaxSpeed(botId: number, maxSpeedMps: number | null): boolean {
+    if (!this.session || this.closed) return false;
+    // WASM takes a negative sentinel for "clear override".
+    const value = maxSpeedMps === null ? -1 : maxSpeedMps;
+    return this.session.setBotMaxSpeed(botId, value);
+  }
+
   /** Push a fire packet for a specific bot id. */
   sendBotFire(botId: number, cmd: FireCmd): void {
     if (!this.session || this.closed) return;

--- a/client/src/net/netcodeClient.ts
+++ b/client/src/net/netcodeClient.ts
@@ -100,6 +100,15 @@ export class NetcodeClient {
   private config: NetcodeClientConfig;
   private closedByClient = false;
 
+  /**
+   * Returns the underlying local-preview transport if this client is
+   * running in practice mode, or null otherwise. Used by
+   * `PracticeBotRuntime` to push per-bot input / fire packets.
+   */
+  getLocalPreviewTransport(): LocalPreviewTransport | null {
+    return this.localTransport;
+  }
+
   // Rolling accumulators for 1Hz debug stats report to server
   private _debugCorrectionSum = 0;
   private _debugPhysicsSum = 0;

--- a/client/src/net/netcodeClient.ts
+++ b/client/src/net/netcodeClient.ts
@@ -37,6 +37,8 @@ export type RemotePlayer = {
   yaw: number;
   pitch: number;
   hp: number;
+  /** Latest player state flags (FLAG_DEAD, FLAG_IN_VEHICLE, ...). */
+  flags: number;
 };
 
 export type NetcodeClientConfig = {
@@ -410,6 +412,7 @@ export class NetcodeClient {
         yaw,
         pitch,
         hp: player.hp,
+        flags: player.flags,
       });
     }
 
@@ -728,6 +731,7 @@ export class NetcodeClient {
               yaw: m.yaw,
               pitch: m.pitch,
               hp: m.hp,
+              flags: ps.flags,
             });
           }
         }

--- a/client/src/pages/LoadTest.tsx
+++ b/client/src/pages/LoadTest.tsx
@@ -2,8 +2,15 @@ import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { resolveRequestedMatchId } from '../app/matchId';
 import { resolveMultiplayerBackend } from '../app/runtimeConfig';
 import { buildInputFromButtons } from '../scene/inputBuilder';
-import { stepBotBrain, createBotBrainState, type ObservedPlayer } from '../loadtest/brain';
+import {
+  createBotBrainState,
+  disposeBotBrainState,
+  stepBotBrain,
+  type ObservedPlayer,
+} from '../loadtest/brain';
 import { PacketImpairment } from '../loadtest/networkModel';
+import { createBotCrowd, type BotCrowd } from '../bots';
+import { DEFAULT_WORLD_DOCUMENT } from '../world/worldDocument';
 import type { BenchmarkPageState, WebTransportWorkerResult } from '../benchmark/contracts';
 import {
   DEFAULT_SCENARIO,
@@ -36,6 +43,7 @@ type BrowserBot = {
   localState: PlayerStateMeters | null;
   remotePlayers: Map<number, ObservedPlayer>;
   brainState: ReturnType<typeof createBotBrainState>;
+  botCrowd: BotCrowd;
   currentTargetPlayerId: number | null;
   inboundImpairment: PacketImpairment<ServerReliablePacket | ServerDatagramPacket>;
   outboundImpairment: PacketImpairment<ReturnType<typeof buildInputFromButtons>>;
@@ -233,6 +241,8 @@ export function LoadTestPage() {
   const [snapshotsReceived, setSnapshotsReceived] = useState(0);
   const [bottleneck, setBottleneck] = useState('waiting for server stats');
   const botsRef = useRef<BrowserBot[]>([]);
+  const botCrowdRef = useRef<BotCrowd | null>(null);
+  const botCrowdTickerRef = useRef<number | null>(null);
   const statsSocketRef = useRef<WebSocket | null>(null);
   const presets = createScenarioPresets(launchConfigRef.current.requestedMatchId);
   const activePresetId = detectActivePreset(scenarioText, presets);
@@ -274,7 +284,11 @@ export function LoadTestPage() {
       window.clearTimeout(completionTimerRef.current);
       completionTimerRef.current = null;
     }
-    stopBots(botsRef.current);
+    stopBots(botsRef.current, botCrowdRef.current);
+    if (botCrowdTickerRef.current !== null) {
+      window.clearInterval(botCrowdTickerRef.current);
+      botCrowdTickerRef.current = null;
+    }
     statsSocketRef.current?.close();
   }, []);
 
@@ -310,8 +324,24 @@ export function LoadTestPage() {
         throw new Error('This browser does not support WebTransport.');
       }
 
-      stopBots(botsRef.current);
+      stopBots(botsRef.current, botCrowdRef.current);
       botsRef.current = [];
+      if (botCrowdTickerRef.current !== null) {
+        window.clearInterval(botCrowdTickerRef.current);
+        botCrowdTickerRef.current = null;
+      }
+      const navBuildStarted = performance.now();
+      botCrowdRef.current = createBotCrowd(DEFAULT_WORLD_DOCUMENT, { maxAgentRadius: 0.6 });
+      // eslint-disable-next-line no-console
+      console.log(
+        `[LoadTest] built navmesh in ${(performance.now() - navBuildStarted).toFixed(1)}ms`,
+        `(${botCrowdRef.current.nav.geometry.triangleCount} tris)`,
+      );
+      const crowdTickHz = 30;
+      const crowdDt = 1 / crowdTickHz;
+      botCrowdTickerRef.current = window.setInterval(() => {
+        botCrowdRef.current?.step(crowdDt);
+      }, 1000 / crowdTickHz);
       runStartedAtRef.current = new Date().toISOString();
       peakConnectedBotsRef.current = 0;
       latestBottleneckRef.current = 'waiting for server stats';
@@ -339,6 +369,10 @@ export function LoadTestPage() {
       connectStatsSocket(scenario.matchId);
 
       const rng = new SeededRandom(scenario.seed);
+      const botCrowd = botCrowdRef.current;
+      if (!botCrowd) {
+        throw new Error('Bot crowd was not initialized.');
+      }
       const results = await Promise.allSettled(
         Array.from({ length: scenario.transportMix.webtransport }, async (_, index) => {
           const profile = chooseWeightedProfile(scenario, 'webtransport', rng);
@@ -346,7 +380,7 @@ export function LoadTestPage() {
             ? Math.round((scenario.rampUpS * 1000 * index) / Math.max(1, scenario.transportMix.webtransport))
             : 0;
           await new Promise((resolve) => window.setTimeout(resolve, delayMs));
-          return spawnWebTransportBot(index + 1, scenario, profile);
+          return spawnWebTransportBot(index + 1, scenario, profile, botCrowd);
         }),
       );
       const bots: BrowserBot[] = [];
@@ -422,8 +456,13 @@ export function LoadTestPage() {
       completionTimerRef.current = null;
     }
     const result = buildBenchmarkResult(completedScenario);
-    stopBots(botsRef.current);
+    stopBots(botsRef.current, botCrowdRef.current);
     botsRef.current = [];
+    if (botCrowdTickerRef.current !== null) {
+      window.clearInterval(botCrowdTickerRef.current);
+      botCrowdTickerRef.current = null;
+    }
+    botCrowdRef.current = null;
     statsSocketRef.current?.close();
     statsSocketRef.current = null;
     setRunning(false);
@@ -521,6 +560,7 @@ export function LoadTestPage() {
     id: number,
     scenario: LoadTestScenario,
     profile: NetworkProfile,
+    botCrowd: BotCrowd,
   ): Promise<BrowserBot> {
     const bot = {} as BrowserBot;
     const inboundImpairment = new PacketImpairment<ServerReliablePacket | ServerDatagramPacket>(
@@ -555,7 +595,8 @@ export function LoadTestPage() {
       tickHandle: null,
       localState: null,
       remotePlayers: new Map<number, ObservedPlayer>(),
-      brainState: createBotBrainState(id - 1, scenario),
+      brainState: createBotBrainState(id - 1, scenario, { crowd: botCrowd }),
+      botCrowd,
       currentTargetPlayerId: null,
       inboundImpairment,
       outboundImpairment: new PacketImpairment(
@@ -613,12 +654,13 @@ export function LoadTestPage() {
   }
 }
 
-function stopBots(bots: BrowserBot[]): void {
+function stopBots(bots: BrowserBot[], botCrowd: BotCrowd | null): void {
   for (const bot of bots) {
     if (bot.tickHandle !== null) {
       window.clearInterval(bot.tickHandle);
       bot.tickHandle = null;
     }
+    disposeBotBrainState(bot.brainState, botCrowd ?? bot.botCrowd);
     bot.inboundImpairment.dispose();
     bot.outboundImpairment.dispose();
     bot.client.close();

--- a/client/src/scene/BotsDebugOverlay.tsx
+++ b/client/src/scene/BotsDebugOverlay.tsx
@@ -1,0 +1,353 @@
+/**
+ * In-scene debug overlay for practice-mode bots.
+ *
+ * Mounted as a child of the R3F Canvas (alongside the rest of GameWorld),
+ * this component polls {@link PracticeBotRuntime.getBotDebugInfos} every
+ * frame and renders, per bot:
+ *
+ * - A vertical pole + capsule highlight at the bot's position.
+ * - A polyline tracing the navcat steering corners from the bot to its
+ *   current target (the "path it intends to take").
+ * - A magenta sphere at the target position.
+ * - A green arrow showing the crowd's desiredVelocity (where the bot
+ *   wants to go *this tick*).
+ * - An HTML billboard above the bot's head with: id, behavior, mode,
+ *   target distance, current speed, and HP icons.
+ *
+ * Designed to be cheap: one shared LineSegments and a small pool of
+ * meshes, allocated once and updated in-place each frame.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Html } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { BotDebugInfo, PracticeBotRuntime } from '../bots';
+
+interface BotsDebugOverlayProps {
+  runtime: PracticeBotRuntime;
+}
+
+const MAX_BOTS = 32;
+const MAX_PATH_POINTS_PER_BOT = 9; // start + up to 8 corners
+// Each segment = 2 vertices * 3 floats. (MAX_PATH_POINTS - 1) segments per bot.
+const MAX_PATH_SEGMENTS = MAX_BOTS * (MAX_PATH_POINTS_PER_BOT - 1);
+const MAX_PATH_VERTICES = MAX_PATH_SEGMENTS * 2;
+
+const PATH_COLOR_HARASS = new THREE.Color(0xffae42);
+const PATH_COLOR_WANDER = new THREE.Color(0x6bd8ff);
+const PATH_COLOR_HOLD = new THREE.Color(0xc586ff);
+const TARGET_COLOR = new THREE.Color(0xff5fb1);
+const VEL_COLOR = new THREE.Color(0x6bff7c);
+
+function pathColor(behavior: BotDebugInfo['behaviorKind']): THREE.Color {
+  switch (behavior) {
+    case 'wander':
+      return PATH_COLOR_WANDER;
+    case 'hold':
+      return PATH_COLOR_HOLD;
+    case 'harass':
+    default:
+      return PATH_COLOR_HARASS;
+  }
+}
+
+interface BotSlot {
+  group: THREE.Group;
+  targetMesh: THREE.Mesh;
+  velArrow: THREE.ArrowHelper;
+  ringMesh: THREE.Mesh;
+  /** Most recent debug info to drive the HTML label. */
+  info: BotDebugInfo | null;
+}
+
+export function BotsDebugOverlay({ runtime }: BotsDebugOverlayProps) {
+  const rootRef = useRef<THREE.Group>(null);
+  const pathLinesRef = useRef<THREE.LineSegments | null>(null);
+  const slotsRef = useRef<Map<number, BotSlot>>(new Map());
+  // Latest debug infos written by useFrame each frame. Mirrored into
+  // React state at 10Hz for the HTML labels (they don't need 60Hz).
+  const latestInfosRef = useRef<BotDebugInfo[]>([]);
+  const [labelInfos, setLabelInfos] = useState<BotDebugInfo[]>([]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLabelInfos(latestInfosRef.current.slice());
+    }, 100);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Pre-allocate the line buffer geometry once. We update its xyz floats
+  // and `drawRange.count` in place every frame.
+  const pathGeometry = useMemo(() => {
+    const geom = new THREE.BufferGeometry();
+    const positions = new Float32Array(MAX_PATH_VERTICES * 3);
+    const colors = new Float32Array(MAX_PATH_VERTICES * 3);
+    geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geom.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    geom.setDrawRange(0, 0);
+    return geom;
+  }, []);
+
+  const pathMaterial = useMemo(
+    () => new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.85 }),
+    [],
+  );
+
+  // Tear down on unmount.
+  useEffect(() => {
+    return () => {
+      pathGeometry.dispose();
+      pathMaterial.dispose();
+      const slots = slotsRef.current;
+      for (const slot of slots.values()) {
+        slot.group.removeFromParent();
+        slot.targetMesh.geometry.dispose();
+        (slot.targetMesh.material as THREE.Material).dispose();
+        slot.ringMesh.geometry.dispose();
+        (slot.ringMesh.material as THREE.Material).dispose();
+      }
+      slots.clear();
+    };
+  }, [pathGeometry, pathMaterial]);
+
+  // Per-frame update: read live bot state and push it into the THREE
+  // objects without allocating per-bot.
+  useFrame(() => {
+    const root = rootRef.current;
+    const lineSegs = pathLinesRef.current;
+    if (!root || !lineSegs) return;
+
+    const infos = runtime.getBotDebugInfos();
+    latestInfosRef.current = infos;
+    const slots = slotsRef.current;
+    const seen = new Set<number>();
+
+    const positions = pathGeometry.attributes.position.array as Float32Array;
+    const colors = pathGeometry.attributes.color.array as Float32Array;
+    let vertexCount = 0;
+
+    for (const info of infos) {
+      seen.add(info.id);
+      let slot = slots.get(info.id);
+      if (!slot) {
+        slot = makeSlot();
+        slots.set(info.id, slot);
+        root.add(slot.group);
+        // Target marker is parented to the scene root so its position is
+        // in world space, independent of the bot's per-frame position.
+        root.add(slot.targetMesh);
+      }
+      slot.info = info;
+
+      // Position the per-bot group at the bot's feet.
+      slot.group.position.set(info.position[0], info.position[1], info.position[2]);
+
+      // Selection ring color follows behavior.
+      const color = pathColor(info.behaviorKind);
+      const ringMat = slot.ringMesh.material as THREE.MeshBasicMaterial;
+      ringMat.color.copy(color);
+
+      // Target marker: hide when no target. (World-space positioning.)
+      if (info.target) {
+        slot.targetMesh.visible = true;
+        slot.targetMesh.position.set(info.target[0], info.target[1] + 0.1, info.target[2]);
+      } else {
+        slot.targetMesh.visible = false;
+      }
+
+      // Desired velocity arrow.
+      const dv = info.desiredVelocity;
+      const dvLen = Math.hypot(dv[0], dv[1], dv[2]);
+      if (dvLen > 0.05) {
+        slot.velArrow.visible = true;
+        slot.velArrow.position.set(0, 1.2, 0); // local to bot group
+        slot.velArrow.setDirection(
+          new THREE.Vector3(dv[0] / dvLen, dv[1] / dvLen, dv[2] / dvLen),
+        );
+        slot.velArrow.setLength(Math.min(dvLen * 0.8, 4), 0.25, 0.15);
+      } else {
+        slot.velArrow.visible = false;
+      }
+
+      // Path polyline: emit one segment per pair of consecutive corners.
+      const points = info.pathPoints;
+      const segCount = Math.min(points.length - 1, MAX_PATH_POINTS_PER_BOT - 1);
+      for (let i = 0; i < segCount; i += 1) {
+        if (vertexCount + 2 > MAX_PATH_VERTICES) break;
+        const a = points[i];
+        const b = points[i + 1];
+        const aOffset = vertexCount * 3;
+        positions[aOffset + 0] = a[0];
+        positions[aOffset + 1] = a[1] + 0.1;
+        positions[aOffset + 2] = a[2];
+        colors[aOffset + 0] = color.r;
+        colors[aOffset + 1] = color.g;
+        colors[aOffset + 2] = color.b;
+        const bOffset = (vertexCount + 1) * 3;
+        positions[bOffset + 0] = b[0];
+        positions[bOffset + 1] = b[1] + 0.1;
+        positions[bOffset + 2] = b[2];
+        colors[bOffset + 0] = color.r;
+        colors[bOffset + 1] = color.g;
+        colors[bOffset + 2] = color.b;
+        vertexCount += 2;
+      }
+    }
+
+    // Garbage-collect slots for bots that no longer exist.
+    for (const [id, slot] of slots) {
+      if (!seen.has(id)) {
+        slot.group.removeFromParent();
+        slot.targetMesh.removeFromParent();
+        slot.targetMesh.geometry.dispose();
+        (slot.targetMesh.material as THREE.Material).dispose();
+        slot.ringMesh.geometry.dispose();
+        (slot.ringMesh.material as THREE.Material).dispose();
+        slots.delete(id);
+      }
+    }
+
+    pathGeometry.attributes.position.needsUpdate = true;
+    pathGeometry.attributes.color.needsUpdate = true;
+    pathGeometry.setDrawRange(0, vertexCount);
+    pathGeometry.computeBoundingSphere();
+  });
+
+  return (
+    <group ref={rootRef}>
+      <lineSegments
+        ref={pathLinesRef}
+        geometry={pathGeometry}
+        material={pathMaterial}
+        frustumCulled={false}
+      />
+      {labelInfos.map((info) => (
+        <Html
+          key={info.id}
+          position={[info.position[0], info.position[1] + 2.4, info.position[2]]}
+          center
+          distanceFactor={10}
+          occlude={false}
+          style={{ pointerEvents: 'none' }}
+        >
+          <div style={labelBoxStyle}>
+            <div style={labelTitleStyle}>
+              <span style={{ color: '#ffae42' }}>bot</span>{' '}
+              {info.id - 1_000_000 + 1}
+            </div>
+            <div style={labelRowStyle}>
+              <span style={labelKeyStyle}>behavior</span>
+              <span>{info.behaviorKind}</span>
+            </div>
+            <div style={labelRowStyle}>
+              <span style={labelKeyStyle}>mode</span>
+              <span>{info.mode}</span>
+            </div>
+            <div style={labelRowStyle}>
+              <span style={labelKeyStyle}>target</span>
+              <span>{describeTarget(info)}</span>
+            </div>
+            <div style={labelRowStyle}>
+              <span style={labelKeyStyle}>speed</span>
+              <span>
+                {Math.hypot(info.velocity[0], info.velocity[2]).toFixed(1)} /{' '}
+                {info.maxSpeed.toFixed(1)} m/s
+              </span>
+            </div>
+          </div>
+        </Html>
+      ))}
+    </group>
+  );
+}
+
+function makeSlot(): BotSlot {
+  const group = new THREE.Group();
+  group.name = 'bot-debug-slot';
+
+  // Selection ring at the bot's feet.
+  const ringGeometry = new THREE.RingGeometry(0.55, 0.65, 32);
+  ringGeometry.rotateX(-Math.PI / 2);
+  const ringMaterial = new THREE.MeshBasicMaterial({
+    color: PATH_COLOR_HARASS,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.75,
+    depthWrite: false,
+  });
+  const ringMesh = new THREE.Mesh(ringGeometry, ringMaterial);
+  ringMesh.position.y = 0.05;
+  group.add(ringMesh);
+
+  // Velocity arrow (hidden until updated). Lives in bot-local space.
+  const velArrow = new THREE.ArrowHelper(
+    new THREE.Vector3(0, 0, 1),
+    new THREE.Vector3(0, 1.2, 0),
+    1,
+    VEL_COLOR.getHex(),
+    0.25,
+    0.15,
+  );
+  velArrow.visible = false;
+  group.add(velArrow);
+
+  // Target marker — separate mesh, attached by the caller to the scene
+  // root (not this group) so it can sit at an absolute world position.
+  const targetGeometry = new THREE.SphereGeometry(0.18, 12, 8);
+  const targetMaterial = new THREE.MeshBasicMaterial({
+    color: TARGET_COLOR,
+    transparent: true,
+    opacity: 0.85,
+  });
+  const targetMesh = new THREE.Mesh(targetGeometry, targetMaterial);
+  targetMesh.visible = false;
+
+  return { group, targetMesh, velArrow, ringMesh, info: null };
+}
+
+function describeTarget(info: BotDebugInfo): string {
+  if (info.targetPlayerId !== null) {
+    return `player #${info.targetPlayerId}`;
+  }
+  if (info.target) {
+    const dx = info.target[0] - info.position[0];
+    const dz = info.target[2] - info.position[2];
+    return `${Math.hypot(dx, dz).toFixed(1)}m away`;
+  }
+  return '—';
+}
+
+const labelBoxStyle: React.CSSProperties = {
+  background: 'rgba(0, 0, 0, 0.78)',
+  border: '1px solid rgba(255, 174, 66, 0.5)',
+  borderRadius: 4,
+  padding: '4px 8px',
+  color: '#fff',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+  fontSize: 11,
+  lineHeight: 1.35,
+  whiteSpace: 'nowrap',
+  userSelect: 'none',
+  pointerEvents: 'none',
+  boxShadow: '0 2px 6px rgba(0,0,0,0.35)',
+};
+
+const labelTitleStyle: React.CSSProperties = {
+  fontWeight: 700,
+  fontSize: 12,
+  marginBottom: 2,
+};
+
+const labelRowStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 6,
+  justifyContent: 'space-between',
+};
+
+const labelKeyStyle: React.CSSProperties = {
+  color: 'rgba(255,255,255,0.55)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  fontSize: 10,
+};

--- a/client/src/scene/BotsDebugOverlay.tsx
+++ b/client/src/scene/BotsDebugOverlay.tsx
@@ -22,7 +22,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Html } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { BotDebugInfo, PracticeBotRuntime } from '../bots';
+import type { BotDebugInfo, BotObstacleDebugInfo, PracticeBotRuntime } from '../bots';
 
 interface BotsDebugOverlayProps {
   runtime: PracticeBotRuntime;
@@ -61,10 +61,19 @@ interface BotSlot {
   info: BotDebugInfo | null;
 }
 
+interface ObstacleSlot {
+  group: THREE.Group;
+  ring: THREE.Mesh;
+  pillar: THREE.Mesh;
+}
+
+const OBSTACLE_COLOR = new THREE.Color(0xff5050);
+
 export function BotsDebugOverlay({ runtime }: BotsDebugOverlayProps) {
   const rootRef = useRef<THREE.Group>(null);
   const pathLinesRef = useRef<THREE.LineSegments | null>(null);
   const slotsRef = useRef<Map<number, BotSlot>>(new Map());
+  const obstacleSlotsRef = useRef<Map<number, ObstacleSlot>>(new Map());
   // Latest debug infos written by useFrame each frame. Mirrored into
   // React state at 10Hz for the HTML labels (they don't need 60Hz).
   const latestInfosRef = useRef<BotDebugInfo[]>([]);
@@ -108,6 +117,15 @@ export function BotsDebugOverlay({ runtime }: BotsDebugOverlayProps) {
         (slot.ringMesh.material as THREE.Material).dispose();
       }
       slots.clear();
+      const obstacleSlots = obstacleSlotsRef.current;
+      for (const slot of obstacleSlots.values()) {
+        slot.group.removeFromParent();
+        slot.ring.geometry.dispose();
+        (slot.ring.material as THREE.Material).dispose();
+        slot.pillar.geometry.dispose();
+        (slot.pillar.material as THREE.Material).dispose();
+      }
+      obstacleSlots.clear();
     };
   }, [pathGeometry, pathMaterial]);
 
@@ -212,6 +230,39 @@ export function BotsDebugOverlay({ runtime }: BotsDebugOverlayProps) {
     pathGeometry.attributes.color.needsUpdate = true;
     pathGeometry.setDrawRange(0, vertexCount);
     pathGeometry.computeBoundingSphere();
+
+    // Update obstacle markers (currently: vehicles). Shows the bots the
+    // footprint of every vehicle pseudo-agent, so you can see what their
+    // crowd-level avoidance is actually steering around.
+    const obstacles: BotObstacleDebugInfo[] = runtime.getObstacleDebugInfos();
+    const obstacleSlots = obstacleSlotsRef.current;
+    const seenObstacles = new Set<number>();
+    for (const obs of obstacles) {
+      seenObstacles.add(obs.sourceId);
+      let slot = obstacleSlots.get(obs.sourceId);
+      if (!slot) {
+        slot = makeObstacleSlot();
+        obstacleSlots.set(obs.sourceId, slot);
+        root.add(slot.group);
+      }
+      slot.group.position.set(obs.position[0], obs.position[1], obs.position[2]);
+      // Scale the ring in X/Z to the obstacle's radius (it was created
+      // with radius 1 so we can scale it here without rebuilding the
+      // geometry).
+      slot.ring.scale.set(obs.radius, 1, obs.radius);
+      slot.pillar.scale.set(obs.radius, obs.height / 2, obs.radius);
+      slot.pillar.position.y = obs.height / 2;
+    }
+    for (const [id, slot] of obstacleSlots) {
+      if (!seenObstacles.has(id)) {
+        slot.group.removeFromParent();
+        slot.ring.geometry.dispose();
+        (slot.ring.material as THREE.Material).dispose();
+        slot.pillar.geometry.dispose();
+        (slot.pillar.material as THREE.Material).dispose();
+        obstacleSlots.delete(id);
+      }
+    }
   });
 
   return (
@@ -304,6 +355,39 @@ function makeSlot(): BotSlot {
   targetMesh.visible = false;
 
   return { group, targetMesh, velArrow, ringMesh, info: null };
+}
+
+function makeObstacleSlot(): ObstacleSlot {
+  const group = new THREE.Group();
+  group.name = 'bot-obstacle-slot';
+  // Unit-radius ring; the overlay update loop scales this per frame to
+  // match each obstacle's real radius.
+  const ringGeometry = new THREE.RingGeometry(0.96, 1.0, 48);
+  ringGeometry.rotateX(-Math.PI / 2);
+  const ringMaterial = new THREE.MeshBasicMaterial({
+    color: OBSTACLE_COLOR,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.75,
+    depthWrite: false,
+  });
+  const ring = new THREE.Mesh(ringGeometry, ringMaterial);
+  ring.position.y = 0.05;
+  group.add(ring);
+  // Subtle translucent pillar so the obstacle reads as a volume from a
+  // first-person camera, not just a floor ring.
+  const pillarGeometry = new THREE.CylinderGeometry(1.0, 1.0, 2, 24, 1, true);
+  const pillarMaterial = new THREE.MeshBasicMaterial({
+    color: OBSTACLE_COLOR,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.12,
+    depthWrite: false,
+  });
+  const pillar = new THREE.Mesh(pillarGeometry, pillarMaterial);
+  pillar.position.y = 1;
+  group.add(pillar);
+  return { group, ring, pillar };
 }
 
 function describeTarget(info: BotDebugInfo): string {

--- a/client/src/scene/GameScene.tsx
+++ b/client/src/scene/GameScene.tsx
@@ -24,6 +24,7 @@ type GameSceneProps = {
   renderStatsParent?: React.RefObject<HTMLElement>;
   worldDocument?: WorldDocument;
   benchmarkAutopilot?: React.ComponentProps<typeof GameWorld>['benchmarkAutopilot'];
+  practiceBots?: React.ComponentProps<typeof GameWorld>['practiceBots'];
   localRenderSmoothingEnabled?: boolean;
   sceneExtras?: ReactNode;
 };
@@ -45,6 +46,7 @@ export function GameScene({
   renderStatsParent,
   worldDocument,
   benchmarkAutopilot,
+  practiceBots,
   localRenderSmoothingEnabled = true,
   sceneExtras,
 }: GameSceneProps) {
@@ -80,6 +82,7 @@ export function GameScene({
           onSnapshot={onSnapshot}
           rapierDebugModeBits={rapierDebugModeBits}
           benchmarkAutopilot={benchmarkAutopilot}
+          practiceBots={practiceBots}
           localRenderSmoothingEnabled={localRenderSmoothingEnabled}
           sceneExtras={sceneExtras}
         />

--- a/client/src/scene/GameScene.tsx
+++ b/client/src/scene/GameScene.tsx
@@ -25,6 +25,7 @@ type GameSceneProps = {
   worldDocument?: WorldDocument;
   benchmarkAutopilot?: React.ComponentProps<typeof GameWorld>['benchmarkAutopilot'];
   practiceBots?: React.ComponentProps<typeof GameWorld>['practiceBots'];
+  practiceBotsDebugOverlay?: boolean;
   localRenderSmoothingEnabled?: boolean;
   sceneExtras?: ReactNode;
 };
@@ -47,6 +48,7 @@ export function GameScene({
   worldDocument,
   benchmarkAutopilot,
   practiceBots,
+  practiceBotsDebugOverlay,
   localRenderSmoothingEnabled = true,
   sceneExtras,
 }: GameSceneProps) {
@@ -83,6 +85,7 @@ export function GameScene({
           rapierDebugModeBits={rapierDebugModeBits}
           benchmarkAutopilot={benchmarkAutopilot}
           practiceBots={practiceBots}
+          practiceBotsDebugOverlay={practiceBotsDebugOverlay}
           localRenderSmoothingEnabled={localRenderSmoothingEnabled}
           sceneExtras={sceneExtras}
         />

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -507,12 +507,21 @@ export function GameWorld({
   // `ready`, which means the welcome packet landed and the client's
   // LocalPreviewTransport exists). Detaches automatically when the scene
   // unmounts, when the runtime reference swaps, or when we leave practice.
+  //
+  // IMPORTANT: the dep list is deliberately narrow. `usePredictionWithWorld`
+  // returns a fresh object literal each render, so including `prediction`
+  // directly would cause this effect to re-fire every frame, thrashing
+  // attach/detach. We keep a live `predictionRef` updated outside the effect
+  // and read it from the `getSelf` closure instead.
+  const predictionRef = useRef(prediction);
+  predictionRef.current = prediction;
   useEffect(() => {
     if (!practiceBots || !practiceMode || !ready) return;
     const client = clientRef.current;
     if (!client) return;
     const getSelf = () => {
-      const position = prediction.getPosition() ?? stateRef.current.localPosition;
+      const position =
+        predictionRef.current.getPosition() ?? stateRef.current.localPosition;
       return {
         id: client.playerId,
         position: [position[0], position[1], position[2]] as [number, number, number],
@@ -523,7 +532,7 @@ export function GameWorld({
     return () => {
       practiceBots.detach();
     };
-  }, [practiceBots, practiceMode, ready, clientRef, prediction, stateRef]);
+  }, [practiceBots, practiceMode, ready]);
 
   useFrame((_frameState, delta) => {
     if (!ready) return;

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -528,8 +528,17 @@ export function GameWorld({
     const client = clientRef.current;
     if (!client) return;
     const getSelf = () => {
-      const position =
-        predictionRef.current.getPosition() ?? stateRef.current.localPosition;
+      // When the human is in a vehicle, the on-foot prediction capsule
+      // is parked / static and `prediction.getPosition()` no longer
+      // tracks where the player actually is. The snapshot already
+      // resolves the vehicle's chassis position (see
+      // `local_arena.rs::snapshot_player`), so prefer
+      // `state.localPosition` in that case. On foot, prediction is the
+      // smoothed source-of-truth.
+      const inVehicle = (client.localPlayerFlags & FLAG_IN_VEHICLE) !== 0;
+      const position = inVehicle
+        ? stateRef.current.localPosition
+        : predictionRef.current.getPosition() ?? stateRef.current.localPosition;
       return {
         id: client.playerId,
         position: [position[0], position[1], position[2]] as [number, number, number],

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -185,10 +185,11 @@ type GameWorldProps = {
     scenario: LoadTestScenario;
   };
   /**
-   * Optional runtime for client-only practice bots. When supplied (only in
-   * practice mode), GameWorld ticks it each frame and uses its
-   * `remotePlayers` map in place of the real network map so the bots render
-   * as regular capsule meshes alongside the local player.
+   * Optional {@link PracticeBotRuntime}. When supplied and we're in a
+   * practice session, GameWorld attaches the runtime to the NetcodeClient
+   * as soon as the welcome packet arrives (so the runtime has access to
+   * the shared `LocalPreviewTransport` and can push bot inputs). Detached
+   * automatically on unmount.
    */
   practiceBots?: PracticeBotRuntime | null;
   localRenderSmoothingEnabled?: boolean;
@@ -501,6 +502,28 @@ export function GameWorld({
       ? createBotBrainState(benchmarkAutopilot.clientIndex, benchmarkAutopilot.scenario)
       : null;
   }, [benchmarkAutopilot]);
+
+  // Attach the practice bot runtime to the live NetcodeClient (only after
+  // `ready`, which means the welcome packet landed and the client's
+  // LocalPreviewTransport exists). Detaches automatically when the scene
+  // unmounts, when the runtime reference swaps, or when we leave practice.
+  useEffect(() => {
+    if (!practiceBots || !practiceMode || !ready) return;
+    const client = clientRef.current;
+    if (!client) return;
+    const getSelf = () => {
+      const position = prediction.getPosition() ?? stateRef.current.localPosition;
+      return {
+        id: client.playerId,
+        position: [position[0], position[1], position[2]] as [number, number, number],
+        dead: (client.localPlayerFlags & FLAG_DEAD) !== 0 || client.localPlayerHp <= 0,
+      };
+    };
+    practiceBots.attach(client, getSelf);
+    return () => {
+      practiceBots.detach();
+    };
+  }, [practiceBots, practiceMode, ready, clientRef, prediction, stateRef]);
 
   useFrame((_frameState, delta) => {
     if (!ready) return;
@@ -1134,20 +1157,7 @@ export function GameWorld({
     const group = remoteGroupRef.current;
     if (!group) return;
 
-    // In practice mode with a bot runtime attached, we treat the runtime's
-    // map as the source of truth for "remote players" so bots render the
-    // same way network-driven players do. Tick it here (once per frame) so
-    // its positions are fresh for the render code below.
-    if (practiceBots && practiceMode) {
-      const localPosRaw = prediction.getPosition() ?? state.localPosition;
-      practiceBots.update(frameDelta, {
-        id: client?.playerId ?? 1,
-        position: [localPosRaw[0], localPosRaw[1], localPosRaw[2]],
-        dead: localDead,
-      });
-    }
-    const currentRemote =
-      practiceBots && practiceMode ? practiceBots.remotePlayers : state.remotePlayers;
+    const currentRemote = state.remotePlayers;
     const activeIds = new Set<number>();
     const renderTimeUs = state.serverClock.renderTimeUs(state.interpolationDelayMs * 1000);
     let crosshairAimState: CrosshairAimState = 'idle';

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -38,6 +38,7 @@ import {
 import type { NetVehicleState, VehicleStateMeters } from '../net/protocol';
 import { createBotBrainState, stepBotBrain, type BotBrainState, type ObservedPlayer } from '../loadtest/brain';
 import type { LoadTestScenario } from '../loadtest/scenario';
+import type { PracticeBotRuntime } from '../bots';
 import { WorldTerrain } from './WorldTerrain';
 import { WorldStaticProps } from './WorldStaticProps';
 import { DEFAULT_WORLD_DOCUMENT, serializeWorldDocument, type WorldDocument } from '../world/worldDocument';
@@ -183,6 +184,13 @@ type GameWorldProps = {
     clientIndex: number;
     scenario: LoadTestScenario;
   };
+  /**
+   * Optional runtime for client-only practice bots. When supplied (only in
+   * practice mode), GameWorld ticks it each frame and uses its
+   * `remotePlayers` map in place of the real network map so the bots render
+   * as regular capsule meshes alongside the local player.
+   */
+  practiceBots?: PracticeBotRuntime | null;
   localRenderSmoothingEnabled?: boolean;
   // Optional children rendered inside the R3F scene. Used by the calibration
   // wizard to inject drill targets (FlickDrill / TrackDrill) into the live
@@ -385,6 +393,7 @@ export function GameWorld({
   onSnapshot,
   rapierDebugModeBits = 0,
   benchmarkAutopilot,
+  practiceBots,
   localRenderSmoothingEnabled = true,
   sceneExtras,
 }: GameWorldProps) {
@@ -1125,7 +1134,20 @@ export function GameWorld({
     const group = remoteGroupRef.current;
     if (!group) return;
 
-    const currentRemote = state.remotePlayers;
+    // In practice mode with a bot runtime attached, we treat the runtime's
+    // map as the source of truth for "remote players" so bots render the
+    // same way network-driven players do. Tick it here (once per frame) so
+    // its positions are fresh for the render code below.
+    if (practiceBots && practiceMode) {
+      const localPosRaw = prediction.getPosition() ?? state.localPosition;
+      practiceBots.update(frameDelta, {
+        id: client?.playerId ?? 1,
+        position: [localPosRaw[0], localPosRaw[1], localPosRaw[2]],
+        dead: localDead,
+      });
+    }
+    const currentRemote =
+      practiceBots && practiceMode ? practiceBots.remotePlayers : state.remotePlayers;
     const activeIds = new Set<number>();
     const renderTimeUs = state.serverClock.renderTimeUs(state.interpolationDelayMs * 1000);
     let crosshairAimState: CrosshairAimState = 'idle';

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -39,6 +39,7 @@ import type { NetVehicleState, VehicleStateMeters } from '../net/protocol';
 import { createBotBrainState, stepBotBrain, type BotBrainState, type ObservedPlayer } from '../loadtest/brain';
 import type { LoadTestScenario } from '../loadtest/scenario';
 import type { PracticeBotRuntime } from '../bots';
+import { BotsDebugOverlay } from './BotsDebugOverlay';
 import { WorldTerrain } from './WorldTerrain';
 import { WorldStaticProps } from './WorldStaticProps';
 import { DEFAULT_WORLD_DOCUMENT, serializeWorldDocument, type WorldDocument } from '../world/worldDocument';
@@ -192,6 +193,12 @@ type GameWorldProps = {
    * automatically on unmount.
    */
   practiceBots?: PracticeBotRuntime | null;
+  /**
+   * When true, render the in-scene bot debug overlay (path lines,
+   * target markers, brain state labels). Only meaningful in practice
+   * mode and when a `practiceBots` runtime is attached.
+   */
+  practiceBotsDebugOverlay?: boolean;
   localRenderSmoothingEnabled?: boolean;
   // Optional children rendered inside the R3F scene. Used by the calibration
   // wizard to inject drill targets (FlickDrill / TrackDrill) into the live
@@ -395,6 +402,7 @@ export function GameWorld({
   rapierDebugModeBits = 0,
   benchmarkAutopilot,
   practiceBots,
+  practiceBotsDebugOverlay,
   localRenderSmoothingEnabled = true,
   sceneExtras,
 }: GameWorldProps) {
@@ -1482,6 +1490,10 @@ export function GameWorld({
 
       {/* Crosshair */}
       <CrosshairHUD />
+
+      {practiceMode && practiceBots && practiceBotsDebugOverlay && (
+        <BotsDebugOverlay runtime={practiceBots} />
+      )}
 
       {sceneExtras}
     </>

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -31,7 +31,7 @@ export function PracticeBotsPanel({
 
   const count = stats?.bots ?? 0;
   const behavior = stats?.behavior ?? 'harass';
-  const maxSpeed = stats?.maxSpeed ?? 5.5;
+  const maxSpeed = stats?.maxSpeed ?? 3.0;
 
   return (
     <div style={containerStyle}>

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -1,0 +1,236 @@
+import { useState, type CSSProperties } from 'react';
+import type { PracticeBotBehaviorKind, PracticeBotStats } from '../bots';
+
+interface PracticeBotsPanelProps {
+  /** Whether the panel should be visible at all (practice mode + connected). */
+  visible: boolean;
+  /** Current runtime stats. When the runtime has been cleaned up this is null. */
+  stats: PracticeBotStats | null;
+  onSetBotCount: (count: number) => void;
+  onClear: () => void;
+  onSetBehavior: (kind: PracticeBotBehaviorKind) => void;
+  onSetMaxSpeed: (speed: number) => void;
+}
+
+const BEHAVIORS: Array<{ value: PracticeBotBehaviorKind; label: string; desc: string }> = [
+  { value: 'harass', label: 'Chase me', desc: 'Bots path toward the local player' },
+  { value: 'wander', label: 'Wander', desc: 'Bots roam random walkable points' },
+  { value: 'hold', label: 'Hold anchor', desc: 'Bots stay near their spawn anchor' },
+];
+
+export function PracticeBotsPanel({
+  visible,
+  stats,
+  onSetBotCount,
+  onClear,
+  onSetBehavior,
+  onSetMaxSpeed,
+}: PracticeBotsPanelProps) {
+  const [open, setOpen] = useState(false);
+  if (!visible) return null;
+
+  const count = stats?.bots ?? 0;
+  const behavior = stats?.behavior ?? 'harass';
+  const maxSpeed = stats?.maxSpeed ?? 5.5;
+
+  return (
+    <div style={containerStyle}>
+      <button
+        type="button"
+        style={toggleButtonStyle}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {open ? '▼ Bots' : '▶ Bots'} · {count}
+      </button>
+      {open && (
+        <div style={panelStyle}>
+          <div style={rowStyle}>
+            <label style={labelStyle}>Count</label>
+            <input
+              type="range"
+              min={0}
+              max={16}
+              step={1}
+              value={count}
+              onChange={(event) => onSetBotCount(Number(event.target.value))}
+              style={sliderStyle}
+            />
+            <input
+              type="number"
+              min={0}
+              max={32}
+              step={1}
+              value={count}
+              onChange={(event) => {
+                const next = Number.parseInt(event.target.value, 10);
+                if (Number.isFinite(next)) onSetBotCount(next);
+              }}
+              style={numberInputStyle}
+            />
+          </div>
+          <div style={rowStyle}>
+            <label style={labelStyle}>Speed</label>
+            <input
+              type="range"
+              min={1}
+              max={10}
+              step={0.5}
+              value={maxSpeed}
+              onChange={(event) => onSetMaxSpeed(Number(event.target.value))}
+              style={sliderStyle}
+            />
+            <span style={valueStyle}>{maxSpeed.toFixed(1)} m/s</span>
+          </div>
+          <div style={{ ...rowStyle, alignItems: 'flex-start' }}>
+            <label style={labelStyle}>Behavior</label>
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: 4 }}>
+              {BEHAVIORS.map((option) => (
+                <label key={option.value} style={radioLabelStyle}>
+                  <input
+                    type="radio"
+                    name="practice-bot-behavior"
+                    value={option.value}
+                    checked={behavior === option.value}
+                    onChange={() => onSetBehavior(option.value)}
+                  />
+                  <span>
+                    <span style={{ fontWeight: 600 }}>{option.label}</span>
+                    <span style={descStyle}> — {option.desc}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <div style={rowStyle}>
+            <button type="button" style={actionButtonStyle} onClick={() => onSetBotCount(count + 1)}>
+              + Add bot
+            </button>
+            <button
+              type="button"
+              style={{ ...actionButtonStyle, ...dangerButtonStyle }}
+              onClick={onClear}
+              disabled={count === 0}
+            >
+              Clear
+            </button>
+          </div>
+          {stats && (
+            <div style={footerStyle}>
+              navmesh: {stats.navTriangles.toLocaleString()} tris · bots rendered as remote players
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const containerStyle: CSSProperties = {
+  position: 'absolute',
+  top: 48,
+  right: 8,
+  zIndex: 12,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  gap: 4,
+  fontFamily: 'system-ui, sans-serif',
+  color: '#fff',
+};
+
+const toggleButtonStyle: CSSProperties = {
+  background: 'rgba(0, 0, 0, 0.6)',
+  border: '1px solid rgba(255,255,255,0.12)',
+  color: '#fff',
+  padding: '6px 12px',
+  borderRadius: 4,
+  fontSize: 12,
+  cursor: 'pointer',
+  minWidth: 96,
+  textAlign: 'left',
+};
+
+const panelStyle: CSSProperties = {
+  background: 'rgba(0, 0, 0, 0.72)',
+  border: '1px solid rgba(255,255,255,0.12)',
+  borderRadius: 6,
+  padding: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  minWidth: 280,
+  boxShadow: '0 4px 16px rgba(0, 0, 0, 0.4)',
+};
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  fontSize: 12,
+};
+
+const labelStyle: CSSProperties = {
+  minWidth: 60,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  color: 'rgba(255,255,255,0.65)',
+  fontSize: 11,
+};
+
+const sliderStyle: CSSProperties = {
+  flex: 1,
+  accentColor: '#6bd8ff',
+};
+
+const numberInputStyle: CSSProperties = {
+  width: 56,
+  background: 'rgba(255,255,255,0.08)',
+  color: '#fff',
+  border: '1px solid rgba(255,255,255,0.18)',
+  borderRadius: 3,
+  padding: '2px 4px',
+  fontSize: 12,
+  textAlign: 'right',
+};
+
+const valueStyle: CSSProperties = {
+  fontVariantNumeric: 'tabular-nums',
+  minWidth: 56,
+  textAlign: 'right',
+};
+
+const radioLabelStyle: CSSProperties = {
+  display: 'flex',
+  gap: 6,
+  alignItems: 'baseline',
+  cursor: 'pointer',
+};
+
+const descStyle: CSSProperties = {
+  color: 'rgba(255,255,255,0.55)',
+  fontSize: 11,
+};
+
+const actionButtonStyle: CSSProperties = {
+  flex: 1,
+  background: 'rgba(107, 216, 255, 0.18)',
+  border: '1px solid rgba(107, 216, 255, 0.45)',
+  color: '#edf9ff',
+  padding: '6px 10px',
+  borderRadius: 4,
+  cursor: 'pointer',
+  fontSize: 12,
+};
+
+const dangerButtonStyle: CSSProperties = {
+  background: 'rgba(255, 107, 107, 0.18)',
+  border: '1px solid rgba(255, 107, 107, 0.45)',
+  color: '#ffeaea',
+};
+
+const footerStyle: CSSProperties = {
+  color: 'rgba(255,255,255,0.45)',
+  fontSize: 11,
+  paddingTop: 4,
+  borderTop: '1px solid rgba(255,255,255,0.08)',
+};

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -13,6 +13,7 @@ interface PracticeBotsPanelProps {
   onSetBehavior: (kind: PracticeBotBehaviorKind) => void;
   onSetMaxSpeed: (speed: number) => void;
   onToggleDebugOverlay: (value: boolean) => void;
+  onSetUseVehicles: (value: boolean) => void;
 }
 
 const BEHAVIORS: Array<{ value: PracticeBotBehaviorKind; label: string; desc: string }> = [
@@ -69,12 +70,14 @@ export function PracticeBotsPanel({
   onSetBehavior,
   onSetMaxSpeed,
   onToggleDebugOverlay,
+  onSetUseVehicles,
 }: PracticeBotsPanelProps) {
   const [open, setOpen] = useState(false);
 
   const count = stats?.bots ?? 0;
   const behavior = stats?.behavior ?? 'harass';
   const maxSpeed = stats?.maxSpeed ?? 3.0;
+  const useVehicles = stats?.useVehicles ?? false;
 
   const [countSliderRef, countDragStart, countDragEnd] = useDraggableInputSync(count);
   const [countNumberRef, , ] = useDraggableInputSync(count);
@@ -176,6 +179,17 @@ export function PracticeBotsPanel({
                 </label>
               ))}
             </div>
+          </div>
+          <div style={rowStyle}>
+            <label style={labelStyle}>Vehicles</label>
+            <label style={toggleLabelStyle}>
+              <input
+                type="checkbox"
+                checked={useVehicles}
+                onChange={(event) => onSetUseVehicles(event.target.checked)}
+              />
+              <span>bots can drive vehicles to reach targets</span>
+            </label>
           </div>
           <div style={rowStyle}>
             <label style={labelStyle}>Debug</label>

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import type { PracticeBotBehaviorKind, PracticeBotStats } from '../bots';
 
 interface PracticeBotsPanelProps {
@@ -21,6 +21,45 @@ const BEHAVIORS: Array<{ value: PracticeBotBehaviorKind; label: string; desc: st
   { value: 'hold', label: 'Hold anchor', desc: 'Bots stay near their spawn anchor' },
 ];
 
+/**
+ * Native ranges and number inputs are notoriously fragile when used as
+ * fully controlled React inputs — a re-render that lands mid-drag can
+ * snap the slider back to the last committed value, making it feel
+ * "stuck". To avoid that, the inputs in this panel are **uncontrolled**:
+ *
+ * - `defaultValue` initializes them once.
+ * - `onInput` pushes drag-time updates straight to the runtime via the
+ *   parent callback (no React state in the loop).
+ * - A small `useEffect` writes the latest external value into the input
+ *   via a ref *only* when the user is not currently dragging. That way
+ *   external state changes (e.g. another control or a programmatic
+ *   reset) still update the input, but a controlled-component fight
+ *   never happens during interactive drags.
+ */
+function useDraggableInputSync(
+  externalValue: number,
+): readonly [
+  React.RefObject<HTMLInputElement>,
+  () => void,
+  () => void,
+] {
+  const ref = useRef<HTMLInputElement>(null);
+  const draggingRef = useRef(false);
+  useEffect(() => {
+    if (draggingRef.current) return;
+    if (!ref.current) return;
+    const next = String(externalValue);
+    if (ref.current.value !== next) ref.current.value = next;
+  }, [externalValue]);
+  const onPointerDown = () => {
+    draggingRef.current = true;
+  };
+  const onPointerUp = () => {
+    draggingRef.current = false;
+  };
+  return [ref, onPointerDown, onPointerUp];
+}
+
 export function PracticeBotsPanel({
   visible,
   stats,
@@ -32,11 +71,17 @@ export function PracticeBotsPanel({
   onToggleDebugOverlay,
 }: PracticeBotsPanelProps) {
   const [open, setOpen] = useState(false);
-  if (!visible) return null;
 
   const count = stats?.bots ?? 0;
   const behavior = stats?.behavior ?? 'harass';
   const maxSpeed = stats?.maxSpeed ?? 3.0;
+
+  const [countSliderRef, countDragStart, countDragEnd] = useDraggableInputSync(count);
+  const [countNumberRef, , ] = useDraggableInputSync(count);
+  const [speedSliderRef, speedDragStart, speedDragEnd] = useDraggableInputSync(maxSpeed);
+  const [speedNumberRef, , ] = useDraggableInputSync(maxSpeed);
+
+  if (!visible) return null;
 
   return (
     <div style={containerStyle}>
@@ -52,20 +97,27 @@ export function PracticeBotsPanel({
           <div style={rowStyle}>
             <label style={labelStyle}>Count</label>
             <input
+              ref={countSliderRef}
               type="range"
               min={0}
               max={16}
               step={1}
-              value={count}
-              onChange={(event) => onSetBotCount(Number(event.target.value))}
+              defaultValue={count}
+              onInput={(event) =>
+                onSetBotCount(Number((event.target as HTMLInputElement).value))
+              }
+              onPointerDown={countDragStart}
+              onPointerUp={countDragEnd}
+              onPointerCancel={countDragEnd}
               style={sliderStyle}
             />
             <input
+              ref={countNumberRef}
               type="number"
               min={0}
               max={32}
               step={1}
-              value={count}
+              defaultValue={count}
               onChange={(event) => {
                 const next = Number.parseInt(event.target.value, 10);
                 if (Number.isFinite(next)) onSetBotCount(next);
@@ -76,23 +128,27 @@ export function PracticeBotsPanel({
           <div style={rowStyle}>
             <label style={labelStyle}>Speed</label>
             <input
+              ref={speedSliderRef}
               type="range"
               min={0.5}
               max={8}
               step={0.25}
-              value={maxSpeed}
-              onChange={(event) => onSetMaxSpeed(Number(event.target.value))}
+              defaultValue={maxSpeed}
               onInput={(event) =>
                 onSetMaxSpeed(Number((event.target as HTMLInputElement).value))
               }
+              onPointerDown={speedDragStart}
+              onPointerUp={speedDragEnd}
+              onPointerCancel={speedDragEnd}
               style={sliderStyle}
             />
             <input
+              ref={speedNumberRef}
               type="number"
               min={0.5}
               max={12}
               step={0.25}
-              value={maxSpeed}
+              defaultValue={maxSpeed}
               onChange={(event) => {
                 const next = Number(event.target.value);
                 if (Number.isFinite(next) && next > 0) onSetMaxSpeed(next);
@@ -145,9 +201,16 @@ export function PracticeBotsPanel({
               Clear
             </button>
           </div>
+          <div style={liveValueStyle}>
+            <span>{count} bots</span>
+            <span>·</span>
+            <span>{maxSpeed.toFixed(2)} m/s</span>
+            <span>·</span>
+            <span>{behavior}</span>
+          </div>
           {stats && (
             <div style={footerStyle}>
-              navmesh: {stats.navTriangles.toLocaleString()} tris · bots rendered as remote players
+              navmesh: {stats.navTriangles.toLocaleString()} tris · bots are real players in WASM
             </div>
           )}
         </div>
@@ -241,6 +304,17 @@ const toggleLabelStyle: CSSProperties = {
   fontSize: 12,
   color: 'rgba(255,255,255,0.85)',
   cursor: 'pointer',
+};
+
+const liveValueStyle: CSSProperties = {
+  display: 'flex',
+  gap: 6,
+  alignItems: 'center',
+  fontSize: 11,
+  color: 'rgba(255,255,255,0.7)',
+  paddingTop: 4,
+  borderTop: '1px dashed rgba(255,255,255,0.08)',
+  fontVariantNumeric: 'tabular-nums',
 };
 
 const valueStyle: CSSProperties = {

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -72,14 +72,26 @@ export function PracticeBotsPanel({
             <label style={labelStyle}>Speed</label>
             <input
               type="range"
-              min={1}
-              max={10}
-              step={0.5}
+              min={0.5}
+              max={8}
+              step={0.25}
               value={maxSpeed}
               onChange={(event) => onSetMaxSpeed(Number(event.target.value))}
               style={sliderStyle}
             />
-            <span style={valueStyle}>{maxSpeed.toFixed(1)} m/s</span>
+            <input
+              type="number"
+              min={0.5}
+              max={12}
+              step={0.25}
+              value={maxSpeed}
+              onChange={(event) => {
+                const next = Number(event.target.value);
+                if (Number.isFinite(next)) onSetMaxSpeed(next);
+              }}
+              style={{ ...numberInputStyle, width: 64 }}
+            />
+            <span style={{ ...valueStyle, minWidth: 36 }}>m/s</span>
           </div>
           <div style={{ ...rowStyle, alignItems: 'flex-start' }}>
             <label style={labelStyle}>Behavior</label>

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -6,10 +6,13 @@ interface PracticeBotsPanelProps {
   visible: boolean;
   /** Current runtime stats. When the runtime has been cleaned up this is null. */
   stats: PracticeBotStats | null;
+  /** Whether the in-scene bot debug overlay is currently rendering. */
+  debugOverlay: boolean;
   onSetBotCount: (count: number) => void;
   onClear: () => void;
   onSetBehavior: (kind: PracticeBotBehaviorKind) => void;
   onSetMaxSpeed: (speed: number) => void;
+  onToggleDebugOverlay: (value: boolean) => void;
 }
 
 const BEHAVIORS: Array<{ value: PracticeBotBehaviorKind; label: string; desc: string }> = [
@@ -21,10 +24,12 @@ const BEHAVIORS: Array<{ value: PracticeBotBehaviorKind; label: string; desc: st
 export function PracticeBotsPanel({
   visible,
   stats,
+  debugOverlay,
   onSetBotCount,
   onClear,
   onSetBehavior,
   onSetMaxSpeed,
+  onToggleDebugOverlay,
 }: PracticeBotsPanelProps) {
   const [open, setOpen] = useState(false);
   if (!visible) return null;
@@ -77,6 +82,9 @@ export function PracticeBotsPanel({
               step={0.25}
               value={maxSpeed}
               onChange={(event) => onSetMaxSpeed(Number(event.target.value))}
+              onInput={(event) =>
+                onSetMaxSpeed(Number((event.target as HTMLInputElement).value))
+              }
               style={sliderStyle}
             />
             <input
@@ -87,11 +95,11 @@ export function PracticeBotsPanel({
               value={maxSpeed}
               onChange={(event) => {
                 const next = Number(event.target.value);
-                if (Number.isFinite(next)) onSetMaxSpeed(next);
+                if (Number.isFinite(next) && next > 0) onSetMaxSpeed(next);
               }}
-              style={{ ...numberInputStyle, width: 64 }}
+              style={numberInputStyle}
             />
-            <span style={{ ...valueStyle, minWidth: 36 }}>m/s</span>
+            <span style={unitStyle}>m/s</span>
           </div>
           <div style={{ ...rowStyle, alignItems: 'flex-start' }}>
             <label style={labelStyle}>Behavior</label>
@@ -112,6 +120,17 @@ export function PracticeBotsPanel({
                 </label>
               ))}
             </div>
+          </div>
+          <div style={rowStyle}>
+            <label style={labelStyle}>Debug</label>
+            <label style={toggleLabelStyle}>
+              <input
+                type="checkbox"
+                checked={debugOverlay}
+                onChange={(event) => onToggleDebugOverlay(event.target.checked)}
+              />
+              <span>show path / target / state in scene</span>
+            </label>
           </div>
           <div style={rowStyle}>
             <button type="button" style={actionButtonStyle} onClick={() => onSetBotCount(count + 1)}>
@@ -170,7 +189,10 @@ const panelStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
-  minWidth: 280,
+  // Wide enough that the slider has comfortable drag distance after the
+  // label, number input, and unit suffix take their share. Cramped
+  // sliders feel "broken" — they hit-test poorly.
+  minWidth: 360,
   boxShadow: '0 4px 16px rgba(0, 0, 0, 0.4)',
 };
 
@@ -203,6 +225,22 @@ const numberInputStyle: CSSProperties = {
   padding: '2px 4px',
   fontSize: 12,
   textAlign: 'right',
+};
+
+const unitStyle: CSSProperties = {
+  fontSize: 11,
+  color: 'rgba(255,255,255,0.55)',
+  minWidth: 28,
+};
+
+const toggleLabelStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  flex: 1,
+  fontSize: 12,
+  color: 'rgba(255,255,255,0.85)',
+  cursor: 'pointer',
 };
 
 const valueStyle: CSSProperties = {

--- a/server/src/movement.rs
+++ b/server/src/movement.rs
@@ -198,6 +198,9 @@ impl PhysicsArena {
             input,
             dt,
             self.player_kcc_mode,
+            // Server-side players always use the walk/sprint tiers from
+            // MoveConfig. Only practice-mode bots override this.
+            None,
         );
         let sync_started = Instant::now();
         self.dynamic

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -22,3 +22,9 @@ simd-stable = ["rapier3d/simd-stable", "vibe-netcode/simd-stable"]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 console_error_panic_hook = "0.1"
+
+# wasm-pack release profile — disable wasm-opt so the build doesn't require
+# network access to download binaryen. The opt step is mostly a size win,
+# not a speed win, and our builds run in environments without internet.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/shared/src/local_arena.rs
+++ b/shared/src/local_arena.rs
@@ -54,6 +54,12 @@ pub struct PlayerMotorState {
     pub hp: u8,
     pub dead: bool,
     pub last_input: InputCmd,
+    /// Optional per-player override for the KCC's max horizontal move
+    /// speed (m/s). When `Some`, the simulation uses this value instead
+    /// of the walk/sprint tiers from `MoveConfig`, letting bots move at
+    /// arbitrary continuous speeds independent of the human's
+    /// walk/sprint buttons.
+    pub max_speed_override: Option<f64>,
 }
 
 /// Browser-local authoritative physics world: wraps `DynamicArena` and adds
@@ -109,6 +115,7 @@ impl PhysicsArena {
                 hp: 100,
                 dead: false,
                 last_input: InputCmd::default(),
+                max_speed_override: None,
             },
         );
 
@@ -199,6 +206,7 @@ impl PhysicsArena {
         }
         state.last_input = input.clone();
 
+        let max_speed_override = state.max_speed_override;
         let mut tick_result = simulate_player_tick(
             &self.dynamic.sim,
             state.collider,
@@ -209,6 +217,7 @@ impl PhysicsArena {
             &mut state.on_ground,
             input,
             dt,
+            max_speed_override,
         );
         let sync_started = now_marker();
         self.dynamic
@@ -373,6 +382,22 @@ impl PhysicsArena {
                 state.velocity = Vec3d::zeros();
                 state.on_ground = false;
             }
+        }
+    }
+
+    /// Sets an override for the KCC's max horizontal move speed for the
+    /// given player. Pass `None` to restore the default walk/sprint tiers.
+    /// Returns true if the player exists.
+    pub fn set_player_max_speed_override(
+        &mut self,
+        player_id: u32,
+        max_speed: Option<f64>,
+    ) -> bool {
+        if let Some(state) = self.players.get_mut(&player_id) {
+            state.max_speed_override = max_speed;
+            true
+        } else {
+            false
         }
     }
 

--- a/shared/src/local_arena.rs
+++ b/shared/src/local_arena.rs
@@ -376,6 +376,25 @@ impl PhysicsArena {
         }
     }
 
+    /// Applies damage to `player_id`, clamping hp at 0 and setting the dead
+    /// flag when hp reaches zero. Returns true if this damage killed the
+    /// player (was alive, now dead).
+    pub fn apply_player_damage(&mut self, player_id: u32, damage: u8) -> bool {
+        let Some(state) = self.players.get_mut(&player_id) else {
+            return false;
+        };
+        if state.dead || state.hp == 0 {
+            return false;
+        }
+        state.hp = state.hp.saturating_sub(damage);
+        if state.hp == 0 {
+            state.dead = true;
+            state.velocity = Vec3d::zeros();
+            return true;
+        }
+        false
+    }
+
     pub fn respawn_player(&mut self, player_id: u32) -> Option<[f32; 3]> {
         let lane = self.next_spawn_index % 8;
         self.next_spawn_index += 1;

--- a/shared/src/local_session.rs
+++ b/shared/src/local_session.rs
@@ -165,18 +165,22 @@ impl LocalPreviewSession {
         true
     }
 
-    /// Push a bot's input packet (same wire format as the human client's
-    /// input bundle). Shots/vehicle packets are not supported for bots in
-    /// v1 — they route to the `handle_client_packet` path of the human.
+    /// Push a bot's input packet. Bots use the same wire format as the
+    /// human client; supported kinds are `PKT_INPUT_BUNDLE`, `PKT_FIRE`,
+    /// `PKT_VEHICLE_ENTER`, and `PKT_VEHICLE_EXIT`. Vehicle enter/exit
+    /// routes straight through `arena.enter_vehicle` /
+    /// `arena.exit_vehicle`, which already take a generic player id.
     pub fn handle_bot_packet(&mut self, bot_id: u32, bytes: &[u8]) -> Result<(), String> {
         if bot_id == LOCAL_PLAYER_ID {
             return Err("cannot push bot input for local player id".to_string());
         }
-        let Some(runtime) = self.players.get_mut(&bot_id) else {
-            return Err(format!("unknown bot id {bot_id}"));
-        };
-        if !runtime.is_bot {
-            return Err(format!("player {bot_id} is not a bot"));
+        {
+            let Some(runtime) = self.players.get(&bot_id) else {
+                return Err(format!("unknown bot id {bot_id}"));
+            };
+            if !runtime.is_bot {
+                return Err(format!("player {bot_id} is not a bot"));
+            }
         }
         if bytes.is_empty() {
             return Err("empty bot packet".to_string());
@@ -186,12 +190,30 @@ impl LocalPreviewSession {
         match kind {
             PKT_INPUT_BUNDLE => {
                 let frames = decode_input_bundle_frames(&mut buf)?;
+                let runtime = self
+                    .players
+                    .get_mut(&bot_id)
+                    .expect("bot runtime existed in the check above");
                 enqueue_inputs(runtime, frames);
                 Ok(())
             }
             PKT_FIRE => {
                 let shot = decode_fire_cmd(&mut buf)?;
                 self.queued_shots.push((bot_id, shot));
+                Ok(())
+            }
+            PKT_VEHICLE_ENTER => {
+                let vehicle_id = decode_vehicle_enter(&mut buf)?;
+                if self.arena.vehicles.contains_key(&vehicle_id) {
+                    self.arena.enter_vehicle(bot_id, vehicle_id);
+                }
+                Ok(())
+            }
+            PKT_VEHICLE_EXIT => {
+                let vehicle_id = decode_vehicle_exit(&mut buf)?;
+                if self.arena.vehicle_of_player.get(&bot_id) == Some(&vehicle_id) {
+                    self.arena.exit_vehicle(bot_id);
+                }
                 Ok(())
             }
             other => Err(format!("unsupported bot packet kind {other}")),
@@ -837,13 +859,14 @@ mod tests {
             .find(|pkt| pkt[0] == PKT_SNAPSHOT)
             .expect("initial local preview snapshot");
         let initial_vehicle = decode_snapshot_vehicle_states(&initial_snapshot);
-        assert_eq!(
-            initial_vehicle.len(),
-            1,
-            "demo local preview should expose one vehicle"
+        assert!(
+            !initial_vehicle.is_empty(),
+            "demo local preview should expose at least one vehicle"
         );
-        let (vehicle_id, driver_id, _, _, _) = initial_vehicle[0];
-        assert_eq!(driver_id, 0, "authored vehicle should start unoccupied");
+        let (vehicle_id, _, _, _, _) = *initial_vehicle
+            .iter()
+            .find(|(_, driver, _, _, _)| *driver == 0)
+            .expect("at least one authored vehicle should start unoccupied");
 
         session
             .handle_client_packet(&encode_vehicle_enter_packet_for_test(vehicle_id))
@@ -857,8 +880,10 @@ mod tests {
             .find(|pkt| pkt[0] == PKT_SNAPSHOT)
             .expect("latest local preview snapshot");
         let latest_vehicle = decode_snapshot_vehicle_states(&latest_snapshot);
-        assert_eq!(latest_vehicle.len(), 1);
-        let (_, latest_driver_id, _, _, _) = latest_vehicle[0];
+        let (_, latest_driver_id, _, _, _) = *latest_vehicle
+            .iter()
+            .find(|(id, _, _, _, _)| *id == vehicle_id)
+            .expect("entered vehicle should still be in snapshot");
         assert_eq!(
             latest_driver_id, LOCAL_PLAYER_ID,
             "local preview vehicle should be driven by the local player after enter"
@@ -933,6 +958,131 @@ mod tests {
         let after = session.arena.snapshot_player(202).unwrap().0;
         let dz = (after[2] - start[2]).abs();
         assert!(dz > 0.0, "bot should have moved after 10 ticks of forward input");
+    }
+
+    fn encode_vehicle_exit_packet_for_test(vehicle_id: u32) -> Vec<u8> {
+        let mut out = BytesMut::with_capacity(5);
+        out.put_u8(PKT_VEHICLE_EXIT);
+        out.put_u32_le(vehicle_id);
+        out.to_vec()
+    }
+
+    #[test]
+    fn bot_can_enter_and_drive_a_vehicle() {
+        let mut session = LocalPreviewSession::new();
+        session.connect();
+        let _ = session.drain_packets();
+        assert!(session.connect_bot(404));
+
+        // Tick once so the vehicle state is represented in a snapshot the
+        // test can inspect.
+        session.tick(1.0 / 60.0);
+        let initial_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("initial snapshot after connect_bot");
+        let initial_vehicles = decode_snapshot_vehicle_states(&initial_snapshot);
+        assert!(
+            !initial_vehicles.is_empty(),
+            "demo local preview should expose at least one authored vehicle"
+        );
+        let (vehicle_id, _, start_px, _, start_pz) = *initial_vehicles
+            .iter()
+            .find(|(_, driver, _, _, _)| *driver == 0)
+            .expect("at least one authored vehicle should start unoccupied");
+
+        // Route the enter packet through `handle_bot_packet` — this is the
+        // path `PracticeBotRuntime` uses when a bot reaches the
+        // `entering_vehicle` FSM state.
+        session
+            .handle_bot_packet(404, &encode_vehicle_enter_packet_for_test(vehicle_id))
+            .expect("bot vehicle enter should be accepted");
+        session.tick(1.0 / 60.0);
+
+        // The arena should now record the bot as the vehicle's driver, and
+        // `vehicle_of_player` should mirror that.
+        assert_eq!(
+            session.arena.vehicle_of_player.get(&404),
+            Some(&vehicle_id),
+            "bot should be seated in the vehicle after handle_bot_packet"
+        );
+        let seated_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("snapshot after bot entered vehicle");
+        let seated_vehicles = decode_snapshot_vehicle_states(&seated_snapshot);
+        let (_, seated_driver_id, _, _, _) = *seated_vehicles
+            .iter()
+            .find(|(id, _, _, _, _)| *id == vehicle_id)
+            .expect("seated vehicle should still be in the snapshot");
+        assert_eq!(
+            seated_driver_id, 404,
+            "snapshot driver_id should reflect the seated bot"
+        );
+
+        // Push a forward-throttle input bundle and tick for ~0.5 s of sim
+        // time. With `input_to_vehicle_cmd` driving the raycast vehicle,
+        // chassis-local forward (−Z) should translate the vehicle along
+        // world −Z (authored vehicle spawns unrotated in the demo world).
+        let frame = InputCmd {
+            seq: 1,
+            buttons: 0,
+            move_x: 0,
+            move_y: 127,
+            yaw: 0.0,
+            pitch: 0.0,
+        };
+        let bytes = encode_single_input_bundle(&frame);
+        session
+            .handle_bot_packet(404, &bytes)
+            .expect("bot input bundle should be accepted while driving");
+        for _ in 0..30 {
+            session.tick(1.0 / 60.0);
+        }
+        let driven_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .rev()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("snapshot after driving the vehicle");
+        let driven_vehicles = decode_snapshot_vehicle_states(&driven_snapshot);
+        let (_, _, end_px, _, end_pz) = *driven_vehicles
+            .iter()
+            .find(|(id, _, _, _, _)| *id == vehicle_id)
+            .expect("driven vehicle should still be in the snapshot");
+        let dx = (end_px - start_px).abs();
+        let dz = (end_pz - start_pz).abs();
+        assert!(
+            dx > 0 || dz > 0,
+            "bot-driven vehicle should have moved from its spawn after 30 forward ticks"
+        );
+
+        // Exit cleanly via `handle_bot_packet` and confirm the driver slot
+        // clears.
+        session
+            .handle_bot_packet(404, &encode_vehicle_exit_packet_for_test(vehicle_id))
+            .expect("bot vehicle exit should be accepted");
+        session.tick(1.0 / 60.0);
+        assert!(
+            !session.arena.vehicle_of_player.contains_key(&404),
+            "bot should no longer be seated after exit packet"
+        );
+        let exited_snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .expect("snapshot after bot exited");
+        let exited_vehicles = decode_snapshot_vehicle_states(&exited_snapshot);
+        let (_, exited_driver_id, _, _, _) = *exited_vehicles
+            .iter()
+            .find(|(id, _, _, _, _)| *id == vehicle_id)
+            .expect("exited vehicle should still be in the snapshot");
+        assert_eq!(
+            exited_driver_id, 0,
+            "vehicle should be unoccupied again after exit"
+        );
     }
 
     #[test]

--- a/shared/src/local_session.rs
+++ b/shared/src/local_session.rs
@@ -130,6 +130,24 @@ impl LocalPreviewSession {
         true
     }
 
+    /// Set (or clear) a bot's max horizontal move speed override (m/s).
+    /// Pass `None` to restore the default walk/sprint tiers. Returns true
+    /// if the id was a known bot. Refuses to touch the local player.
+    pub fn set_bot_max_speed(&mut self, bot_id: u32, max_speed: Option<f64>) -> bool {
+        if bot_id == LOCAL_PLAYER_ID {
+            return false;
+        }
+        let is_bot = self
+            .players
+            .get(&bot_id)
+            .map(|runtime| runtime.is_bot)
+            .unwrap_or(false);
+        if !is_bot {
+            return false;
+        }
+        self.arena.set_player_max_speed_override(bot_id, max_speed)
+    }
+
     /// Remove a bot from the arena. Returns true if the id was a known bot.
     pub fn disconnect_bot(&mut self, bot_id: u32) -> bool {
         if bot_id == LOCAL_PLAYER_ID {

--- a/shared/src/local_session.rs
+++ b/shared/src/local_session.rs
@@ -1,9 +1,10 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 use crate::{
     constants::{
-        HIT_ZONE_NONE, PKT_DEBUG_STATS, PKT_FIRE, PKT_INPUT_BUNDLE, PKT_PING, PKT_SHOT_RESULT,
-        PKT_SNAPSHOT, PKT_VEHICLE_ENTER, PKT_VEHICLE_EXIT, PKT_WELCOME,
+        FLAG_DEAD, HIT_ZONE_BODY, HIT_ZONE_HEAD, HIT_ZONE_NONE, PKT_DEBUG_STATS, PKT_FIRE,
+        PKT_INPUT_BUNDLE, PKT_PING, PKT_SHOT_RESULT, PKT_SNAPSHOT, PKT_VEHICLE_ENTER,
+        PKT_VEHICLE_EXIT, PKT_WELCOME,
     },
     local_arena::{MoveConfig, PhysicsArena},
     protocol::*,
@@ -12,15 +13,19 @@ use crate::{
     world_document::WorldDocument,
 };
 use bytes::{Buf, BufMut, BytesMut};
+use vibe_netcode::lag_comp::{classify_player_hitscan, HitZone};
 
 const SIM_HZ: u16 = 60;
 const SNAPSHOT_HZ: u16 = SIM_HZ;
 const MAX_PENDING_INPUTS: usize = 120;
-const LOCAL_PLAYER_ID: u32 = 1;
+pub const LOCAL_PLAYER_ID: u32 = 1;
 const LOCAL_RIFLE_INTERVAL_MS: u32 = 100;
 const PLAYER_EYE_HEIGHT_M: f32 = 0.8;
 const HITSCAN_MAX_DISTANCE: f32 = 1000.0;
 const DYNAMIC_BODY_IMPULSE: f32 = 6.0;
+const HITSCAN_BODY_DAMAGE: u8 = 25;
+const HITSCAN_HEAD_DAMAGE: u8 = 100;
+const BOT_RESPAWN_TICKS: u32 = 60 * 3; // 3 seconds
 
 #[derive(Default)]
 struct PlayerRuntime {
@@ -29,13 +34,21 @@ struct PlayerRuntime {
     last_received_input_seq: Option<u16>,
     last_ack_input_seq: u16,
     next_allowed_fire_ms: u32,
+    /// True when this runtime is for a bot (driven by the client-side
+    /// practice bot runtime). Bots have their own lifecycle — they don't
+    /// receive welcome packets and they're auto-respawned on death.
+    is_bot: bool,
+    /// Ticks remaining until respawn (only used for bots; 0 means alive).
+    respawn_cooldown_ticks: u32,
 }
 
 pub struct LocalPreviewSession {
     arena: PhysicsArena,
     connected: bool,
-    player: PlayerRuntime,
-    queued_shots: Vec<FireCmd>,
+    /// Per-player runtime state. The human player (if connected) lives at
+    /// key {@link LOCAL_PLAYER_ID}; bots live at ids >= {@link BOT_ID_BASE}.
+    players: HashMap<u32, PlayerRuntime>,
+    queued_shots: Vec<(u32, FireCmd)>,
     outbound_packets: Vec<Vec<u8>>,
     server_tick: u32,
 }
@@ -60,7 +73,7 @@ impl LocalPreviewSession {
         Ok(Self {
             arena,
             connected: false,
-            player: PlayerRuntime::default(),
+            players: HashMap::new(),
             queued_shots: Vec::new(),
             outbound_packets: Vec::new(),
             server_tick: 0,
@@ -73,7 +86,7 @@ impl LocalPreviewSession {
         }
 
         self.connected = true;
-        self.player = PlayerRuntime::default();
+        self.players.insert(LOCAL_PLAYER_ID, PlayerRuntime::default());
         self.arena.spawn_player(LOCAL_PLAYER_ID);
 
         let server_time_us = self.server_time_us();
@@ -93,9 +106,78 @@ impl LocalPreviewSession {
         }
         self.connected = false;
         self.queued_shots.clear();
-        self.player = PlayerRuntime::default();
+        // Tear down every player (human + bots) so the arena is clean if
+        // the session is reused.
+        let ids: Vec<u32> = self.players.keys().copied().collect();
+        for id in ids {
+            self.arena.remove_player(id);
+        }
+        self.players.clear();
         self.outbound_packets.clear();
-        self.arena.remove_player(LOCAL_PLAYER_ID);
+    }
+
+    /// Spawn a bot as a first-class player in the arena. Returns true if the
+    /// bot was added (false if the id already existed or the session is not
+    /// connected).
+    pub fn connect_bot(&mut self, bot_id: u32) -> bool {
+        if !self.connected || bot_id == LOCAL_PLAYER_ID || self.players.contains_key(&bot_id) {
+            return false;
+        }
+        let mut runtime = PlayerRuntime::default();
+        runtime.is_bot = true;
+        self.players.insert(bot_id, runtime);
+        self.arena.spawn_player(bot_id);
+        true
+    }
+
+    /// Remove a bot from the arena. Returns true if the id was a known bot.
+    pub fn disconnect_bot(&mut self, bot_id: u32) -> bool {
+        if bot_id == LOCAL_PLAYER_ID {
+            return false;
+        }
+        let Some(runtime) = self.players.remove(&bot_id) else {
+            return false;
+        };
+        if !runtime.is_bot {
+            // Put it back; we only disconnect bots through this path.
+            self.players.insert(bot_id, runtime);
+            return false;
+        }
+        self.arena.remove_player(bot_id);
+        true
+    }
+
+    /// Push a bot's input packet (same wire format as the human client's
+    /// input bundle). Shots/vehicle packets are not supported for bots in
+    /// v1 — they route to the `handle_client_packet` path of the human.
+    pub fn handle_bot_packet(&mut self, bot_id: u32, bytes: &[u8]) -> Result<(), String> {
+        if bot_id == LOCAL_PLAYER_ID {
+            return Err("cannot push bot input for local player id".to_string());
+        }
+        let Some(runtime) = self.players.get_mut(&bot_id) else {
+            return Err(format!("unknown bot id {bot_id}"));
+        };
+        if !runtime.is_bot {
+            return Err(format!("player {bot_id} is not a bot"));
+        }
+        if bytes.is_empty() {
+            return Err("empty bot packet".to_string());
+        }
+        let mut buf = bytes;
+        let kind = buf.get_u8();
+        match kind {
+            PKT_INPUT_BUNDLE => {
+                let frames = decode_input_bundle_frames(&mut buf)?;
+                enqueue_inputs(runtime, frames);
+                Ok(())
+            }
+            PKT_FIRE => {
+                let shot = decode_fire_cmd(&mut buf)?;
+                self.queued_shots.push((bot_id, shot));
+                Ok(())
+            }
+            other => Err(format!("unsupported bot packet kind {other}")),
+        }
     }
 
     pub fn handle_client_packet(&mut self, bytes: &[u8]) -> Result<(), String> {
@@ -111,10 +193,14 @@ impl LocalPreviewSession {
         match kind {
             PKT_INPUT_BUNDLE => {
                 let frames = decode_input_bundle_frames(&mut buf)?;
-                enqueue_inputs(&mut self.player, frames);
+                let Some(runtime) = self.players.get_mut(&LOCAL_PLAYER_ID) else {
+                    return Ok(());
+                };
+                enqueue_inputs(runtime, frames);
             }
             PKT_FIRE => {
-                self.queued_shots.push(decode_fire_cmd(&mut buf)?);
+                self.queued_shots
+                    .push((LOCAL_PLAYER_ID, decode_fire_cmd(&mut buf)?));
             }
             PKT_VEHICLE_ENTER => {
                 let vehicle_id = decode_vehicle_enter(&mut buf)?;
@@ -142,8 +228,36 @@ impl LocalPreviewSession {
         self.server_tick += 1;
         let server_time_ms = self.server_time_ms();
 
-        let input = take_input_for_tick(&mut self.player);
-        self.arena.simulate_player_tick(LOCAL_PLAYER_ID, &input, dt);
+        // Drive each connected player's KCC for this tick. The iteration
+        // order doesn't matter for correctness since the arena is a shared
+        // physics world and each player is a kinematic capsule.
+        let player_ids: Vec<u32> = self.players.keys().copied().collect();
+        for id in player_ids {
+            // Bot respawn handling: tick cooldown, then respawn in place
+            // when it reaches zero. We skip input processing while dead.
+            let mut skip_sim = false;
+            if let Some(runtime) = self.players.get_mut(&id) {
+                if runtime.is_bot && runtime.respawn_cooldown_ticks > 0 {
+                    runtime.respawn_cooldown_ticks -= 1;
+                    if runtime.respawn_cooldown_ticks == 0 {
+                        self.arena.respawn_player(id);
+                    } else {
+                        skip_sim = true;
+                    }
+                }
+            }
+            if skip_sim {
+                continue;
+            }
+            let input = {
+                let Some(runtime) = self.players.get_mut(&id) else {
+                    continue;
+                };
+                take_input_for_tick(runtime)
+            };
+            self.arena.simulate_player_tick(id, &input, dt);
+        }
+
         self.arena.step_vehicles(dt);
         self.arena.step_dynamics(dt);
         self.process_hitscan(server_time_ms);
@@ -170,18 +284,20 @@ impl LocalPreviewSession {
 
     fn process_hitscan(&mut self, server_time_ms: u32) {
         let shots = std::mem::take(&mut self.queued_shots);
-        for shot in shots {
-            if self.player.next_allowed_fire_ms > server_time_ms {
+        for (shooter_id, shot) in shots {
+            let Some(shooter) = self.players.get_mut(&shooter_id) else {
+                continue;
+            };
+            if shooter.next_allowed_fire_ms > server_time_ms {
                 continue;
             }
-            self.player.next_allowed_fire_ms =
-                server_time_ms.saturating_add(LOCAL_RIFLE_INTERVAL_MS);
+            shooter.next_allowed_fire_ms = server_time_ms.saturating_add(LOCAL_RIFLE_INTERVAL_MS);
 
-            if self.arena.vehicle_of_player.contains_key(&LOCAL_PLAYER_ID) {
+            if self.arena.vehicle_of_player.contains_key(&shooter_id) {
                 continue;
             }
             let Some((pos, _vel, _yaw, _pitch, hp, _flags)) =
-                self.arena.snapshot_player(LOCAL_PLAYER_ID)
+                self.arena.snapshot_player(shooter_id)
             else {
                 continue;
             };
@@ -194,19 +310,47 @@ impl LocalPreviewSession {
                 origin,
                 shot.dir,
                 HITSCAN_MAX_DISTANCE,
-                Some(LOCAL_PLAYER_ID),
+                Some(shooter_id),
             );
             let dynamic_hit = self.arena.cast_dynamic_body_ray(
                 origin,
                 shot.dir,
                 HITSCAN_MAX_DISTANCE,
-                Some(LOCAL_PLAYER_ID),
+                Some(shooter_id),
             );
+            let player_hit = self.cast_player_hitscan(shooter_id, origin, shot.dir);
 
-            let result = if let Some((dynamic_body_id, dynamic_toi, normal)) = dynamic_hit {
-                if world_toi.map(|world| world < dynamic_toi).unwrap_or(false) {
-                    make_shot_result(shot.shot_id, shot.weapon)
-                } else {
+            // Find the nearest obstacle between the shooter and any candidate
+            // target (wall, dynamic body, or player).
+            let nearest_toi = [
+                world_toi,
+                dynamic_hit.map(|(_, toi, _)| toi),
+                player_hit.map(|(_, toi, _)| toi),
+            ]
+            .into_iter()
+            .flatten()
+            .fold(f32::MAX, f32::min);
+
+            let mut result = make_shot_result(shot.shot_id, shot.weapon);
+
+            // Resolve player hit first — they deal damage and are the only
+            // target that fills hit_player_id.
+            if let Some((victim_id, toi, zone)) = player_hit {
+                if toi <= nearest_toi + 1e-3 {
+                    result.confirmed = true;
+                    result.hit_player_id = victim_id;
+                    result.hit_zone = match zone {
+                        HitZone::Head => HIT_ZONE_HEAD,
+                        HitZone::Body => HIT_ZONE_BODY,
+                    };
+                    let damage = match zone {
+                        HitZone::Head => HITSCAN_HEAD_DAMAGE,
+                        HitZone::Body => HITSCAN_BODY_DAMAGE,
+                    };
+                    self.apply_damage(victim_id, damage);
+                }
+            } else if let Some((dynamic_body_id, dynamic_toi, normal)) = dynamic_hit {
+                if world_toi.map(|world| world >= dynamic_toi).unwrap_or(true) {
                     let impact_point = [
                         origin[0] + shot.dir[0] * dynamic_toi,
                         origin[1] + shot.dir[1] * dynamic_toi,
@@ -222,19 +366,79 @@ impl LocalPreviewSession {
                         impulse,
                         impact_point,
                     );
-                    make_shot_result(shot.shot_id, shot.weapon)
                 }
-            } else {
-                make_shot_result(shot.shot_id, shot.weapon)
-            };
+            }
 
             self.outbound_packets
                 .push(encode_shot_result_packet(&result));
         }
     }
 
+    /// Casts a ray from `shooter_id`'s muzzle through every other connected
+    /// player's capsule/head pair and returns the nearest hit's (victim id,
+    /// time-of-impact, hit zone). Returns None if no player is intersected.
+    fn cast_player_hitscan(
+        &self,
+        shooter_id: u32,
+        origin: [f32; 3],
+        dir: [f32; 3],
+    ) -> Option<(u32, f32, HitZone)> {
+        let capsule_half_segment = self.arena.config().capsule_half_segment;
+        let capsule_radius = self.arena.config().capsule_radius;
+        let mut best: Option<(u32, f32, HitZone)> = None;
+        for &victim_id in self.players.keys() {
+            if victim_id == shooter_id {
+                continue;
+            }
+            let Some((pos, _vel, _yaw, _pitch, hp, flags)) =
+                self.arena.snapshot_player(victim_id)
+            else {
+                continue;
+            };
+            if hp == 0 || (flags & FLAG_DEAD) != 0 {
+                continue;
+            }
+            let Some(hit) = classify_player_hitscan(
+                origin,
+                dir,
+                pos,
+                capsule_half_segment,
+                capsule_radius,
+                None,
+            ) else {
+                continue;
+            };
+            if hit.distance > HITSCAN_MAX_DISTANCE {
+                continue;
+            }
+            if best
+                .map(|(_, toi, _)| hit.distance < toi)
+                .unwrap_or(true)
+            {
+                best = Some((victim_id, hit.distance, hit.zone));
+            }
+        }
+        best
+    }
+
+    fn apply_damage(&mut self, victim_id: u32, damage: u8) {
+        let is_bot = self
+            .players
+            .get(&victim_id)
+            .map(|runtime| runtime.is_bot)
+            .unwrap_or(false);
+        let died = self.arena.apply_player_damage(victim_id, damage);
+        if died && is_bot {
+            if let Some(runtime) = self.players.get_mut(&victim_id) {
+                runtime.respawn_cooldown_ticks = BOT_RESPAWN_TICKS;
+            }
+        }
+    }
+
     fn build_snapshot_packet(&self) -> Vec<u8> {
         let mut player_states = Vec::new();
+        // The human player goes first so the client's self-resolution logic
+        // (which matches on id) finds it quickly. Bots follow in any order.
         if let Some((pos, vel, yaw, pitch, hp, flags)) = self.arena.snapshot_player(LOCAL_PLAYER_ID)
         {
             player_states.push(make_net_player_state(
@@ -247,6 +451,14 @@ impl LocalPreviewSession {
                 flags,
             ));
         }
+        for (&id, _) in &self.players {
+            if id == LOCAL_PLAYER_ID {
+                continue;
+            }
+            if let Some((pos, vel, yaw, pitch, hp, flags)) = self.arena.snapshot_player(id) {
+                player_states.push(make_net_player_state(id, pos, vel, yaw, pitch, hp, flags));
+            }
+        }
 
         let dynamic_body_states = self
             .arena
@@ -258,10 +470,16 @@ impl LocalPreviewSession {
             .collect();
         let vehicle_states = self.arena.snapshot_vehicles();
 
+        let ack_input_seq = self
+            .players
+            .get(&LOCAL_PLAYER_ID)
+            .map(|runtime| runtime.last_ack_input_seq)
+            .unwrap_or(0);
+
         encode_snapshot_packet(&SnapshotPacket {
             server_time_us: self.server_time_us(),
             server_tick: self.server_tick,
-            ack_input_seq: self.player.last_ack_input_seq,
+            ack_input_seq,
             player_states,
             projectile_states: Vec::new(),
             dynamic_body_states,
@@ -627,5 +845,97 @@ mod tests {
             latest_driver_id, LOCAL_PLAYER_ID,
             "local preview vehicle should be driven by the local player after enter"
         );
+    }
+
+    fn decode_snapshot_player_ids(bytes: &[u8]) -> Vec<u32> {
+        let mut buf = bytes;
+        assert_eq!(buf.get_u8(), PKT_SNAPSHOT);
+        let _server_time = buf.get_u64_le();
+        let _server_tick = buf.get_u32_le();
+        let _ack = buf.get_u16_le();
+        let player_count = buf.get_u16_le() as usize;
+        let _projectile_count = buf.get_u16_le() as usize;
+        let _dynamic_count = buf.get_u16_le() as usize;
+        let _vehicle_count = buf.get_u16_le() as usize;
+        let mut ids = Vec::with_capacity(player_count);
+        for _ in 0..player_count {
+            ids.push(buf.get_u32_le());
+            buf.advance(25);
+        }
+        ids
+    }
+
+    #[test]
+    fn connect_bot_spawns_extra_player_state() {
+        let mut session = LocalPreviewSession::new();
+        session.connect();
+        let _ = session.drain_packets();
+
+        assert!(session.connect_bot(101));
+        // duplicate id: rejected
+        assert!(!session.connect_bot(101));
+        // disallow using the local player id
+        assert!(!session.connect_bot(LOCAL_PLAYER_ID));
+
+        session.tick(1.0 / 60.0);
+        let snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .unwrap();
+        let ids = decode_snapshot_player_ids(&snapshot);
+        assert!(ids.contains(&LOCAL_PLAYER_ID));
+        assert!(ids.contains(&101));
+        assert_eq!(ids.len(), 2);
+    }
+
+    #[test]
+    fn bot_input_drives_its_own_kcc() {
+        let mut session = LocalPreviewSession::new();
+        session.connect();
+        let _ = session.drain_packets();
+        assert!(session.connect_bot(202));
+
+        // Push a forward-walking input for the bot and tick a handful of
+        // frames so the KCC integrates position.
+        let frame = InputCmd {
+            seq: 1,
+            buttons: crate::constants::BTN_FORWARD,
+            move_x: 0,
+            move_y: 127,
+            yaw: 0.0,
+            pitch: 0.0,
+        };
+        let bytes = encode_single_input_bundle(&frame);
+        session.handle_bot_packet(202, &bytes).unwrap();
+        let start = session.arena.snapshot_player(202).unwrap().0;
+        for _ in 0..10 {
+            session.tick(1.0 / 60.0);
+        }
+        let after = session.arena.snapshot_player(202).unwrap().0;
+        let dz = (after[2] - start[2]).abs();
+        assert!(dz > 0.0, "bot should have moved after 10 ticks of forward input");
+    }
+
+    #[test]
+    fn disconnect_bot_removes_it_from_snapshots() {
+        let mut session = LocalPreviewSession::new();
+        session.connect();
+        let _ = session.drain_packets();
+        assert!(session.connect_bot(303));
+        assert!(session.disconnect_bot(303));
+        // Cannot disconnect twice.
+        assert!(!session.disconnect_bot(303));
+        // Cannot disconnect the local player via this path.
+        assert!(!session.disconnect_bot(LOCAL_PLAYER_ID));
+
+        session.tick(1.0 / 60.0);
+        let snapshot = session
+            .drain_packets()
+            .into_iter()
+            .find(|pkt| pkt[0] == PKT_SNAPSHOT)
+            .unwrap();
+        let ids = decode_snapshot_player_ids(&snapshot);
+        assert!(!ids.contains(&303));
     }
 }

--- a/shared/src/simulation.rs
+++ b/shared/src/simulation.rs
@@ -95,6 +95,7 @@ fn update_player_motion(
     on_ground: &mut bool,
     input: &InputCmd,
     dt: f32,
+    max_speed_override: Option<f64>,
 ) {
     let cfg = &sim.config;
     let dt64 = dt as f64;
@@ -103,7 +104,11 @@ fn update_player_motion(
     *pitch = (input.pitch as f64).clamp(-1.55, 1.55);
 
     let wish = build_wish_dir(input, *yaw);
-    let max_speed = pick_move_speed(cfg, input.buttons);
+    // Per-player override replaces the walk/sprint tier the KCC would have
+    // picked. Used by practice-mode bots so their speed is a continuous
+    // dial instead of a walk-or-sprint toggle.
+    let max_speed = max_speed_override
+        .unwrap_or_else(|| pick_move_speed(cfg, input.buttons));
 
     apply_horizontal_friction(velocity, cfg.friction, dt64, *on_ground);
     accelerate(
@@ -421,6 +426,7 @@ pub fn simulate_player_tick(
     on_ground: &mut bool,
     input: &InputCmd,
     dt: f32,
+    max_speed_override: Option<f64>,
 ) -> PlayerTickResult {
     simulate_player_tick_with_mode(
         sim,
@@ -433,6 +439,7 @@ pub fn simulate_player_tick(
         input,
         dt,
         PlayerKccMode::TwoPass,
+        max_speed_override,
     )
 }
 
@@ -447,11 +454,21 @@ pub fn simulate_player_tick_with_mode(
     input: &InputCmd,
     dt: f32,
     kcc_mode: PlayerKccMode,
+    max_speed_override: Option<f64>,
 ) -> PlayerTickResult {
     let mut result = PlayerTickResult::default();
 
     let move_math_started = now_marker();
-    update_player_motion(sim, velocity, yaw, pitch, on_ground, input, dt);
+    update_player_motion(
+        sim,
+        velocity,
+        yaw,
+        pitch,
+        on_ground,
+        input,
+        dt,
+        max_speed_override,
+    );
     result.timings.move_math_ms = elapsed_ms(move_math_started);
 
     let start_position = *position;
@@ -633,7 +650,7 @@ mod tests {
         input: &InputCmd,
         dt: f32,
     ) {
-        simulate_player_tick(sim, collider, pos, vel, yaw, pitch, on_ground, input, dt);
+        simulate_player_tick(sim, collider, pos, vel, yaw, pitch, on_ground, input, dt, None);
         sim.sync_player_collider(collider, pos);
     }
 
@@ -683,6 +700,87 @@ mod tests {
     }
 
     #[test]
+    fn max_speed_override_caps_horizontal_velocity() {
+        // Sanity-check: with no override and a full-forward input, the KCC
+        // settles to walk_speed. With Some(2.0), it settles near 2.0.
+        let mut sim = sim_with_ground();
+        let walk_speed = sim.config.walk_speed;
+        let mut pos = Vec3d::new(0.0, 2.0, 0.0);
+        let mut vel = Vec3d::zeros();
+        let mut yaw = 0.0;
+        let mut pitch = 0.0;
+        let mut on_ground = false;
+        let collider = sim.create_player_collider(pos, 1);
+        sim.rebuild_broad_phase();
+
+        // Settle onto the ground.
+        let idle = input();
+        for _ in 0..60 {
+            simulate_player_tick(
+                &sim,
+                collider,
+                &mut pos,
+                &mut vel,
+                &mut yaw,
+                &mut pitch,
+                &mut on_ground,
+                &idle,
+                1.0 / 60.0,
+                None,
+            );
+            sim.sync_player_collider(collider, &pos);
+        }
+        assert!(on_ground);
+
+        // No override: accelerates toward walk_speed.
+        let mut fwd = input();
+        fwd.move_y = 127;
+        for _ in 0..60 {
+            simulate_player_tick(
+                &sim,
+                collider,
+                &mut pos,
+                &mut vel,
+                &mut yaw,
+                &mut pitch,
+                &mut on_ground,
+                &fwd,
+                1.0 / 60.0,
+                None,
+            );
+            sim.sync_player_collider(collider, &pos);
+        }
+        let planar_no_override = (vel.x * vel.x + vel.z * vel.z).sqrt();
+        assert!(
+            (planar_no_override - walk_speed).abs() < 0.5,
+            "default run should approach walk_speed ({walk_speed}), got {planar_no_override}"
+        );
+
+        // Reset and run with an override of 2.0 m/s.
+        vel = Vec3d::zeros();
+        for _ in 0..120 {
+            simulate_player_tick(
+                &sim,
+                collider,
+                &mut pos,
+                &mut vel,
+                &mut yaw,
+                &mut pitch,
+                &mut on_ground,
+                &fwd,
+                1.0 / 60.0,
+                Some(2.0),
+            );
+            sim.sync_player_collider(collider, &pos);
+        }
+        let planar_override = (vel.x * vel.x + vel.z * vel.z).sqrt();
+        assert!(
+            (planar_override - 2.0).abs() < 0.3,
+            "override should cap horizontal velocity near 2.0 m/s, got {planar_override}"
+        );
+    }
+
+    #[test]
     fn one_pass_without_dynamic_support_skips_support_probe() {
         let mut sim = sim_with_ground();
         let mut pos = Vec3d::new(0.0, 2.0, 0.0);
@@ -705,6 +803,7 @@ mod tests {
                 &input(),
                 1.0 / 60.0,
                 PlayerKccMode::OnePassSupportPredicate,
+                None,
             );
             sim.sync_player_collider(collider, &pos);
         }
@@ -720,6 +819,7 @@ mod tests {
             &input(),
             1.0 / 60.0,
             PlayerKccMode::OnePassSupportPredicate,
+            None,
         );
 
         assert!(on_ground, "player should remain grounded on static floor");

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -1336,6 +1336,31 @@ impl WasmLocalSession {
             .map_err(|err| JsValue::from_str(&err))
     }
 
+    /// Spawn a bot as a first-class player in this local session. Returns
+    /// `true` if the bot was spawned (`false` if the id is already taken or
+    /// the session isn't connected yet).
+    #[wasm_bindgen(js_name = connectBot)]
+    pub fn connect_bot(&mut self, bot_id: u32) -> bool {
+        self.inner.connect_bot(bot_id)
+    }
+
+    /// Remove a previously spawned bot. Returns `true` if the id was a
+    /// known bot.
+    #[wasm_bindgen(js_name = disconnectBot)]
+    pub fn disconnect_bot(&mut self, bot_id: u32) -> bool {
+        self.inner.disconnect_bot(bot_id)
+    }
+
+    /// Push an input or fire packet authored for a bot (same wire format as
+    /// the human client's `handleClientPacket`, but routed to the bot's
+    /// PlayerRuntime).
+    #[wasm_bindgen(js_name = handleBotPacket)]
+    pub fn handle_bot_packet(&mut self, bot_id: u32, bytes: &[u8]) -> Result<(), JsValue> {
+        self.inner
+            .handle_bot_packet(bot_id, bytes)
+            .map_err(|err| JsValue::from_str(&err))
+    }
+
     pub fn tick(&mut self, dt: f32) {
         self.inner.tick(dt);
     }

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -286,6 +286,7 @@ impl WasmSimWorld {
             &mut self.on_ground,
             &input,
             dt,
+            None,
         );
         for impulse in &tick.dynamic_impulses {
             let _ = self.apply_dynamic_body_impulse(
@@ -426,6 +427,7 @@ impl WasmSimWorld {
                 &mut self.on_ground,
                 input,
                 dt,
+                None,
             );
             for impulse in &tick.dynamic_impulses {
                 let _ = self.apply_dynamic_body_impulse(
@@ -1359,6 +1361,18 @@ impl WasmLocalSession {
         self.inner
             .handle_bot_packet(bot_id, bytes)
             .map_err(|err| JsValue::from_str(&err))
+    }
+
+    /// Override the bot's max horizontal move speed (m/s). Pass a negative
+    /// value to clear the override and restore the walk/sprint tiers.
+    #[wasm_bindgen(js_name = setBotMaxSpeed)]
+    pub fn set_bot_max_speed(&mut self, bot_id: u32, max_speed: f64) -> bool {
+        let override_value = if max_speed.is_finite() && max_speed >= 0.0 {
+            Some(max_speed)
+        } else {
+            None
+        };
+        self.inner.set_bot_max_speed(bot_id, override_value)
     }
 
     pub fn tick(&mut self, dt: f32) {

--- a/vercel.json
+++ b/vercel.json
@@ -68,6 +68,15 @@
           "value": "public, max-age=0, must-revalidate"
         }
       ]
+    },
+    {
+      "source": "/godmode",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary

This PR adds a complete vehicle driving system to practice bots, including a walk-vs-drive planner that intelligently chooses between foot and vehicle travel modes based on distance and terrain. Bots can now reserve vehicles, drive them using steering commands, and exit when reaching their destination.

## Key Changes

- **Vehicle FSM per bot**: Added a state machine (`VehicleFsmStage`) that manages bot transitions through `on_foot` → `walking_to_vehicle` → `entering_vehicle` → `driving` → `exiting_vehicle` states, with proper cleanup and timeout handling.

- **Walk-vs-drive planner**: Implemented cost comparison logic that estimates travel time on both foot and vehicle navmeshes, choosing the faster route. Short trips (<15m) default to walking to avoid overhead.

- **Vehicle-sized navmesh**: Added `buildVehicleBotNavMesh()` that creates a second navmesh with inflated agent radius (`VehicleProfile.agentRadius`) to automatically exclude narrow passages vehicles can't traverse.

- **Turn-aware pathfinding**: Implemented `createVehicleQueryFilter()` with `computeTurnAwareCost()` that penalizes sharp corners based on the vehicle's turning radius, preventing unrealistic paths through tight angles.

- **Vehicle steering**: Added `vehicleAgentStateToIntent()` that converts crowd-planned velocities into discrete drive commands (forward/reverse/left/right buttons) by rotating desired velocity into chassis-local coordinates.

- **Vehicle reservation system**: Prevents multiple bots from racing for the same vehicle using a `reservedVehicles` map keyed by vehicle ID.

- **Dual crowd management**: Maintains separate foot and vehicle crowds with lazy initialization of the vehicle crowd on first enable via `setUseVehicles()`.

- **Server integration**: Extended `LocalPreviewSession::handle_bot_packet()` to route `PKT_VEHICLE_ENTER` and `PKT_VEHICLE_EXIT` packets through `arena.enter_vehicle()` / `arena.exit_vehicle()`.

- **UI controls**: Added `onSetUseVehicles` callback to `PracticeBotPanel` for toggling vehicle mode and updated stats display to show vehicle navmesh triangle count.

## Notable Implementation Details

- Vehicle FSM runs every tick and can transition at most once per frame, with `fsmTicks` counter for timeout-based state resets.
- Self-driven vehicles are excluded from foot-crowd obstacle syncing to prevent the bot's own chassis from distorting walk-vs-drive cost comparisons for peer bots.
- Vehicle crowd agents are synced to vehicle chassis positions (not player positions) during the driving stage.
- `DEFAULT_VEHICLE_PROFILE` provides conservative defaults (5m turning radius, 12 m/s cruise speed) tuned for the stock Rapier raycast car.
- All vehicle-related state is cleanly reset when `setUseVehicles(false)` is called or the session disconnects.

https://claude.ai/code/session_01VmjFtZuEtDr7Hf1mtx1j3E