### PR TITLE
Sync player position to vehicle chassis during driving

### DIFF
--- a/client/src/physics/predictionManager.ts
+++ b/client/src/physics/predictionManager.ts
@@ -219,6 +219,23 @@ export class PredictionManager {
     return [p[0], p[1], p[2]];
   }
 
+  /**
+   * Resync the visual interpolation state from the current WASM sim
+   * position. Called after vehicle exit: while driving, `update()` is
+   * skipped so `prevPosition` / `currPosition` / `accumulator` stay frozen
+   * at entry-time values. After `clearLocalVehicle` has applied the
+   * post-exit offset on the WASM side, this refreshes the JS state so the
+   * next camera frame reads the new position rather than the stale one.
+   */
+  resyncFromSim(): void {
+    if (!this.initialized) return;
+    const p = this.sim.getPosition();
+    this.currPosition = [p[0], p[1], p[2]];
+    this.prevPosition = [p[0], p[1], p[2]];
+    this.correctionOffset = [0, 0, 0];
+    this.accumulator = 0;
+  }
+
   getCorrectionOffset(): [number, number, number] {
     return [...this.correctionOffset] as [number, number, number];
   }

--- a/client/src/physics/usePrediction.ts
+++ b/client/src/physics/usePrediction.ts
@@ -302,6 +302,11 @@ export function usePredictionWithWorld(
     if (!vm) return;
     managerRef.current?.setNextSeq(vm.getNextSeq());
     vm.exitVehicle();
+    // vm.exitVehicle() -> sim.clearLocalVehicle() has applied the post-exit
+    // offset on the WASM side; refresh JS interpolation state so the next
+    // camera frame reads the new position rather than the stale pre-entry
+    // one (update() is skipped while driving, so currPosition is stale).
+    managerRef.current?.resyncFromSim();
   }, []);
 
   const updateVehicle = useCallback((

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -681,9 +681,7 @@ export function GameWorld({
     if (resolvedInput.interactPressed) {
       if (isDrivingNow) {
         // Exit current vehicle
-        const vehiclePose = prediction.getVehiclePose();
         prediction.exitVehicle();
-        void vehiclePose; // suppress unused warning
         // Notify server — find which vehicle we're in
         if (client) {
           for (const [id, vs] of client.vehicles) {

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -65,7 +65,6 @@ const LOCAL_VEHICLE_RENDER_PLANAR_RATE = 40.0;
 const LOCAL_VEHICLE_RENDER_VERTICAL_RATE = 12.0;
 const LOCAL_VEHICLE_RENDER_YAW_RATE = 24.0;
 const LOCAL_VEHICLE_RENDER_TILT_RATE = 10.0;
-
 type FrameDebugCallback = (
   frameTimeMs: number,
   rendererInfo: { render: { calls: number; triangles: number }; memory: { geometries: number; textures: number } },

--- a/server/src/movement.rs
+++ b/server/src/movement.rs
@@ -194,33 +194,35 @@ impl PhysicsArena {
             return None;
         }
 
-        let Some(state) = self.players.get_mut(&player_id) else {
-            return None;
+        let mut tick_result = {
+            let Some(state) = self.players.get_mut(&player_id) else {
+                return None;
+            };
+            if state.dead {
+                state.last_input = InputCmd::default();
+                state.velocity = Vec3d::zeros();
+                return None;
+            }
+            state.last_input = input.clone();
+            let mut tick_result = simulate_player_tick_with_mode(
+                &self.dynamic.sim,
+                state.collider,
+                &mut state.position,
+                &mut state.velocity,
+                &mut state.yaw,
+                &mut state.pitch,
+                &mut state.on_ground,
+                input,
+                dt,
+                self.player_kcc_mode,
+            );
+            let sync_started = Instant::now();
+            self.dynamic
+                .sim
+                .sync_player_collider(state.collider, &state.position);
+            tick_result.timings.collider_sync_ms = sync_started.elapsed().as_secs_f32() * 1000.0;
+            tick_result
         };
-        if state.dead {
-            state.last_input = InputCmd::default();
-            state.velocity = Vec3d::zeros();
-            return None;
-        }
-        state.last_input = input.clone();
-
-        let mut tick_result = simulate_player_tick_with_mode(
-            &self.dynamic.sim,
-            state.collider,
-            &mut state.position,
-            &mut state.velocity,
-            &mut state.yaw,
-            &mut state.pitch,
-            &mut state.on_ground,
-            input,
-            dt,
-            self.player_kcc_mode,
-        );
-        let sync_started = Instant::now();
-        self.dynamic
-            .sim
-            .sync_player_collider(state.collider, &state.position);
-        tick_result.timings.collider_sync_ms = sync_started.elapsed().as_secs_f32() * 1000.0;
 
         let impulse_started = Instant::now();
         let mut impulses_applied_count = 0usize;

--- a/server/src/movement.rs
+++ b/server/src/movement.rs
@@ -169,10 +169,27 @@ impl PhysicsArena {
         input: &InputCmd,
         dt: f32,
     ) -> Option<PlayerTickResult> {
-        // Players driving a vehicle don't move independently — store input for vehicle use.
-        if self.vehicle_of_player.contains_key(&player_id) {
+        // Players driving a vehicle don't move independently. Store the input
+        // (consumed by step_vehicles) and continuously sync the player's
+        // position to the chassis so any system reading state.position
+        // (bots, AI, snapshot_player, stats, debug overlays) sees the real
+        // location rather than the stale pre-entry pose.
+        if let Some(&vehicle_id) = self.vehicle_of_player.get(&player_id) {
             if let Some(state) = self.players.get_mut(&player_id) {
                 state.last_input = input.clone();
+            }
+            if let Some(vehicle) = self.vehicles.get(&vehicle_id) {
+                if let Some(rb) = self.dynamic.sim.rigid_bodies.get(vehicle.chassis_body) {
+                    let p = *rb.translation();
+                    if let Some(state) = self.players.get_mut(&player_id) {
+                        state.position = Vec3d::new(p.x as f64, p.y as f64, p.z as f64);
+                        state.velocity = Vec3d::zeros();
+                        state.on_ground = false;
+                        let collider = state.collider;
+                        let position = state.position;
+                        self.dynamic.sim.sync_player_collider(collider, &position);
+                    }
+                }
             }
             return None;
         }
@@ -235,24 +252,11 @@ impl PhysicsArena {
         if state.dead {
             flags |= FLAG_DEAD;
         }
-
-        // When driving, report chassis position so client can keep player in vehicle.
-        if let Some(&vehicle_id) = self.vehicle_of_player.get(&player_id) {
+        // `state.position` is continuously synced to the chassis while the
+        // player is driving (see `simulate_player_tick`), so no special case
+        // is needed here — just tag the flag so clients know.
+        if self.vehicle_of_player.contains_key(&player_id) {
             flags |= FLAG_IN_VEHICLE;
-            if let Some(vehicle) = self.vehicles.get(&vehicle_id) {
-                if let Some(rb) = self.dynamic.sim.rigid_bodies.get(vehicle.chassis_body) {
-                    let p = rb.translation();
-                    let v = rb.linvel();
-                    return Some((
-                        [p.x, p.y, p.z],
-                        [v.x, v.y, v.z],
-                        state.yaw as f32,
-                        state.pitch as f32,
-                        state.hp,
-                        flags,
-                    ));
-                }
-            }
         }
 
         Some((
@@ -584,22 +588,22 @@ impl PhysicsArena {
 
     /// Remove `player_id` from their current vehicle.
     pub fn exit_vehicle(&mut self, player_id: u32) {
-        if let Some(vehicle_id) = self.detach_player_from_vehicles(player_id) {
-            if let Some(vehicle) = self.vehicles.get_mut(&vehicle_id) {
-                // Teleport player 2.5 m to the right of the chassis.
-                if let Some(rb) = self.dynamic.sim.rigid_bodies.get(vehicle.chassis_body) {
-                    let p = *rb.translation();
-                    if let Some(state) = self.players.get_mut(&player_id) {
-                        state.position =
-                            Vec3d::new((p.x + 2.5) as f64, (p.y + 1.0) as f64, p.z as f64);
-                        if let Some(c) = self.dynamic.sim.colliders.get_mut(state.collider) {
-                            c.set_collision_groups(InteractionGroups::all());
-                        }
-                        self.dynamic
-                            .sim
-                            .sync_player_collider(state.collider, &state.position);
-                    }
+        if self.detach_player_from_vehicles(player_id).is_some() {
+            if let Some(state) = self.players.get_mut(&player_id) {
+                // state.position is already the chassis center (kept in sync
+                // every tick by simulate_player_tick's driving branch).
+                // Offset to place the player beside the vehicle instead of
+                // inside the chassis collider.
+                state.position.x += 2.5;
+                state.position.y += 1.0;
+                state.velocity = Vec3d::zeros();
+                state.on_ground = false;
+                if let Some(c) = self.dynamic.sim.colliders.get_mut(state.collider) {
+                    c.set_collision_groups(InteractionGroups::all());
                 }
+                let collider = state.collider;
+                let position = state.position;
+                self.dynamic.sim.sync_player_collider(collider, &position);
             }
         }
     }

--- a/shared/src/local_arena.rs
+++ b/shared/src/local_arena.rs
@@ -182,9 +182,27 @@ impl PhysicsArena {
         input: &InputCmd,
         dt: f32,
     ) -> Option<PlayerTickResult> {
-        if self.vehicle_of_player.contains_key(&player_id) {
+        // Players driving a vehicle don't move independently. Store the
+        // input (consumed by step_vehicles) and continuously sync the
+        // player's position to the chassis so any system reading
+        // state.position sees the real location rather than the stale
+        // pre-entry pose. Mirrors server::movement::PhysicsArena.
+        if let Some(&vehicle_id) = self.vehicle_of_player.get(&player_id) {
             if let Some(state) = self.players.get_mut(&player_id) {
                 state.last_input = input.clone();
+            }
+            if let Some(vehicle) = self.vehicles.get(&vehicle_id) {
+                if let Some(rb) = self.dynamic.sim.rigid_bodies.get(vehicle.chassis_body) {
+                    let p = *rb.translation();
+                    if let Some(state) = self.players.get_mut(&player_id) {
+                        state.position = Vec3d::new(p.x as f64, p.y as f64, p.z as f64);
+                        state.velocity = Vec3d::zeros();
+                        state.on_ground = false;
+                        let collider = state.collider;
+                        let position = state.position;
+                        self.dynamic.sim.sync_player_collider(collider, &position);
+                    }
+                }
             }
             return None;
         }
@@ -245,23 +263,11 @@ impl PhysicsArena {
         if state.dead {
             flags |= FLAG_DEAD;
         }
-
-        if let Some(&vehicle_id) = self.vehicle_of_player.get(&player_id) {
+        // `state.position` is continuously synced to the chassis while the
+        // player is driving (see `simulate_player_tick`), so no special case
+        // is needed here — just tag the flag so clients know.
+        if self.vehicle_of_player.contains_key(&player_id) {
             flags |= FLAG_IN_VEHICLE;
-            if let Some(vehicle) = self.vehicles.get(&vehicle_id) {
-                if let Some(rb) = self.dynamic.sim.rigid_bodies.get(vehicle.chassis_body) {
-                    let p = rb.translation();
-                    let v = rb.linvel();
-                    return Some((
-                        [p.x, p.y, p.z],
-                        [v.x, v.y, v.z],
-                        state.yaw as f32,
-                        state.pitch as f32,
-                        state.hp,
-                        flags,
-                    ));
-                }
-            }
         }
 
         Some((
@@ -565,21 +571,22 @@ impl PhysicsArena {
     }
 
     pub fn exit_vehicle(&mut self, player_id: u32) {
-        if let Some(vehicle_id) = self.detach_player_from_vehicles(player_id) {
-            if let Some(vehicle) = self.vehicles.get_mut(&vehicle_id) {
-                if let Some(rb) = self.dynamic.sim.rigid_bodies.get(vehicle.chassis_body) {
-                    let p = *rb.translation();
-                    if let Some(state) = self.players.get_mut(&player_id) {
-                        state.position =
-                            Vec3d::new((p.x + 2.5) as f64, (p.y + 1.0) as f64, p.z as f64);
-                        if let Some(c) = self.dynamic.sim.colliders.get_mut(state.collider) {
-                            c.set_collision_groups(InteractionGroups::all());
-                        }
-                        self.dynamic
-                            .sim
-                            .sync_player_collider(state.collider, &state.position);
-                    }
+        if self.detach_player_from_vehicles(player_id).is_some() {
+            if let Some(state) = self.players.get_mut(&player_id) {
+                // state.position is already the chassis center (kept in sync
+                // every tick by simulate_player_tick's driving branch).
+                // Offset to place the player beside the vehicle instead of
+                // inside the chassis collider.
+                state.position.x += 2.5;
+                state.position.y += 1.0;
+                state.velocity = Vec3d::zeros();
+                state.on_ground = false;
+                if let Some(c) = self.dynamic.sim.colliders.get_mut(state.collider) {
+                    c.set_collision_groups(InteractionGroups::all());
                 }
+                let collider = state.collider;
+                let position = state.position;
+                self.dynamic.sim.sync_player_collider(collider, &position);
             }
         }
     }

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -970,13 +970,52 @@ impl WasmSimWorld {
     pub fn set_local_vehicle(&mut self, vehicle_id: u32) {
         self.local_vehicle_id = Some(vehicle_id);
         self.vehicle_pending_inputs.clear();
+        // Snap the player pose onto the chassis immediately so
+        // `getPosition()` is correct from the moment the driver takes the
+        // wheel, even before the first `tickVehicle` runs.
+        self.sync_player_to_local_chassis();
     }
 
     /// Clear the local vehicle (called on exit).
     #[wasm_bindgen(js_name = clearLocalVehicle)]
     pub fn clear_local_vehicle(&mut self) {
+        // `self.position` is kept at the chassis center by `tick_vehicle`'s
+        // continuous drive sync, so apply the same offset as the server's
+        // `PhysicsArena::exit_vehicle` here so client prediction matches
+        // authority and the on-foot KCC resumes from a safe pose.
+        if self.local_vehicle_id.is_some() {
+            self.position.x += 2.5;
+            self.position.y += 1.0;
+            self.velocity = Vec3d::zeros();
+            self.on_ground = false;
+            if let Some(collider) = self.player_collider {
+                self.sim.sync_player_collider(collider, &self.position);
+            }
+        }
         self.local_vehicle_id = None;
         self.vehicle_pending_inputs.clear();
+    }
+
+    /// Internal: sync the player's predicted pose to the locally-driven
+    /// vehicle's chassis. No-op if there is no local vehicle or the
+    /// chassis rigid body has been removed.
+    fn sync_player_to_local_chassis(&mut self) {
+        let Some(vid) = self.local_vehicle_id else {
+            return;
+        };
+        let Some(vehicle) = self.vehicles.get(&vid) else {
+            return;
+        };
+        let Some(rb) = self.sim.rigid_bodies.get(vehicle.chassis_body) else {
+            return;
+        };
+        let p = *rb.translation();
+        self.position = Vec3d::new(p.x as f64, p.y as f64, p.z as f64);
+        self.velocity = Vec3d::zeros();
+        self.on_ground = false;
+        if let Some(collider) = self.player_collider {
+            self.sim.sync_player_collider(collider, &self.position);
+        }
     }
 
     /// Sync a remote vehicle's chassis pose/velocity (kinematic update).
@@ -1051,6 +1090,13 @@ impl WasmSimWorld {
 
         self.apply_vehicle_input(vid, &input);
         self.step_vehicle_pipeline(dt);
+
+        // Continuous drive sync: keep `self.position` glued to the chassis
+        // so any code reading `getPosition()` during driving gets the real
+        // location. Mirrors the server's `PhysicsArena::simulate_player_tick`
+        // driving branch so client prediction and authority stay aligned,
+        // and the next on-foot tick after exit starts from a sensible pose.
+        self.sync_player_to_local_chassis();
 
         self.get_vehicle_state(vid)
     }
@@ -1167,6 +1213,10 @@ impl WasmSimWorld {
             self.apply_vehicle_input(vid, input);
             self.step_vehicle_pipeline(dt);
         }
+
+        // Keep the driver's player pose aligned with the (now reconciled)
+        // chassis so `getPosition()` returns the real location.
+        self.sync_player_to_local_chassis();
 
         let state = self.get_vehicle_state(vid);
         let (after_px, after_py, after_pz) = (state[0] as f32, state[1] as f32, state[2] as f32);

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -984,6 +984,12 @@ impl WasmSimWorld {
         // `PhysicsArena::exit_vehicle` here so client prediction matches
         // authority and the on-foot KCC resumes from a safe pose.
         if self.local_vehicle_id.is_some() {
+            // Re-read the active chassis pose at the moment of exit instead of
+            // trusting any cached player position. If a vehicle snapshot was
+            // already visually current but the cached player pose lagged behind,
+            // exiting from the stale pose can strand the local KCC at an old
+            // location and create a phantom movement boundary.
+            self.sync_player_to_local_chassis();
             self.position.x += 2.5;
             self.position.y += 1.0;
             self.velocity = Vec3d::zeros();


### PR DESCRIPTION
## Summary
This PR refactors vehicle driving mechanics to continuously synchronize the player's position to the vehicle chassis throughout the driving session, rather than only reporting the chassis position when querying player state. This ensures all systems reading player position (bots, AI, snapshots, stats, debug overlays) see the real location instead of stale pre-entry poses.

## Key Changes

**Server & Local Arena Physics (`server/src/movement.rs` and `shared/src/local_arena.rs`)**
- Modified `simulate_player_tick()` to continuously sync player position to the chassis when driving:
  - Extract vehicle chassis position each tick
  - Update player state position, velocity, and ground state to match chassis
  - Sync the player collider to the new position
- Simplified `get_player_state()` to only set the `FLAG_IN_VEHICLE` flag; position is now always current since it's synced every tick
- Refactored `exit_vehicle()` to use the already-synced position as the baseline, then apply the 2.5m/1.0m offset to place the player beside the vehicle

**Client WASM Simulation (`shared/src/wasm_api.rs`)**
- Added `sync_player_to_local_chassis()` helper to snap player pose to chassis position
- Call this helper in `set_local_vehicle()` to ensure position is correct immediately upon entering
- Call this helper in `tick_vehicle()` after stepping the vehicle pipeline for continuous drive sync
- Call this helper in `reconcile_vehicle()` after reconciliation to keep position aligned
- Modified `clear_local_vehicle()` to apply the same post-exit offset as the server

**Client Prediction Manager (`client/src/physics/predictionManager.ts` and `usePrediction.ts`)**
- Added `resyncFromSim()` method to refresh interpolation state from current WASM position
  - Resets `prevPosition`, `currPosition`, and `accumulator` to eliminate stale interpolation after vehicle exit
- Call `resyncFromSim()` in `exitVehicle()` handler to sync JS interpolation state after WASM has applied the exit offset

## Implementation Details
- The continuous sync approach ensures consistency: all code paths reading `state.position` get the real chassis location
- Client prediction and server authority remain aligned by mirroring the sync logic on both sides
- Vehicle exit applies a consistent offset (2.5m right, 1.0m up) on both server and client before resuming on-foot movement
- The interpolation state refresh on client prevents visual jitter when transitioning from driving (where `update()` is skipped) back to on-foot movement

https://claude.ai/code/session_01BLD461zYRgnB3ps9bjgaV2