### PR TITLE
Add AI co-editor chat panel with world editing capabilities

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,11 +8,16 @@
       "name": "vibe-land-client",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^2.0.74",
+        "@ai-sdk/google": "^2.0.68",
+        "@ai-sdk/openai": "^2.0.102",
         "@react-three/drei": "^9.117.0",
         "@react-three/fiber": "^8.17.0",
+        "ai": "^6.0.159",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "three": "^0.170.0"
+        "three": "^0.170.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
@@ -25,6 +30,129 @@
         "vite": "^6.0.0",
         "vitest": "^4.1.2",
         "ws": "^8.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "2.0.74",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.74.tgz",
+      "integrity": "sha512-1Z7142GVIF4XkcSvQpL6ij2c7J51dtm4/Z84P+O0bGBDZI1Nbvz897hXkJf2cfNhq5XdpvUYbI+oExXM7Ko8Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.96.tgz",
+      "integrity": "sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "2.0.68",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.68.tgz",
+      "integrity": "sha512-YnigC1MtgqiU9b7uTO0jYGIzmB0H4wBp/dmo8iJuZZZNx21upXuLXd3fjBA2ICrVk7szPHrXGkmQSDOeyQ1q6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "2.0.102",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.102.tgz",
+      "integrity": "sha512-tYarHJhyMioGegsnhpqz1/tKoCAJJ6zBHoIQaredNkt8V3o/JXj2647NnEOJVe7WHQXGvCfzbfnP1TADFhPmcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz",
+      "integrity": "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -828,6 +956,15 @@
         "three": ">= 0.159.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@react-spring/animated": {
       "version": "9.7.5",
       "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
@@ -1368,8 +1505,7 @@
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
@@ -1554,6 +1690,15 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1686,6 +1831,53 @@
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ai": {
+      "version": "6.0.159",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.159.tgz",
+      "integrity": "sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.96",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1987,6 +2179,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2146,6 +2347,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3538,6 +3745,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.12",

--- a/client/package.json
+++ b/client/package.json
@@ -28,11 +28,16 @@
     "benchmark:compare": "node --import=tsx/esm benchmark-compare.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^2.0.74",
+    "@ai-sdk/google": "^2.0.68",
+    "@ai-sdk/openai": "^2.0.102",
     "@react-three/drei": "^9.117.0",
     "@react-three/fiber": "^8.17.0",
+    "ai": "^6.0.159",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "three": "^0.170.0"
+    "three": "^0.170.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/client/src/ai/chatTypes.ts
+++ b/client/src/ai/chatTypes.ts
@@ -1,0 +1,136 @@
+import type { ModelMessage, ToolContent, ToolResultPart } from 'ai';
+
+export type ChatTextPart = { type: 'text'; text: string };
+export type ChatReasoningPart = { type: 'reasoning'; text: string };
+export type ChatToolCallPart = {
+  type: 'tool-call';
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+};
+export type ChatToolResultPart = {
+  type: 'tool-result';
+  toolCallId: string;
+  toolName: string;
+  output: unknown;
+  isError?: boolean;
+};
+
+export type ChatPart =
+  | ChatTextPart
+  | ChatReasoningPart
+  | ChatToolCallPart
+  | ChatToolResultPart;
+
+export type ChatRole = 'user' | 'assistant';
+
+export type ChatMessage = {
+  id: string;
+  role: ChatRole;
+  parts: ChatPart[];
+  createdAt: number;
+  /**
+   * Optional hidden context prepended to the user message before sending.
+   * Used to inject auto-summarized human edits without polluting the visible
+   * chat bubble.
+   */
+  hiddenContext?: string;
+};
+
+/**
+ * Convert our local chat-message list into AI SDK `ModelMessage[]` for
+ * `streamText`. Tool calls and results are inlined onto the assistant
+ * message and a follow-up tool message respectively, matching the shape the
+ * SDK expects.
+ */
+export function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
+  const out: ModelMessage[] = [];
+  for (const msg of messages) {
+    if (msg.role === 'user') {
+      const text = renderUserContent(msg);
+      out.push({ role: 'user', content: text });
+      continue;
+    }
+    // assistant message — content can be a mix of text/reasoning/tool-call parts
+    const assistantContent: Array<
+      | { type: 'text'; text: string }
+      | { type: 'reasoning'; text: string }
+      | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
+    > = [];
+    const toolResults: ToolContent = [];
+
+    for (const part of msg.parts) {
+      if (part.type === 'text' && part.text.length > 0) {
+        assistantContent.push({ type: 'text', text: part.text });
+      } else if (part.type === 'reasoning' && part.text.length > 0) {
+        assistantContent.push({ type: 'reasoning', text: part.text });
+      } else if (part.type === 'tool-call') {
+        assistantContent.push({
+          type: 'tool-call',
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          input: part.input ?? {},
+        });
+      } else if (part.type === 'tool-result') {
+        const resultPart: ToolResultPart = {
+          type: 'tool-result',
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          output: part.isError
+            ? { type: 'error-text', value: stringifyForModel(part.output) }
+            : ({ type: 'json', value: toJsonValue(part.output) } as ToolResultPart['output']),
+        };
+        toolResults.push(resultPart);
+      }
+    }
+
+    if (assistantContent.length > 0) {
+      out.push({ role: 'assistant', content: assistantContent });
+    }
+    if (toolResults.length > 0) {
+      out.push({ role: 'tool', content: toolResults });
+    }
+  }
+  return out;
+}
+
+function renderUserContent(msg: ChatMessage): string {
+  const visible = msg.parts
+    .filter((p): p is ChatTextPart => p.type === 'text')
+    .map((p) => p.text)
+    .join('');
+  if (msg.hiddenContext && msg.hiddenContext.length > 0) {
+    return `${msg.hiddenContext}\n\n${visible}`;
+  }
+  return visible;
+}
+
+function stringifyForModel(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Coerce an arbitrary JS value into something the AI SDK accepts as a
+ * JSONValue tool result. We round-trip through JSON to drop functions/symbols
+ * and turn cycles into strings.
+ */
+function toJsonValue(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value ?? null));
+  } catch {
+    return String(value);
+  }
+}
+
+export function makeChatId(): string {
+  const cryptoRef = typeof crypto !== 'undefined' ? crypto : undefined;
+  if (cryptoRef && typeof cryptoRef.randomUUID === 'function') {
+    return cryptoRef.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/client/src/ai/providers.ts
+++ b/client/src/ai/providers.ts
@@ -6,15 +6,44 @@ import { createOpenAI } from '@ai-sdk/openai';
 export type ProviderId = 'openai' | 'anthropic' | 'google';
 
 // NOTE: model IDs drift over time. These are sensible defaults that the
-// user can override at runtime via the chat settings UI.
+// user can override at runtime via the chat settings UI (any string is
+// accepted — this list is just for convenience).
 export const MODELS: Record<ProviderId, string[]> = {
-  openai: ['gpt-5', 'gpt-5-mini', 'gpt-5-nano', 'gpt-4.1', 'gpt-4.1-mini'],
+  openai: [
+    'gpt-5.4',
+    'gpt-5.4-pro',
+    'gpt-5.4-mini',
+    'gpt-5.4-nano',
+    'gpt-5.2',
+    'gpt-5.2-pro',
+    'gpt-5.1',
+    'gpt-5',
+    'gpt-5-mini',
+    'gpt-5-nano',
+    'gpt-4.1',
+    'gpt-4.1-mini',
+    'gpt-4.1-nano',
+    'o3',
+    'o3-mini',
+  ],
   anthropic: [
     'claude-opus-4-6',
     'claude-sonnet-4-6',
-    'claude-haiku-4-5-20251001',
+    'claude-opus-4-5',
+    'claude-sonnet-4-5',
+    'claude-opus-4-1',
+    'claude-sonnet-4-0',
+    'claude-haiku-4-5',
   ],
-  google: ['gemini-2.5-pro', 'gemini-2.5-flash'],
+  google: [
+    'gemini-3.1-pro-preview',
+    'gemini-3.1-flash-image-preview',
+    'gemini-3-pro-preview',
+    'gemini-3-flash-preview',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+    'gemini-2.5-flash-lite',
+  ],
 };
 
 export const PROVIDER_LABELS: Record<ProviderId, string> = {

--- a/client/src/ai/providers.ts
+++ b/client/src/ai/providers.ts
@@ -1,0 +1,72 @@
+import type { LanguageModel } from 'ai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createOpenAI } from '@ai-sdk/openai';
+
+export type ProviderId = 'openai' | 'anthropic' | 'google';
+
+// NOTE: model IDs drift over time. These are sensible defaults that the
+// user can override at runtime via the chat settings UI.
+export const MODELS: Record<ProviderId, string[]> = {
+  openai: ['gpt-5', 'gpt-5-mini', 'gpt-5-nano', 'gpt-4.1', 'gpt-4.1-mini'],
+  anthropic: [
+    'claude-opus-4-6',
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5-20251001',
+  ],
+  google: ['gemini-2.5-pro', 'gemini-2.5-flash'],
+};
+
+export const PROVIDER_LABELS: Record<ProviderId, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  google: 'Google Gemini',
+};
+
+export function isProviderId(value: unknown): value is ProviderId {
+  return value === 'openai' || value === 'anthropic' || value === 'google';
+}
+
+export function defaultModelFor(provider: ProviderId): string {
+  return MODELS[provider][0];
+}
+
+/**
+ * Build a LanguageModel that talks directly to the provider from the browser.
+ *
+ * The user supplies their own API key (BYOK) — there is no backend proxy. We
+ * pass `dangerouslyAllowBrowser`-style flags where each provider supports them
+ * so the SDK doesn't refuse to run in a browser environment.
+ */
+export function createLanguageModel(
+  provider: ProviderId,
+  modelId: string,
+  apiKey: string,
+): LanguageModel {
+  if (!apiKey) {
+    throw new Error(`Missing API key for ${PROVIDER_LABELS[provider]}.`);
+  }
+  switch (provider) {
+    case 'openai': {
+      const client = createOpenAI({ apiKey });
+      return client.chat(modelId);
+    }
+    case 'anthropic': {
+      const client = createAnthropic({
+        apiKey,
+        // Required for the Anthropic Messages API to accept browser-origin
+        // requests (CORS preflight). Without this header the call fails.
+        headers: { 'anthropic-dangerous-direct-browser-access': 'true' },
+      });
+      return client(modelId);
+    }
+    case 'google': {
+      const client = createGoogleGenerativeAI({ apiKey });
+      return client(modelId);
+    }
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`Unknown provider: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/client/src/ai/sandbox.test.ts
+++ b/client/src/ai/sandbox.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { executeUserCode, truncateForModel } from './sandbox';
+
+describe('executeUserCode', () => {
+  it('returns the value of the user code', async () => {
+    const result = await executeUserCode({
+      code: 'return 1 + ctx.bonus;',
+      ctx: { bonus: 41 },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.returnValue).toBe(42);
+    expect(result.logs).toEqual([]);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('captures console.log/info/warn/error in order', async () => {
+    const result = await executeUserCode({
+      code: `
+        console.log('hello', 'world');
+        console.info({ a: 1 });
+        console.warn('warn-text');
+        console.error('error-text');
+        return null;
+      `,
+      ctx: {},
+    });
+    expect(result.ok).toBe(true);
+    expect(result.logs).toEqual([
+      { level: 'log', text: 'hello world' },
+      { level: 'info', text: '{"a":1}' },
+      { level: 'warn', text: 'warn-text' },
+      { level: 'error', text: 'error-text' },
+    ]);
+  });
+
+  it('catches synchronous errors and reports them with stack trace', async () => {
+    const result = await executeUserCode({
+      code: 'throw new Error("boom");',
+      ctx: {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error?.name).toBe('Error');
+    expect(result.error?.message).toBe('boom');
+    expect(typeof result.error?.stack).toBe('string');
+  });
+
+  it('catches async/await errors', async () => {
+    const result = await executeUserCode({
+      code: `
+        await Promise.resolve();
+        throw new TypeError('async-fail');
+      `,
+      ctx: {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error?.name).toBe('TypeError');
+    expect(result.error?.message).toBe('async-fail');
+  });
+
+  it('catches parse errors before execution', async () => {
+    const result = await executeUserCode({
+      code: 'this is ( not valid javascript',
+      ctx: {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('lets ctx helpers be called and observes their mutations across calls', async () => {
+    let counter = 0;
+    const ctx = { bump: () => ({ next: ++counter }) };
+    const first = await executeUserCode({
+      code: 'return ctx.bump();',
+      ctx,
+    });
+    const second = await executeUserCode({
+      code: 'return ctx.bump();',
+      ctx,
+    });
+    expect(first.returnValue).toEqual({ next: 1 });
+    expect(second.returnValue).toEqual({ next: 2 });
+  });
+});
+
+describe('truncateForModel', () => {
+  it('passes primitives through', () => {
+    expect(truncateForModel(1)).toBe(1);
+    expect(truncateForModel(true)).toBe(true);
+    expect(truncateForModel(null)).toBeNull();
+    expect(truncateForModel('hi')).toBe('hi');
+  });
+
+  it('truncates very long strings', () => {
+    const long = 'x'.repeat(2_500);
+    const trimmed = truncateForModel(long);
+    expect(typeof trimmed).toBe('string');
+    expect((trimmed as string).startsWith('xxxx')).toBe(true);
+    expect((trimmed as string)).toContain('truncated');
+    expect((trimmed as string).length).toBeLessThan(long.length);
+  });
+
+  it('truncates oversized arrays with a marker', () => {
+    const arr = Array.from({ length: 250 }, (_, i) => i);
+    const trimmed = truncateForModel(arr) as unknown[];
+    expect(trimmed.length).toBe(101);
+    expect(trimmed[100]).toMatch(/truncated/);
+  });
+
+  it('replaces cycles with a marker', () => {
+    const obj: Record<string, unknown> = { name: 'root' };
+    obj.self = obj;
+    const trimmed = truncateForModel(obj) as Record<string, unknown>;
+    expect(trimmed.name).toBe('root');
+    expect(trimmed.self).toBe('[Circular]');
+  });
+
+  it('honors max depth', () => {
+    let nested: unknown = 'leaf';
+    for (let i = 0; i < 10; i += 1) {
+      nested = { next: nested };
+    }
+    const trimmed = JSON.stringify(truncateForModel(nested));
+    expect(trimmed).toContain('truncated: max depth');
+  });
+});

--- a/client/src/ai/sandbox.ts
+++ b/client/src/ai/sandbox.ts
@@ -1,0 +1,136 @@
+/**
+ * Tiny in-process JS code runner for the AI's `execute_js` tool.
+ *
+ * SECURITY NOTE: This is **not** a real sandbox. It executes the provided code
+ * in the same realm as the rest of the page (no iframe, no Worker, no isolated
+ * realm). The trust model is: the user pasted their own provider API key into
+ * their own browser to chat with their own AI. Any code that runs originated
+ * from a model the user explicitly chose. Treat this the same as a developer
+ * console — powerful, and the user is responsible for what they ask the model
+ * to do.
+ */
+
+export type LogLevel = 'log' | 'info' | 'warn' | 'error';
+export type LogEntry = { level: LogLevel; text: string };
+
+export type SandboxResult = {
+  ok: boolean;
+  returnValue?: unknown;
+  logs: LogEntry[];
+  error?: { name: string; message: string; stack?: string };
+};
+
+const MAX_STRING_LENGTH = 2_000;
+const MAX_ARRAY_LENGTH = 100;
+const MAX_DEPTH = 6;
+
+export async function executeUserCode(options: {
+  code: string;
+  ctx: Record<string, unknown>;
+}): Promise<SandboxResult> {
+  const { code, ctx } = options;
+  const logs: LogEntry[] = [];
+
+  const capturedConsole = {
+    log: (...args: unknown[]) => logs.push({ level: 'log', text: formatArgs(args) }),
+    info: (...args: unknown[]) => logs.push({ level: 'info', text: formatArgs(args) }),
+    warn: (...args: unknown[]) => logs.push({ level: 'warn', text: formatArgs(args) }),
+    error: (...args: unknown[]) => logs.push({ level: 'error', text: formatArgs(args) }),
+  };
+
+  let runner: (ctx: unknown, console: unknown) => unknown;
+  try {
+    // The wrapping IIFE lets the user's code use `await` and `return` directly.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    runner = new Function(
+      'ctx',
+      'console',
+      `"use strict";\nreturn (async () => {\n${code}\n})();`,
+    ) as (ctx: unknown, console: unknown) => unknown;
+  } catch (parseError) {
+    return {
+      ok: false,
+      logs,
+      error: normalizeError(parseError),
+    };
+  }
+
+  try {
+    const rawValue = await Promise.resolve(runner(ctx, capturedConsole));
+    return {
+      ok: true,
+      returnValue: truncateForModel(rawValue),
+      logs,
+    };
+  } catch (runError) {
+    return {
+      ok: false,
+      logs,
+      error: normalizeError(runError),
+    };
+  }
+}
+
+function formatArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg;
+      if (arg instanceof Error) return `${arg.name}: ${arg.message}`;
+      try {
+        return JSON.stringify(arg);
+      } catch {
+        return String(arg);
+      }
+    })
+    .join(' ');
+}
+
+function normalizeError(err: unknown): { name: string; message: string; stack?: string } {
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message, stack: err.stack };
+  }
+  return { name: 'Error', message: String(err) };
+}
+
+/**
+ * Walk the value and trim oversized arrays/strings so the model's tool result
+ * stays within a reasonable token budget. Cycles are replaced with a marker.
+ */
+export function truncateForModel(value: unknown): unknown {
+  const seen = new WeakSet<object>();
+
+  function walk(node: unknown, depth: number): unknown {
+    if (node === null) return null;
+    if (typeof node === 'undefined') return undefined;
+    if (typeof node === 'string') {
+      return node.length > MAX_STRING_LENGTH
+        ? `${node.slice(0, MAX_STRING_LENGTH)}…[truncated ${node.length - MAX_STRING_LENGTH} chars]`
+        : node;
+    }
+    if (typeof node === 'number' || typeof node === 'boolean') return node;
+    if (typeof node === 'bigint') return node.toString();
+    if (typeof node === 'symbol') return node.toString();
+    if (typeof node === 'function') return `[Function ${node.name || 'anonymous'}]`;
+    if (depth >= MAX_DEPTH) return '[truncated: max depth]';
+    if (typeof node !== 'object') return String(node);
+
+    if (seen.has(node as object)) return '[Circular]';
+    seen.add(node as object);
+
+    if (Array.isArray(node)) {
+      if (node.length > MAX_ARRAY_LENGTH) {
+        const head = node.slice(0, MAX_ARRAY_LENGTH).map((item) => walk(item, depth + 1));
+        head.push(`…[truncated ${node.length - MAX_ARRAY_LENGTH} items]`);
+        return head;
+      }
+      return node.map((item) => walk(item, depth + 1));
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(node as Record<string, unknown>)) {
+      out[key] = walk(val, depth + 1);
+    }
+    return out;
+  }
+
+  return walk(value, 0);
+}

--- a/client/src/ai/settingsStore.ts
+++ b/client/src/ai/settingsStore.ts
@@ -1,0 +1,86 @@
+import { defaultModelFor, isProviderId, MODELS, type ProviderId } from './providers';
+
+const STORAGE_KEY = 'vibe-land:godmode-ai-settings:v1';
+
+export type AiChatSettings = {
+  provider: ProviderId;
+  model: string;
+  apiKeys: Partial<Record<ProviderId, string>>;
+};
+
+export function defaultSettings(): AiChatSettings {
+  return {
+    provider: 'anthropic',
+    model: defaultModelFor('anthropic'),
+    apiKeys: {},
+  };
+}
+
+function safeStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadSettings(): AiChatSettings {
+  const storage = safeStorage();
+  if (!storage) {
+    return defaultSettings();
+  }
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return defaultSettings();
+    }
+    const parsed = JSON.parse(raw) as Partial<AiChatSettings> | null;
+    if (!parsed || typeof parsed !== 'object') {
+      return defaultSettings();
+    }
+    const provider: ProviderId = isProviderId(parsed.provider) ? parsed.provider : 'anthropic';
+    const candidateModel = typeof parsed.model === 'string' ? parsed.model : defaultModelFor(provider);
+    // If the persisted model isn't in the known list, still allow it (custom IDs).
+    const model = candidateModel || defaultModelFor(provider);
+    const apiKeys: Partial<Record<ProviderId, string>> = {};
+    if (parsed.apiKeys && typeof parsed.apiKeys === 'object') {
+      for (const key of Object.keys(MODELS) as ProviderId[]) {
+        const value = (parsed.apiKeys as Record<string, unknown>)[key];
+        if (typeof value === 'string' && value.length > 0) {
+          apiKeys[key] = value;
+        }
+      }
+    }
+    return { provider, model, apiKeys };
+  } catch {
+    return defaultSettings();
+  }
+}
+
+export function saveSettings(settings: AiChatSettings): void {
+  const storage = safeStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Ignore quota / privacy errors — settings just won't persist.
+  }
+}
+
+export function clearStoredApiKeys(): void {
+  const storage = safeStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    const current = loadSettings();
+    saveSettings({ ...current, apiKeys: {} });
+  } catch {
+    storage.removeItem(STORAGE_KEY);
+  }
+}

--- a/client/src/ai/systemPrompt.ts
+++ b/client/src/ai/systemPrompt.ts
@@ -1,0 +1,96 @@
+export const SYSTEM_PROMPT = `You are a collaborative co-editor for a 3D world inside the GodMode editor of Vibe Land. The human you're chatting with can see the world in real time and can also edit it manually; treat this as a shared canvas, not a single-player session.
+
+# World model
+
+The world is a JSON document with the following shape (TypeScript):
+
+\`\`\`ts
+type WorldDocument = {
+  version: number;
+  meta: { name: string; description: string };
+  terrain: {
+    tileGridSize: number;     // samples per side, e.g. 33
+    tileHalfExtentM: number;  // half side length of a tile in meters
+    tiles: Array<{ tileX: number; tileZ: number; heights: number[] }>;
+  };
+  staticProps: Array<{
+    id: number;
+    kind: 'cuboid';
+    position: [x, y, z];          // meters
+    rotation: [x, y, z, w];       // quaternion
+    halfExtents: [hx, hy, hz];    // meters
+    material?: string;
+  }>;
+  dynamicEntities: Array<{
+    id: number;
+    kind: 'box' | 'ball' | 'vehicle';
+    position: [x, y, z];
+    rotation: [x, y, z, w];
+    halfExtents?: [hx, hy, hz];   // box only
+    radius?: number;              // ball only
+    vehicleType?: number;         // vehicle only
+  }>;
+};
+\`\`\`
+
+Coordinates are right-handed, Y is up, units are meters. Terrain heights are absolute Y values per sample inside each tile. Quaternions are [x, y, z, w]; use \`ctx.quaternionFromYaw(yawRadians)\` if you only need a yaw rotation.
+
+# The execute_js tool
+
+You have ONE tool: \`execute_js\`. It runs an async JavaScript snippet inside the user's browser with a pre-bound \`ctx\` object plus a captured \`console\`. You can:
+
+- Inspect state: read from \`ctx.*\` helpers and \`return\` values to yourself.
+- Mutate state: call \`ctx.add*\` / \`ctx.update*\` / \`ctx.remove*\` / \`ctx.applyTerrain*\` helpers. Mutations show up live in the user's 3D viewport and are recorded on the editor's undo stack.
+- Use \`console.log/info/warn/error\` to surface debug info — the captured logs are returned to you.
+
+Your code is wrapped roughly like this:
+
+\`\`\`js
+async (ctx, console) => {
+  // your code here
+  // 'return' here is captured and sent back to you as the tool result
+}
+\`\`\`
+
+The tool result will be JSON like:
+\`\`\`
+{ ok: true,  returnValue: ..., logs: [{level, text}, ...] }
+{ ok: false, error: { name, message, stack }, logs: [...] }
+\`\`\`
+
+You can call the tool multiple times in a single turn to read, then act, then verify.
+
+# ctx helpers
+
+Read:
+- \`ctx.getWorld()\` → deep-cloned WorldDocument snapshot.
+- \`ctx.getMeta()\` → \`{ name, description }\`.
+- \`ctx.listStaticProps()\` / \`ctx.listDynamicEntities()\` → arrays of plain objects.
+- \`ctx.getEntity(id)\` → the static prop or dynamic entity with that id, or null.
+- \`ctx.getTerrainInfo()\` → \`{ tileGridSize, tileHalfExtentM, tileCount, bounds }\`.
+- \`ctx.listTerrainTiles()\` → array of \`{ tileX, tileZ }\`.
+- \`ctx.getTerrainTile(tileX, tileZ)\` → tile with full heights array, or null.
+- \`ctx.sampleTerrainHeight(x, z)\` → interpolated terrain Y at world XZ.
+- \`ctx.getAddableTerrainTiles()\` → tile coords that are valid neighbors to add.
+- \`ctx.nextEntityId()\` → next free numeric id.
+
+Write (each returns \`{ changed: boolean, ...details }\`):
+- \`ctx.addStaticCuboid({ position, halfExtents, rotation?, material? })\`
+- \`ctx.addDynamicEntity({ kind: 'box'|'ball'|'vehicle', position, halfExtents?, radius?, rotation?, vehicleType? })\`
+- \`ctx.removeEntity(id)\`
+- \`ctx.updateEntity(id, patch)\` — patch fields: \`position\`, \`rotation\`, \`halfExtents\`, \`radius\`.
+- \`ctx.applyTerrainBrush({ centerX, centerZ, radius, strength, mode: 'raise'|'lower', minHeight?, maxHeight? })\`
+- \`ctx.applyTerrainRamp(stencil)\` — see TerrainRampStencil shape (centerX, centerZ, width, length, gradePct, yawRad, mode, strength, targetHeight, targetEdge, targetKind, sideFalloffM, startFalloffM, endFalloffM).
+- \`ctx.addTerrainTile(tileX, tileZ)\`
+- \`ctx.removeTerrainTile(tileX, tileZ)\`
+
+Math helpers: \`ctx.quaternionFromYaw(yawRad)\`, \`ctx.identityQuaternion()\`.
+
+# Collaboration etiquette
+
+- Before destructive or sweeping changes, briefly say what you're about to do and wait for confirmation if it's risky (deleting many entities, flattening terrain).
+- Use small focused tool calls. Read state first if you're unsure what's there.
+- Between turns, the human may have edited the world manually. If they did, the user message will start with a "<context>Human edits since last turn: …</context>" block summarizing what changed.
+- When you finish a tool plan, write a short natural-language summary of what you did so the human can follow along.
+
+Be concise. Prefer doing over explaining.`;

--- a/client/src/ai/useGodModeChat.ts
+++ b/client/src/ai/useGodModeChat.ts
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { stepCountIs, streamText } from 'ai';
+import {
+  makeChatId,
+  toModelMessages,
+  type ChatMessage,
+  type ChatPart,
+} from './chatTypes';
+import { createLanguageModel, type ProviderId } from './providers';
+import { SYSTEM_PROMPT } from './systemPrompt';
+import { createExecuteJsTool } from './worldTool';
+import type { WorldAccessors } from './worldToolHelpers';
+
+export type ChatStatus = 'idle' | 'streaming' | 'error';
+
+export type GodModeChatOptions = {
+  accessors: WorldAccessors;
+  provider: ProviderId;
+  model: string;
+  apiKey: string | undefined;
+};
+
+export type GodModeChatHandle = {
+  messages: ChatMessage[];
+  status: ChatStatus;
+  error: Error | null;
+  pendingHumanEdits: number;
+  canSend: boolean;
+  sendMessage(text: string): Promise<void>;
+  stop(): void;
+  clear(): void;
+  pushHumanEdit(summary: string): void;
+};
+
+const MAX_TOOL_STEPS = 12;
+
+export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
+  const { accessors, provider, model, apiKey } = options;
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [status, setStatus] = useState<ChatStatus>('idle');
+  const [error, setError] = useState<Error | null>(null);
+  const [pendingHumanEdits, setPendingHumanEdits] = useState<string[]>([]);
+
+  const accessorsRef = useRef(accessors);
+  useEffect(() => {
+    accessorsRef.current = accessors;
+  }, [accessors]);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const stop = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
+  const pushHumanEdit = useCallback((summary: string) => {
+    if (!summary || summary.length === 0) return;
+    setPendingHumanEdits((prev) => [...prev, summary]);
+  }, []);
+
+  const clear = useCallback(() => {
+    stop();
+    setMessages([]);
+    setError(null);
+    setPendingHumanEdits([]);
+    setStatus('idle');
+  }, [stop]);
+
+  const canSend = Boolean(apiKey) && status === 'idle';
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (trimmed.length === 0) return;
+      if (!apiKey) {
+        setError(new Error(`Add an API key for ${provider} first.`));
+        setStatus('error');
+        return;
+      }
+      if (status === 'streaming') return;
+
+      // Snapshot pending human edits and clear them up-front so concurrent
+      // edits while we wait for the model start a fresh buffer.
+      let hiddenContext: string | undefined;
+      if (pendingHumanEdits.length > 0) {
+        hiddenContext = `<context>Human edits since last turn: ${pendingHumanEdits.join('; ')}</context>`;
+      }
+      setPendingHumanEdits([]);
+
+      const userMessage: ChatMessage = {
+        id: makeChatId(),
+        role: 'user',
+        parts: [{ type: 'text', text: trimmed }],
+        createdAt: Date.now(),
+        hiddenContext,
+      };
+      const assistantId = makeChatId();
+      const assistantMessage: ChatMessage = {
+        id: assistantId,
+        role: 'assistant',
+        parts: [],
+        createdAt: Date.now(),
+      };
+
+      const baseMessages = [...messages, userMessage];
+      setMessages([...baseMessages, assistantMessage]);
+      setStatus('streaming');
+      setError(null);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const languageModel = createLanguageModel(provider, model, apiKey);
+        const result = streamText({
+          model: languageModel,
+          system: SYSTEM_PROMPT,
+          messages: toModelMessages(baseMessages),
+          tools: { execute_js: createExecuteJsTool(accessorsRef.current) },
+          stopWhen: stepCountIs(MAX_TOOL_STEPS),
+          abortSignal: controller.signal,
+        });
+
+        // Track in-flight text/reasoning blocks so streamed deltas append to
+        // the same part instead of creating a new one per chunk.
+        const textPartIds = new Map<string, number>(); // delta id -> parts index
+        const reasoningPartIds = new Map<string, number>();
+
+        const updateAssistant = (mutator: (parts: ChatPart[]) => ChatPart[]) => {
+          setMessages((current) => {
+            const idx = current.findIndex((m) => m.id === assistantId);
+            if (idx === -1) return current;
+            const target = current[idx];
+            const nextParts = mutator(target.parts);
+            const nextMessage: ChatMessage = { ...target, parts: nextParts };
+            const next = current.slice();
+            next[idx] = nextMessage;
+            return next;
+          });
+        };
+
+        for await (const part of result.fullStream) {
+          if (controller.signal.aborted) break;
+
+          switch (part.type) {
+            case 'text-start': {
+              updateAssistant((parts) => {
+                textPartIds.set(part.id, parts.length);
+                return [...parts, { type: 'text', text: '' }];
+              });
+              break;
+            }
+            case 'text-delta': {
+              updateAssistant((parts) => {
+                let index = textPartIds.get(part.id);
+                let nextParts = parts;
+                if (index === undefined) {
+                  index = parts.length;
+                  textPartIds.set(part.id, index);
+                  nextParts = [...parts, { type: 'text', text: '' }];
+                }
+                const target = nextParts[index];
+                if (target?.type !== 'text') return nextParts;
+                const updated: ChatPart = { type: 'text', text: target.text + part.text };
+                const out = nextParts.slice();
+                out[index] = updated;
+                return out;
+              });
+              break;
+            }
+            case 'reasoning-start': {
+              updateAssistant((parts) => {
+                reasoningPartIds.set(part.id, parts.length);
+                return [...parts, { type: 'reasoning', text: '' }];
+              });
+              break;
+            }
+            case 'reasoning-delta': {
+              updateAssistant((parts) => {
+                let index = reasoningPartIds.get(part.id);
+                let nextParts = parts;
+                if (index === undefined) {
+                  index = parts.length;
+                  reasoningPartIds.set(part.id, index);
+                  nextParts = [...parts, { type: 'reasoning', text: '' }];
+                }
+                const target = nextParts[index];
+                if (target?.type !== 'reasoning') return nextParts;
+                const updated: ChatPart = { type: 'reasoning', text: target.text + part.text };
+                const out = nextParts.slice();
+                out[index] = updated;
+                return out;
+              });
+              break;
+            }
+            case 'tool-call': {
+              updateAssistant((parts) => [
+                ...parts,
+                {
+                  type: 'tool-call',
+                  toolCallId: part.toolCallId,
+                  toolName: part.toolName,
+                  input: part.input,
+                },
+              ]);
+              break;
+            }
+            case 'tool-result': {
+              updateAssistant((parts) => [
+                ...parts,
+                {
+                  type: 'tool-result',
+                  toolCallId: part.toolCallId,
+                  toolName: part.toolName,
+                  output: part.output,
+                },
+              ]);
+              break;
+            }
+            case 'tool-error': {
+              updateAssistant((parts) => [
+                ...parts,
+                {
+                  type: 'tool-result',
+                  toolCallId: part.toolCallId,
+                  toolName: part.toolName,
+                  output: { error: errorMessage(part.error) },
+                  isError: true,
+                },
+              ]);
+              break;
+            }
+            case 'error': {
+              throw toError(part.error);
+            }
+            default:
+              break;
+          }
+        }
+
+        if (controller.signal.aborted) {
+          setStatus('idle');
+        } else {
+          setStatus('idle');
+        }
+      } catch (err) {
+        const wrapped = toError(err);
+        if (wrapped.name === 'AbortError') {
+          setStatus('idle');
+        } else {
+          setError(wrapped);
+          setStatus('error');
+        }
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+        }
+      }
+    },
+    [apiKey, messages, model, pendingHumanEdits, provider, status],
+  );
+
+  return useMemo<GodModeChatHandle>(
+    () => ({
+      messages,
+      status,
+      error,
+      pendingHumanEdits: pendingHumanEdits.length,
+      canSend,
+      sendMessage,
+      stop,
+      clear,
+      pushHumanEdit,
+    }),
+    [canSend, clear, error, messages, pendingHumanEdits.length, pushHumanEdit, sendMessage, status, stop],
+  );
+}
+
+function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (typeof value === 'string') return new Error(value);
+  try {
+    return new Error(JSON.stringify(value));
+  } catch {
+    return new Error(String(value));
+  }
+}
+
+function errorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/client/src/ai/useGodModeChat.ts
+++ b/client/src/ai/useGodModeChat.ts
@@ -129,6 +129,9 @@ export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
           tools: { execute_js: createExecuteJsTool(accessorsRef.current) },
           stopWhen: stepCountIs(MAX_TOOL_STEPS),
           abortSignal: controller.signal,
+          // Disable automatic retries — for BYOK in the browser, retrying
+          // on 429/5xx just wastes the user's quota and delays the error.
+          maxRetries: 0,
         });
 
         // Track in-flight text/reasoning blocks so streamed deltas append to

--- a/client/src/ai/worldDiffSummary.test.ts
+++ b/client/src/ai/worldDiffSummary.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeWorldDiff } from './worldDiffSummary';
+import {
+  cloneWorldDocument,
+  identityQuaternion,
+  type WorldDocument,
+} from '../world/worldDocument';
+
+function blankWorld(): WorldDocument {
+  return {
+    version: 2,
+    meta: { name: 'test', description: '' },
+    terrain: {
+      tileGridSize: 3,
+      tileHalfExtentM: 8,
+      tiles: [
+        { tileX: 0, tileZ: 0, heights: [0, 0, 0, 0, 0, 0, 0, 0, 0] },
+      ],
+    },
+    staticProps: [],
+    dynamicEntities: [],
+  };
+}
+
+describe('summarizeWorldDiff', () => {
+  it('returns null when nothing changed', () => {
+    const a = blankWorld();
+    const b = cloneWorldDocument(a);
+    expect(summarizeWorldDiff(a, b)).toBeNull();
+  });
+
+  it('detects added static props with their ids', () => {
+    const before = blankWorld();
+    const after = cloneWorldDocument(before);
+    after.staticProps.push({
+      id: 7,
+      kind: 'cuboid',
+      position: [1, 2, 3],
+      rotation: identityQuaternion(),
+      halfExtents: [1, 1, 1],
+    });
+    const summary = summarizeWorldDiff(before, after);
+    expect(summary).toContain('+1 static prop');
+    expect(summary).toContain('#7');
+  });
+
+  it('detects removed dynamic entities', () => {
+    const before = blankWorld();
+    before.dynamicEntities.push({
+      id: 9,
+      kind: 'ball',
+      position: [0, 0, 0],
+      rotation: identityQuaternion(),
+      radius: 0.5,
+    });
+    const after = cloneWorldDocument(before);
+    after.dynamicEntities = [];
+    const summary = summarizeWorldDiff(before, after);
+    expect(summary).toContain('−1 dynamic entity');
+    expect(summary).toContain('#9');
+  });
+
+  it('detects modified entity transforms', () => {
+    const before = blankWorld();
+    before.staticProps.push({
+      id: 1,
+      kind: 'cuboid',
+      position: [0, 0, 0],
+      rotation: identityQuaternion(),
+      halfExtents: [1, 1, 1],
+    });
+    const after = cloneWorldDocument(before);
+    after.staticProps[0] = { ...after.staticProps[0], position: [5, 0, 0] };
+    const summary = summarizeWorldDiff(before, after);
+    expect(summary).toContain('~1 static prop');
+    expect(summary).toContain('#1');
+  });
+
+  it('detects sculpted terrain', () => {
+    const before = blankWorld();
+    const after = cloneWorldDocument(before);
+    after.terrain.tiles[0] = {
+      ...after.terrain.tiles[0],
+      heights: [1, 0, 0, 0, 0, 0, 0, 0, 0],
+    };
+    const summary = summarizeWorldDiff(before, after);
+    expect(summary).toContain('sculpted 1 terrain tile');
+  });
+
+  it('detects added and removed terrain tiles', () => {
+    const before = blankWorld();
+    const afterAdd = cloneWorldDocument(before);
+    afterAdd.terrain.tiles.push({
+      tileX: 1,
+      tileZ: 0,
+      heights: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    });
+    expect(summarizeWorldDiff(before, afterAdd)).toContain('+1 terrain tile');
+
+    const afterRemove = cloneWorldDocument(before);
+    afterRemove.terrain.tiles = [];
+    expect(summarizeWorldDiff(before, afterRemove)).toContain('−1 terrain tile');
+  });
+
+  it('joins multiple changes with semicolons', () => {
+    const before = blankWorld();
+    const after = cloneWorldDocument(before);
+    after.meta.name = 'renamed';
+    after.staticProps.push({
+      id: 2,
+      kind: 'cuboid',
+      position: [0, 0, 0],
+      rotation: identityQuaternion(),
+      halfExtents: [1, 1, 1],
+    });
+    const summary = summarizeWorldDiff(before, after) ?? '';
+    expect(summary).toContain(';');
+    expect(summary).toContain('renamed');
+    expect(summary).toContain('+1 static prop');
+  });
+});

--- a/client/src/ai/worldDiffSummary.ts
+++ b/client/src/ai/worldDiffSummary.ts
@@ -1,0 +1,155 @@
+import type {
+  DynamicEntity,
+  StaticProp,
+  WorldDocument,
+  WorldTerrainTile,
+} from '../world/worldDocument';
+
+const MAX_SUMMARY_LENGTH = 500;
+
+/**
+ * Compare two WorldDocument snapshots and return a short human-readable string
+ * describing what changed. Returns `null` when the documents are equivalent.
+ */
+export function summarizeWorldDiff(
+  before: WorldDocument,
+  after: WorldDocument,
+): string | null {
+  if (before === after) return null;
+
+  const fragments: string[] = [];
+
+  if (before.meta.name !== after.meta.name) {
+    fragments.push(`renamed world to "${after.meta.name}"`);
+  }
+  if (before.meta.description !== after.meta.description) {
+    fragments.push('updated description');
+  }
+
+  diffEntities('static prop', before.staticProps, after.staticProps, fragments);
+  diffEntities('dynamic entity', before.dynamicEntities, after.dynamicEntities, fragments);
+  diffTerrain(before, after, fragments);
+
+  if (fragments.length === 0) return null;
+  return truncate(fragments.join('; '));
+}
+
+function diffEntities<T extends StaticProp | DynamicEntity>(
+  label: string,
+  before: T[],
+  after: T[],
+  out: string[],
+): void {
+  const beforeById = new Map(before.map((e) => [e.id, e]));
+  const afterById = new Map(after.map((e) => [e.id, e]));
+
+  const added: T[] = [];
+  const removed: T[] = [];
+  const modified: T[] = [];
+
+  for (const entity of after) {
+    const prev = beforeById.get(entity.id);
+    if (!prev) {
+      added.push(entity);
+    } else if (!shallowEqualEntity(prev, entity)) {
+      modified.push(entity);
+    }
+  }
+  for (const entity of before) {
+    if (!afterById.has(entity.id)) {
+      removed.push(entity);
+    }
+  }
+
+  if (added.length > 0) {
+    out.push(`+${added.length} ${label}${plural(added.length)} (${describeIds(added, 4)})`);
+  }
+  if (removed.length > 0) {
+    out.push(`−${removed.length} ${label}${plural(removed.length)} (${describeIds(removed, 4)})`);
+  }
+  if (modified.length > 0) {
+    out.push(`~${modified.length} ${label}${plural(modified.length)} (${describeIds(modified, 4)})`);
+  }
+}
+
+function diffTerrain(before: WorldDocument, after: WorldDocument, out: string[]): void {
+  const beforeByKey = new Map<string, WorldTerrainTile>();
+  for (const tile of before.terrain.tiles) {
+    beforeByKey.set(`${tile.tileX}:${tile.tileZ}`, tile);
+  }
+  const afterByKey = new Map<string, WorldTerrainTile>();
+  for (const tile of after.terrain.tiles) {
+    afterByKey.set(`${tile.tileX}:${tile.tileZ}`, tile);
+  }
+
+  let added = 0;
+  let removed = 0;
+  let modified = 0;
+  for (const [key, tile] of afterByKey) {
+    const prev = beforeByKey.get(key);
+    if (!prev) {
+      added += 1;
+    } else if (!heightsEqual(prev.heights, tile.heights)) {
+      modified += 1;
+    }
+  }
+  for (const key of beforeByKey.keys()) {
+    if (!afterByKey.has(key)) {
+      removed += 1;
+    }
+  }
+
+  if (added > 0) out.push(`+${added} terrain tile${plural(added)}`);
+  if (removed > 0) out.push(`−${removed} terrain tile${plural(removed)}`);
+  if (modified > 0) out.push(`sculpted ${modified} terrain tile${plural(modified)}`);
+}
+
+function describeIds(entities: Array<{ id: number }>, max: number): string {
+  if (entities.length <= max) {
+    return entities.map((e) => `#${e.id}`).join(', ');
+  }
+  const shown = entities.slice(0, max).map((e) => `#${e.id}`).join(', ');
+  return `${shown}, +${entities.length - max} more`;
+}
+
+function plural(n: number): string {
+  return n === 1 ? '' : 's';
+}
+
+function shallowEqualEntity(a: StaticProp | DynamicEntity, b: StaticProp | DynamicEntity): boolean {
+  if (a.id !== b.id) return false;
+  if (a.kind !== b.kind) return false;
+  if (!vec3Equal(a.position, b.position)) return false;
+  if (!quatEqual(a.rotation, b.rotation)) return false;
+  const aHalf = (a as StaticProp).halfExtents;
+  const bHalf = (b as StaticProp).halfExtents;
+  if (aHalf || bHalf) {
+    if (!aHalf || !bHalf || !vec3Equal(aHalf, bHalf)) return false;
+  }
+  const aRadius = (a as DynamicEntity).radius;
+  const bRadius = (b as DynamicEntity).radius;
+  if (aRadius !== bRadius) return false;
+  return true;
+}
+
+function vec3Equal(a: readonly number[], b: readonly number[]): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+function quatEqual(a: readonly number[], b: readonly number[]): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3];
+}
+
+function heightsEqual(a: number[], b: number[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function truncate(text: string): string {
+  if (text.length <= MAX_SUMMARY_LENGTH) return text;
+  return `${text.slice(0, MAX_SUMMARY_LENGTH - 1)}…`;
+}

--- a/client/src/ai/worldTool.ts
+++ b/client/src/ai/worldTool.ts
@@ -1,0 +1,30 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { executeUserCode, type SandboxResult } from './sandbox';
+import { buildWorldCtx, type WorldAccessors } from './worldToolHelpers';
+
+const inputSchema = z.object({
+  code: z
+    .string()
+    .min(1)
+    .describe(
+      'Async JavaScript snippet to run in the user\'s browser. The runner exposes a `ctx` object with helpers for reading and mutating the world (see system prompt) and a captured `console`. Use `return ...` to send a value back to yourself. Each call gets a fresh ctx but mutations persist across calls.',
+    ),
+});
+
+export type ExecuteJsInput = z.infer<typeof inputSchema>;
+
+export function createExecuteJsTool(accessors: WorldAccessors) {
+  return tool({
+    description:
+      'Run JavaScript in the browser to inspect or edit the live World document. The wrapped function signature is `async (ctx, console) => { ... }`. Use `ctx.*` helpers (getWorld, listStaticProps, addStaticCuboid, applyTerrainBrush, etc.) to read state or push edits. The result echoes your `return` value, captured console logs, and any thrown error so you can iterate.',
+    inputSchema,
+    async execute(input): Promise<SandboxResult> {
+      const ctx = buildWorldCtx(accessors);
+      return executeUserCode({
+        code: input.code,
+        ctx: ctx as unknown as Record<string, unknown>,
+      });
+    },
+  });
+}

--- a/client/src/ai/worldToolHelpers.test.ts
+++ b/client/src/ai/worldToolHelpers.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { buildWorldCtx, type WorldAccessors } from './worldToolHelpers';
+import {
+  cloneWorldDocument,
+  identityQuaternion,
+  type WorldDocument,
+} from '../world/worldDocument';
+
+function blankWorld(): WorldDocument {
+  return {
+    version: 2,
+    meta: { name: 'test', description: '' },
+    terrain: {
+      tileGridSize: 3,
+      tileHalfExtentM: 8,
+      tiles: [
+        { tileX: 0, tileZ: 0, heights: [0, 0, 0, 0, 0, 0, 0, 0, 0] },
+      ],
+    },
+    staticProps: [],
+    dynamicEntities: [],
+  };
+}
+
+function makeAccessors(initial: WorldDocument): {
+  accessors: WorldAccessors;
+  current: () => WorldDocument;
+  edits: number;
+  aiEditCount: () => number;
+} {
+  let current = initial;
+  let edits = 0;
+  let aiEditCount = 0;
+  const accessors: WorldAccessors = {
+    getWorld: () => current,
+    commitEdit: (updater, options) => {
+      const next = updater(current);
+      if (next === current) return false;
+      current = next;
+      edits += 1;
+      if (options?.isAiEdit) aiEditCount += 1;
+      return true;
+    },
+  };
+  return {
+    accessors,
+    current: () => current,
+    get edits() {
+      return edits;
+    },
+    aiEditCount: () => aiEditCount,
+  } as never;
+}
+
+describe('buildWorldCtx', () => {
+  it('addStaticCuboid pushes a new cuboid via commitEdit and returns its id', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+
+    const result = ctx.addStaticCuboid({
+      position: [1, 0, 2],
+      halfExtents: [0.5, 0.5, 0.5],
+    });
+
+    expect(result.changed).toBe(true);
+    expect(typeof result.id).toBe('number');
+    const world = env.current();
+    expect(world.staticProps).toHaveLength(1);
+    expect(world.staticProps[0].position).toEqual([1, 0, 2]);
+    expect(world.staticProps[0].id).toBe(result.id);
+    // mutation should be marked as AI-originated
+    expect(env.aiEditCount()).toBe(1);
+  });
+
+  it('addStaticCuboid validates inputs and returns a reason on failure', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    const badPosition = ctx.addStaticCuboid({
+      // @ts-expect-error testing runtime guard
+      position: ['nope', 0, 0],
+      halfExtents: [1, 1, 1],
+    });
+    expect(badPosition.changed).toBe(false);
+    expect(badPosition.reason).toMatch(/position/);
+    expect(env.current().staticProps).toHaveLength(0);
+  });
+
+  it('removeEntity and updateEntity operate on the right id', () => {
+    const initial = blankWorld();
+    initial.dynamicEntities.push({
+      id: 5,
+      kind: 'box',
+      position: [0, 0, 0],
+      rotation: identityQuaternion(),
+      halfExtents: [1, 1, 1],
+    });
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+
+    const updated = ctx.updateEntity(5, { position: [3, 0, 0] });
+    expect(updated.changed).toBe(true);
+    expect(env.current().dynamicEntities[0].position).toEqual([3, 0, 0]);
+
+    const removed = ctx.removeEntity(5);
+    expect(removed.changed).toBe(true);
+    expect(env.current().dynamicEntities).toHaveLength(0);
+
+    const missing = ctx.removeEntity(5);
+    expect(missing.changed).toBe(false);
+    expect(missing.reason).toContain('no entity');
+  });
+
+  it('getWorld returns a deep clone (mutations do not bleed through)', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    const snapshot = ctx.getWorld();
+    snapshot.staticProps.push({
+      id: 99,
+      kind: 'cuboid',
+      position: [0, 0, 0],
+      rotation: identityQuaternion(),
+      halfExtents: [1, 1, 1],
+    });
+    expect(env.current().staticProps).toHaveLength(0);
+  });
+
+  it('applyTerrainBrush mutates terrain heights', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    const result = ctx.applyTerrainBrush({
+      centerX: 0,
+      centerZ: 0,
+      radius: 12,
+      strength: 4,
+      mode: 'raise',
+    });
+    expect(result.changed).toBe(true);
+    const after = env.current().terrain.tiles[0].heights;
+    expect(after.some((h) => h > 0)).toBe(true);
+  });
+});

--- a/client/src/ai/worldToolHelpers.ts
+++ b/client/src/ai/worldToolHelpers.ts
@@ -1,0 +1,343 @@
+import {
+  addTerrainTile,
+  applyTerrainBrush,
+  applyTerrainRampStencil,
+  cloneWorldDocument,
+  getAddableTerrainTiles,
+  getNextWorldEntityId,
+  getTerrainTile,
+  getTerrainWorldBounds,
+  identityQuaternion,
+  quaternionFromYaw,
+  removeTerrainTile,
+  sampleTerrainHeightAtWorldPosition,
+  type DynamicEntity,
+  type Quaternion,
+  type StaticProp,
+  type TerrainRampStencil,
+  type Vec3,
+  type WorldDocument,
+} from '../world/worldDocument';
+
+export type WorldEditUpdater = (current: WorldDocument) => WorldDocument;
+
+export type WorldEditOptions = { isAiEdit?: boolean };
+
+export type WorldAccessors = {
+  getWorld: () => WorldDocument;
+  commitEdit: (updater: WorldEditUpdater, options?: WorldEditOptions) => boolean;
+};
+
+export type WorldCtx = {
+  // ---- READ ----
+  getWorld(): WorldDocument;
+  getMeta(): { name: string; description: string };
+  listStaticProps(): StaticProp[];
+  listDynamicEntities(): DynamicEntity[];
+  getEntity(id: number): { kind: 'static'; entity: StaticProp } | { kind: 'dynamic'; entity: DynamicEntity } | null;
+  getTerrainInfo(): {
+    tileGridSize: number;
+    tileHalfExtentM: number;
+    tileCount: number;
+    bounds: ReturnType<typeof getTerrainWorldBounds>;
+  };
+  listTerrainTiles(): Array<{ tileX: number; tileZ: number }>;
+  getTerrainTile(tileX: number, tileZ: number): {
+    tileX: number;
+    tileZ: number;
+    heights: number[];
+  } | null;
+  sampleTerrainHeight(x: number, z: number): number;
+  getAddableTerrainTiles(): Array<{ tileX: number; tileZ: number }>;
+  nextEntityId(): number;
+
+  // ---- WRITE ----
+  addStaticCuboid(spec: {
+    position: Vec3;
+    halfExtents: Vec3;
+    rotation?: Quaternion;
+    material?: string;
+  }): { changed: boolean; id?: number; reason?: string };
+  addDynamicEntity(spec: {
+    kind: 'box' | 'ball' | 'vehicle';
+    position: Vec3;
+    rotation?: Quaternion;
+    halfExtents?: Vec3;
+    radius?: number;
+    vehicleType?: number;
+  }): { changed: boolean; id?: number; reason?: string };
+  removeEntity(id: number): { changed: boolean; reason?: string };
+  updateEntity(
+    id: number,
+    patch: Partial<{
+      position: Vec3;
+      rotation: Quaternion;
+      halfExtents: Vec3;
+      radius: number;
+    }>,
+  ): { changed: boolean; reason?: string };
+
+  applyTerrainBrush(spec: {
+    centerX: number;
+    centerZ: number;
+    radius: number;
+    strength: number;
+    mode: 'raise' | 'lower';
+    minHeight?: number;
+    maxHeight?: number;
+  }): { changed: boolean };
+  applyTerrainRamp(stencil: TerrainRampStencil): { changed: boolean };
+  addTerrainTile(tileX: number, tileZ: number): { changed: boolean };
+  removeTerrainTile(tileX: number, tileZ: number): { changed: boolean };
+
+  // ---- MATH ----
+  quaternionFromYaw(yawRad: number): Quaternion;
+  identityQuaternion(): Quaternion;
+};
+
+/**
+ * Build a fresh `ctx` object for one tool invocation. The accessors are bound
+ * once; helpers always read live world state via `accessors.getWorld()` so that
+ * sequential calls within the same `executeUserCode` invocation see each
+ * other's mutations.
+ */
+export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
+  const aiEdit = (updater: WorldEditUpdater): boolean =>
+    accessors.commitEdit(updater, { isAiEdit: true });
+
+  function findEntityWithKind(id: number): { kind: 'static' | 'dynamic'; entity: StaticProp | DynamicEntity } | null {
+    const world = accessors.getWorld();
+    const staticEntity = world.staticProps.find((e) => e.id === id);
+    if (staticEntity) return { kind: 'static', entity: staticEntity };
+    const dynamicEntity = world.dynamicEntities.find((e) => e.id === id);
+    if (dynamicEntity) return { kind: 'dynamic', entity: dynamicEntity };
+    return null;
+  }
+
+  return {
+    getWorld(): WorldDocument {
+      return cloneWorldDocument(accessors.getWorld());
+    },
+    getMeta() {
+      const world = accessors.getWorld();
+      return { name: world.meta.name, description: world.meta.description };
+    },
+    listStaticProps() {
+      return cloneArray(accessors.getWorld().staticProps);
+    },
+    listDynamicEntities() {
+      return cloneArray(accessors.getWorld().dynamicEntities);
+    },
+    getEntity(id) {
+      const found = findEntityWithKind(id);
+      if (!found) return null;
+      if (found.kind === 'static') {
+        return { kind: 'static', entity: cloneJson(found.entity as StaticProp) };
+      }
+      return { kind: 'dynamic', entity: cloneJson(found.entity as DynamicEntity) };
+    },
+    getTerrainInfo() {
+      const world = accessors.getWorld();
+      return {
+        tileGridSize: world.terrain.tileGridSize,
+        tileHalfExtentM: world.terrain.tileHalfExtentM,
+        tileCount: world.terrain.tiles.length,
+        bounds: getTerrainWorldBounds(world),
+      };
+    },
+    listTerrainTiles() {
+      return accessors.getWorld().terrain.tiles.map((tile) => ({
+        tileX: tile.tileX,
+        tileZ: tile.tileZ,
+      }));
+    },
+    getTerrainTile(tileX, tileZ) {
+      const tile = getTerrainTile(accessors.getWorld(), tileX, tileZ);
+      if (!tile) return null;
+      return { tileX: tile.tileX, tileZ: tile.tileZ, heights: [...tile.heights] };
+    },
+    sampleTerrainHeight(x, z) {
+      return sampleTerrainHeightAtWorldPosition(accessors.getWorld(), x, z);
+    },
+    getAddableTerrainTiles() {
+      return getAddableTerrainTiles(accessors.getWorld()).map(({ tileX, tileZ }) => ({ tileX, tileZ }));
+    },
+    nextEntityId() {
+      return getNextWorldEntityId(accessors.getWorld());
+    },
+
+    addStaticCuboid(spec) {
+      const validation = validateVec3('position', spec.position) ?? validateVec3('halfExtents', spec.halfExtents);
+      if (validation) return { changed: false, reason: validation };
+      let assignedId = 0;
+      const changed = aiEdit((current) => {
+        const id = getNextWorldEntityId(current);
+        assignedId = id;
+        const next: StaticProp = {
+          id,
+          kind: 'cuboid',
+          position: [...spec.position] as Vec3,
+          halfExtents: [...spec.halfExtents] as Vec3,
+          rotation: spec.rotation ? ([...spec.rotation] as Quaternion) : identityQuaternion(),
+          ...(spec.material ? { material: spec.material } : {}),
+        };
+        return { ...current, staticProps: [...current.staticProps, next] };
+      });
+      return changed ? { changed, id: assignedId } : { changed };
+    },
+
+    addDynamicEntity(spec) {
+      if (spec.kind !== 'box' && spec.kind !== 'ball' && spec.kind !== 'vehicle') {
+        return { changed: false, reason: `unknown kind: ${String(spec.kind)}` };
+      }
+      const positionError = validateVec3('position', spec.position);
+      if (positionError) return { changed: false, reason: positionError };
+      if (spec.kind === 'box' && !spec.halfExtents) {
+        return { changed: false, reason: 'box requires halfExtents' };
+      }
+      if (spec.kind === 'ball' && typeof spec.radius !== 'number') {
+        return { changed: false, reason: 'ball requires radius' };
+      }
+      let assignedId = 0;
+      const changed = aiEdit((current) => {
+        const id = getNextWorldEntityId(current);
+        assignedId = id;
+        const next: DynamicEntity = {
+          id,
+          kind: spec.kind,
+          position: [...spec.position] as Vec3,
+          rotation: spec.rotation ? ([...spec.rotation] as Quaternion) : identityQuaternion(),
+          ...(spec.halfExtents ? { halfExtents: [...spec.halfExtents] as Vec3 } : {}),
+          ...(typeof spec.radius === 'number' ? { radius: spec.radius } : {}),
+          ...(typeof spec.vehicleType === 'number' ? { vehicleType: spec.vehicleType } : {}),
+        };
+        return { ...current, dynamicEntities: [...current.dynamicEntities, next] };
+      });
+      return changed ? { changed, id: assignedId } : { changed };
+    },
+
+    removeEntity(id) {
+      const found = findEntityWithKind(id);
+      if (!found) return { changed: false, reason: `no entity with id ${id}` };
+      const changed = aiEdit((current) => {
+        if (found.kind === 'static') {
+          return { ...current, staticProps: current.staticProps.filter((e) => e.id !== id) };
+        }
+        return { ...current, dynamicEntities: current.dynamicEntities.filter((e) => e.id !== id) };
+      });
+      return { changed };
+    },
+
+    updateEntity(id, patch) {
+      if (!patch || typeof patch !== 'object') {
+        return { changed: false, reason: 'patch must be an object' };
+      }
+      if (patch.position) {
+        const err = validateVec3('position', patch.position);
+        if (err) return { changed: false, reason: err };
+      }
+      if (patch.halfExtents) {
+        const err = validateVec3('halfExtents', patch.halfExtents);
+        if (err) return { changed: false, reason: err };
+      }
+      const found = findEntityWithKind(id);
+      if (!found) return { changed: false, reason: `no entity with id ${id}` };
+
+      const changed = aiEdit((current) => {
+        if (found.kind === 'static') {
+          const idx = current.staticProps.findIndex((e) => e.id === id);
+          if (idx === -1) return current;
+          const target = current.staticProps[idx];
+          const updated: StaticProp = {
+            ...target,
+            ...(patch.position ? { position: [...patch.position] as Vec3 } : {}),
+            ...(patch.rotation ? { rotation: [...patch.rotation] as Quaternion } : {}),
+            ...(patch.halfExtents ? { halfExtents: [...patch.halfExtents] as Vec3 } : {}),
+          };
+          const nextProps = [...current.staticProps];
+          nextProps[idx] = updated;
+          return { ...current, staticProps: nextProps };
+        }
+        const idx = current.dynamicEntities.findIndex((e) => e.id === id);
+        if (idx === -1) return current;
+        const target = current.dynamicEntities[idx];
+        const updated: DynamicEntity = {
+          ...target,
+          ...(patch.position ? { position: [...patch.position] as Vec3 } : {}),
+          ...(patch.rotation ? { rotation: [...patch.rotation] as Quaternion } : {}),
+          ...(patch.halfExtents ? { halfExtents: [...patch.halfExtents] as Vec3 } : {}),
+          ...(typeof patch.radius === 'number' ? { radius: patch.radius } : {}),
+        };
+        const nextEntities = [...current.dynamicEntities];
+        nextEntities[idx] = updated;
+        return { ...current, dynamicEntities: nextEntities };
+      });
+      return { changed };
+    },
+
+    applyTerrainBrush(spec) {
+      if (typeof spec?.centerX !== 'number' || typeof spec?.centerZ !== 'number') {
+        return { changed: false };
+      }
+      const changed = aiEdit((current) =>
+        applyTerrainBrush(
+          current,
+          spec.centerX,
+          spec.centerZ,
+          spec.radius,
+          spec.strength,
+          spec.mode,
+          { minHeight: spec.minHeight, maxHeight: spec.maxHeight },
+        ),
+      );
+      return { changed };
+    },
+
+    applyTerrainRamp(stencil) {
+      if (!stencil || typeof stencil !== 'object') {
+        return { changed: false };
+      }
+      const changed = aiEdit((current) => applyTerrainRampStencil(current, stencil));
+      return { changed };
+    },
+
+    addTerrainTile(tileX, tileZ) {
+      const changed = aiEdit((current) => addTerrainTile(current, tileX, tileZ));
+      return { changed };
+    },
+
+    removeTerrainTile(tileX, tileZ) {
+      const changed = aiEdit((current) => removeTerrainTile(current, tileX, tileZ));
+      return { changed };
+    },
+
+    quaternionFromYaw(yawRad) {
+      return quaternionFromYaw(yawRad);
+    },
+    identityQuaternion() {
+      return identityQuaternion();
+    },
+  };
+}
+
+function validateVec3(name: string, value: unknown): string | null {
+  if (
+    !Array.isArray(value)
+    || value.length !== 3
+    || value.some((v) => typeof v !== 'number' || !Number.isFinite(v))
+  ) {
+    return `${name} must be a [x, y, z] tuple of finite numbers`;
+  }
+  return null;
+}
+
+function cloneArray<T>(arr: readonly T[]): T[] {
+  return arr.map((item) => cloneJson(item));
+}
+
+function cloneJson<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -53,6 +53,9 @@ import {
   undoWorldEdit,
   type WorldEditHistory,
 } from './godModeHistory';
+import { AiChatPanel, type AiChatPanelHandle } from './godmode/AiChatPanel';
+import { useHumanEditTracker } from './godmode/useHumanEditTracker';
+import type { WorldAccessors } from '../ai/worldToolHelpers';
 
 type EditorMode = 'edit' | 'play';
 type EditorTool = 'select' | 'terrain';
@@ -109,6 +112,8 @@ export function GodModePage() {
   const worldRef = useRef(world);
   const editHistoryRef = useRef(editHistory);
   const editTransactionRef = useRef<WorldDocument | null>(null);
+  const isAiEditRef = useRef(false);
+  const aiChatRef = useRef<AiChatPanelHandle>(null);
 
   useEffect(() => {
     worldRef.current = world;
@@ -176,6 +181,31 @@ export function GodModePage() {
   const cancelTrackedWorldEdit = useCallback(() => {
     editTransactionRef.current = null;
   }, []);
+
+  const aiAccessors = useMemo<WorldAccessors>(() => ({
+    getWorld: () => worldRef.current,
+    commitEdit: (updater, options) => {
+      const wasAiEdit = isAiEditRef.current;
+      if (options?.isAiEdit) {
+        isAiEditRef.current = true;
+      }
+      try {
+        return applyCommittedWorldEdit(updater);
+      } finally {
+        isAiEditRef.current = wasAiEdit;
+      }
+    },
+  }), [applyCommittedWorldEdit]);
+
+  const handleHumanEdit = useCallback((summary: string) => {
+    aiChatRef.current?.pushHumanEdit(summary);
+  }, []);
+
+  useHumanEditTracker({
+    world,
+    isAiEditRef,
+    onHumanEdit: handleHumanEdit,
+  });
 
   const handleUndo = useCallback(() => {
     cancelTrackedWorldEdit();
@@ -1115,6 +1145,8 @@ export function GodModePage() {
         )}
         {editScene}
       </main>
+
+      <AiChatPanel ref={aiChatRef} accessors={aiAccessors} />
     </div>
   );
 }
@@ -1925,7 +1957,7 @@ function slugify(value: string): string {
 
 const pageStyle: CSSProperties = {
   display: 'grid',
-  gridTemplateColumns: '340px minmax(0, 1fr)',
+  gridTemplateColumns: '340px minmax(0, 1fr) 380px',
   height: '100vh',
   background: 'linear-gradient(180deg, #0d1824 0%, #060a10 100%)',
   color: '#eef7ff',

--- a/client/src/pages/godmode/AiChatPanel.tsx
+++ b/client/src/pages/godmode/AiChatPanel.tsx
@@ -1,0 +1,657 @@
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ChangeEvent,
+  type ForwardedRef,
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { forwardRef } from 'react';
+import type { ChatMessage, ChatPart } from '../../ai/chatTypes';
+import {
+  MODELS,
+  PROVIDER_LABELS,
+  defaultModelFor,
+  isProviderId,
+  type ProviderId,
+} from '../../ai/providers';
+import {
+  clearStoredApiKeys,
+  loadSettings,
+  saveSettings,
+  type AiChatSettings,
+} from '../../ai/settingsStore';
+import { useGodModeChat } from '../../ai/useGodModeChat';
+import type { WorldAccessors } from '../../ai/worldToolHelpers';
+
+export type AiChatPanelHandle = {
+  pushHumanEdit: (summary: string) => void;
+};
+
+type AiChatPanelProps = {
+  accessors: WorldAccessors;
+};
+
+export const AiChatPanel = forwardRef(function AiChatPanel(
+  { accessors }: AiChatPanelProps,
+  ref: ForwardedRef<AiChatPanelHandle>,
+) {
+  const [settings, setSettings] = useState<AiChatSettings>(() => loadSettings());
+  const apiKey = settings.apiKeys[settings.provider];
+
+  const chat = useGodModeChat({
+    accessors,
+    provider: settings.provider,
+    model: settings.model,
+    apiKey,
+  });
+
+  // Expose pushHumanEdit so the parent page can forward human edit summaries.
+  useImperativeHandle(
+    ref,
+    () => ({
+      pushHumanEdit: (summary: string) => chat.pushHumanEdit(summary),
+    }),
+    [chat],
+  );
+
+  // Persist settings whenever they change.
+  useEffect(() => {
+    saveSettings(settings);
+  }, [settings]);
+
+  const onProviderChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value;
+    if (!isProviderId(next)) return;
+    setSettings((current) => ({
+      ...current,
+      provider: next,
+      model: defaultModelFor(next),
+    }));
+  }, []);
+
+  const onModelChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value;
+    setSettings((current) => ({ ...current, model: next }));
+  }, []);
+
+  const onApiKeyChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const next = event.target.value;
+      setSettings((current) => ({
+        ...current,
+        apiKeys: { ...current.apiKeys, [current.provider]: next },
+      }));
+    },
+    [],
+  );
+
+  const onClearKeys = useCallback(() => {
+    clearStoredApiKeys();
+    setSettings((current) => ({ ...current, apiKeys: {} }));
+  }, []);
+
+  const [draft, setDraft] = useState('');
+  const [settingsOpen, setSettingsOpen] = useState(!apiKey);
+
+  const messageListRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = messageListRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [chat.messages]);
+
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!chat.canSend) return;
+      const text = draft;
+      setDraft('');
+      void chat.sendMessage(text);
+    },
+    [chat, draft],
+  );
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        if (!chat.canSend) return;
+        const text = draft;
+        setDraft('');
+        void chat.sendMessage(text);
+      }
+    },
+    [chat, draft],
+  );
+
+  const modelOptions = useMemo(() => MODELS[settings.provider], [settings.provider]);
+  const placeholderHint = apiKey
+    ? `Ask ${PROVIDER_LABELS[settings.provider]} (${settings.model}) to edit the world…`
+    : `Add an ${PROVIDER_LABELS[settings.provider]} API key to start chatting`;
+
+  return (
+    <aside style={panelStyle}>
+      <div style={headerStyle}>
+        <span style={eyebrowStyle}>AI Co-Editor</span>
+        <h2 style={titleStyle}>Chat</h2>
+        <p style={mutedStyle}>
+          Bring-your-own-key. Calls go straight to the provider from your browser — no proxy.
+        </p>
+      </div>
+
+      <div style={sectionStyle}>
+        <div style={settingsHeaderStyle}>
+          <button
+            type="button"
+            onClick={() => setSettingsOpen((v) => !v)}
+            style={ghostButtonStyle}
+          >
+            {settingsOpen ? '▾ Settings' : '▸ Settings'}
+          </button>
+          <span style={mutedStyle}>
+            {PROVIDER_LABELS[settings.provider]} · {settings.model}
+            {apiKey ? ' · key set' : ' · no key'}
+          </span>
+        </div>
+        {settingsOpen && (
+          <div style={settingsBodyStyle}>
+            <label style={fieldLabelStyle}>
+              Provider
+              <select
+                value={settings.provider}
+                onChange={onProviderChange}
+                style={selectStyle}
+              >
+                {(Object.keys(MODELS) as ProviderId[]).map((id) => (
+                  <option key={id} value={id}>
+                    {PROVIDER_LABELS[id]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={fieldLabelStyle}>
+              Model
+              <select value={settings.model} onChange={onModelChange} style={selectStyle}>
+                {modelOptions.includes(settings.model) ? null : (
+                  <option value={settings.model}>{settings.model} (custom)</option>
+                )}
+                {modelOptions.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={fieldLabelStyle}>
+              {PROVIDER_LABELS[settings.provider]} API key
+              <input
+                type="password"
+                value={apiKey ?? ''}
+                onChange={onApiKeyChange}
+                placeholder="sk-…"
+                style={inputStyle}
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </label>
+            <div style={buttonRowStyle}>
+              <button type="button" onClick={onClearKeys} style={dangerButtonStyle}>
+                Clear all keys
+              </button>
+              <button type="button" onClick={chat.clear} style={secondaryButtonStyle}>
+                Clear chat
+              </button>
+            </div>
+            <p style={mutedStyle}>
+              Keys live in <code>localStorage</code> on this device only. They&apos;re sent
+              directly to the provider with each request.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div style={messageListStyle} ref={messageListRef}>
+        {chat.messages.length === 0 && (
+          <div style={emptyStateStyle}>
+            <p>
+              Try: <em>&ldquo;Add a 2&times;2&times;2 cuboid 5 meters north of the origin.&rdquo;</em>
+            </p>
+            <p>
+              Or: <em>&ldquo;How many static props are in the world right now?&rdquo;</em>
+            </p>
+          </div>
+        )}
+        {chat.messages.map((msg) => (
+          <MessageBubble key={msg.id} message={msg} />
+        ))}
+        {chat.status === 'streaming' && <div style={streamingIndicatorStyle}>…thinking</div>}
+      </div>
+
+      {chat.error && (
+        <div style={errorBannerStyle}>
+          <strong>Error:</strong> {chat.error.message}
+        </div>
+      )}
+
+      {chat.pendingHumanEdits > 0 && (
+        <div style={pendingBannerStyle}>
+          {chat.pendingHumanEdits} human edit{chat.pendingHumanEdits === 1 ? '' : 's'} pending — will be shared with the AI on your next message.
+        </div>
+      )}
+
+      <form onSubmit={onSubmit} style={composerStyle}>
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholderHint}
+          rows={3}
+          style={textareaStyle}
+          disabled={chat.status === 'streaming'}
+        />
+        <div style={composerActionsStyle}>
+          {chat.status === 'streaming' ? (
+            <button type="button" onClick={chat.stop} style={dangerButtonStyle}>
+              Stop
+            </button>
+          ) : (
+            <button
+              type="submit"
+              disabled={!chat.canSend || draft.trim().length === 0}
+              style={chat.canSend && draft.trim().length > 0 ? primaryButtonStyle : disabledButtonStyle}
+            >
+              Send
+            </button>
+          )}
+        </div>
+      </form>
+    </aside>
+  );
+});
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === 'user';
+  return (
+    <div style={isUser ? userBubbleStyle : assistantBubbleStyle}>
+      <div style={roleLabelStyle}>{isUser ? 'You' : 'Assistant'}</div>
+      {message.parts.map((part, idx) => (
+        <PartView key={idx} part={part} />
+      ))}
+    </div>
+  );
+}
+
+function PartView({ part }: { part: ChatPart }) {
+  if (part.type === 'text') {
+    return <div style={textPartStyle}>{part.text}</div>;
+  }
+  if (part.type === 'reasoning') {
+    return <div style={reasoningPartStyle}>{part.text}</div>;
+  }
+  if (part.type === 'tool-call') {
+    const code = extractCode(part.input);
+    return (
+      <details style={toolCallStyle}>
+        <summary style={toolSummaryStyle}>
+          <span style={toolBadgeStyle}>tool</span> {part.toolName}
+        </summary>
+        <pre style={codeBlockStyle}>{code ?? jsonStringify(part.input)}</pre>
+      </details>
+    );
+  }
+  if (part.type === 'tool-result') {
+    const isError = Boolean(part.isError);
+    return (
+      <details
+        open={isError}
+        style={{ ...toolResultStyle, borderColor: isError ? 'rgba(255, 110, 110, 0.45)' : toolResultStyle.borderColor }}
+      >
+        <summary style={toolSummaryStyle}>
+          <span style={isError ? toolErrorBadgeStyle : toolResultBadgeStyle}>
+            {isError ? 'error' : 'result'}
+          </span>{' '}
+          {part.toolName}
+        </summary>
+        <pre style={codeBlockStyle}>{jsonStringify(part.output)}</pre>
+      </details>
+    );
+  }
+  return null;
+}
+
+function extractCode(input: unknown): string | null {
+  if (input && typeof input === 'object' && 'code' in (input as Record<string, unknown>)) {
+    const code = (input as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  return null;
+}
+
+function jsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+// ---------- styles (match GodMode.tsx palette) ----------
+
+const panelStyle: CSSProperties = {
+  borderLeft: '1px solid rgba(141, 186, 221, 0.14)',
+  padding: 20,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+  minHeight: 0,
+  background: 'rgba(3, 8, 14, 0.92)',
+  color: '#eef7ff',
+  overflow: 'hidden',
+};
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+};
+
+const eyebrowStyle: CSSProperties = {
+  fontSize: 11,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: '#86d6f5',
+};
+
+const titleStyle: CSSProperties = {
+  margin: '4px 0 2px',
+  fontSize: 24,
+  lineHeight: 1.1,
+};
+
+const mutedStyle: CSSProperties = {
+  fontSize: 12,
+  color: 'rgba(238, 247, 255, 0.6)',
+  margin: 0,
+};
+
+const sectionStyle: CSSProperties = {
+  border: '1px solid rgba(141, 186, 221, 0.14)',
+  borderRadius: 14,
+  padding: 12,
+  background: 'rgba(14, 26, 38, 0.84)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+};
+
+const settingsHeaderStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+};
+
+const settingsBodyStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+};
+
+const fieldLabelStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  fontSize: 12,
+  color: 'rgba(238, 247, 255, 0.82)',
+};
+
+const selectStyle: CSSProperties = {
+  background: 'rgba(20, 34, 48, 0.96)',
+  color: '#eef7ff',
+  border: '1px solid rgba(167, 208, 237, 0.18)',
+  borderRadius: 8,
+  padding: '6px 8px',
+  fontSize: 13,
+};
+
+const inputStyle: CSSProperties = {
+  background: 'rgba(20, 34, 48, 0.96)',
+  color: '#eef7ff',
+  border: '1px solid rgba(167, 208, 237, 0.18)',
+  borderRadius: 8,
+  padding: '8px 10px',
+  fontSize: 13,
+  fontFamily: 'inherit',
+};
+
+const buttonRowStyle: CSSProperties = {
+  display: 'flex',
+  gap: 8,
+  flexWrap: 'wrap',
+};
+
+const baseButtonStyle: CSSProperties = {
+  borderRadius: 10,
+  padding: '8px 12px',
+  border: '1px solid rgba(167, 208, 237, 0.16)',
+  cursor: 'pointer',
+  fontWeight: 600,
+  fontSize: 13,
+};
+
+const primaryButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  background: '#9ed86f',
+  color: '#10210d',
+};
+
+const secondaryButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  background: 'rgba(20, 34, 48, 0.96)',
+  color: '#eef7ff',
+};
+
+const dangerButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  background: '#ff8573',
+  color: '#38130e',
+};
+
+const ghostButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  background: 'transparent',
+  border: '1px solid transparent',
+  padding: '4px 6px',
+  color: '#86d6f5',
+};
+
+const disabledButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  background: 'rgba(20, 34, 48, 0.96)',
+  color: 'rgba(238, 247, 255, 0.4)',
+  cursor: 'not-allowed',
+};
+
+const messageListStyle: CSSProperties = {
+  flex: 1,
+  minHeight: 0,
+  overflowY: 'auto',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+  paddingRight: 4,
+};
+
+const emptyStateStyle: CSSProperties = {
+  color: 'rgba(238, 247, 255, 0.55)',
+  fontSize: 13,
+  lineHeight: 1.5,
+  border: '1px dashed rgba(141, 186, 221, 0.2)',
+  borderRadius: 14,
+  padding: 14,
+};
+
+const userBubbleStyle: CSSProperties = {
+  alignSelf: 'flex-end',
+  maxWidth: '92%',
+  background: 'rgba(116, 212, 255, 0.16)',
+  border: '1px solid rgba(116, 212, 255, 0.32)',
+  borderRadius: 14,
+  padding: '8px 12px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const assistantBubbleStyle: CSSProperties = {
+  alignSelf: 'flex-start',
+  maxWidth: '96%',
+  background: 'rgba(14, 26, 38, 0.84)',
+  border: '1px solid rgba(141, 186, 221, 0.14)',
+  borderRadius: 14,
+  padding: '8px 12px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const roleLabelStyle: CSSProperties = {
+  fontSize: 10,
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: '#86d6f5',
+};
+
+const textPartStyle: CSSProperties = {
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  fontSize: 13,
+  lineHeight: 1.5,
+};
+
+const reasoningPartStyle: CSSProperties = {
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  fontSize: 12,
+  lineHeight: 1.5,
+  color: 'rgba(238, 247, 255, 0.55)',
+  fontStyle: 'italic',
+};
+
+const toolCallStyle: CSSProperties = {
+  border: '1px solid rgba(116, 212, 255, 0.2)',
+  borderRadius: 10,
+  padding: '6px 8px',
+  background: 'rgba(8, 18, 28, 0.72)',
+};
+
+const toolResultStyle: CSSProperties = {
+  border: '1px solid rgba(158, 216, 111, 0.2)',
+  borderRadius: 10,
+  padding: '6px 8px',
+  background: 'rgba(8, 18, 28, 0.72)',
+};
+
+const toolSummaryStyle: CSSProperties = {
+  cursor: 'pointer',
+  fontSize: 11,
+  letterSpacing: '0.08em',
+  color: 'rgba(238, 247, 255, 0.7)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+};
+
+const toolBadgeStyle: CSSProperties = {
+  background: 'rgba(116, 212, 255, 0.2)',
+  color: '#bae8ff',
+  padding: '1px 6px',
+  borderRadius: 6,
+  fontSize: 10,
+  textTransform: 'uppercase',
+  letterSpacing: '0.12em',
+};
+
+const toolResultBadgeStyle: CSSProperties = {
+  ...toolBadgeStyle,
+  background: 'rgba(158, 216, 111, 0.2)',
+  color: '#d6efaf',
+};
+
+const toolErrorBadgeStyle: CSSProperties = {
+  ...toolBadgeStyle,
+  background: 'rgba(255, 133, 115, 0.22)',
+  color: '#ffbcb0',
+};
+
+const codeBlockStyle: CSSProperties = {
+  margin: '8px 0 2px',
+  padding: 8,
+  background: 'rgba(0, 0, 0, 0.32)',
+  border: '1px solid rgba(141, 186, 221, 0.12)',
+  borderRadius: 8,
+  fontSize: 11,
+  lineHeight: 1.45,
+  overflowX: 'auto',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  color: 'rgba(238, 247, 255, 0.86)',
+  maxHeight: 240,
+};
+
+const streamingIndicatorStyle: CSSProperties = {
+  alignSelf: 'flex-start',
+  fontSize: 12,
+  color: 'rgba(116, 212, 255, 0.7)',
+  fontStyle: 'italic',
+};
+
+const errorBannerStyle: CSSProperties = {
+  border: '1px solid rgba(255, 110, 110, 0.36)',
+  background: 'rgba(255, 110, 110, 0.12)',
+  color: '#ffd0c8',
+  borderRadius: 12,
+  padding: '8px 12px',
+  fontSize: 12,
+};
+
+const pendingBannerStyle: CSSProperties = {
+  border: '1px solid rgba(116, 212, 255, 0.28)',
+  background: 'rgba(116, 212, 255, 0.10)',
+  color: '#bae8ff',
+  borderRadius: 12,
+  padding: '8px 12px',
+  fontSize: 12,
+};
+
+const composerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+};
+
+const composerActionsStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: 8,
+};
+
+const textareaStyle: CSSProperties = {
+  width: '100%',
+  resize: 'vertical',
+  background: 'rgba(20, 34, 48, 0.96)',
+  color: '#eef7ff',
+  border: '1px solid rgba(167, 208, 237, 0.18)',
+  borderRadius: 10,
+  padding: '10px 12px',
+  fontSize: 13,
+  fontFamily: 'inherit',
+  lineHeight: 1.4,
+};

--- a/client/src/pages/godmode/useHumanEditTracker.ts
+++ b/client/src/pages/godmode/useHumanEditTracker.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+import { summarizeWorldDiff } from '../../ai/worldDiffSummary';
+import type { WorldDocument } from '../../world/worldDocument';
+
+/**
+ * Watches the world document for changes and emits a short text summary every
+ * time the document changes due to a *human* edit (i.e. not an AI tool call).
+ *
+ * The caller passes a ref-like getter for the "is this an AI edit?" flag so the
+ * tracker can ignore mutations that originated from the chat hook's own tool
+ * execution path.
+ */
+export function useHumanEditTracker(options: {
+  world: WorldDocument;
+  isAiEditRef: React.MutableRefObject<boolean>;
+  onHumanEdit: (summary: string) => void;
+}): void {
+  const { world, isAiEditRef, onHumanEdit } = options;
+  const previousRef = useRef<WorldDocument | null>(null);
+  const callbackRef = useRef(onHumanEdit);
+  useEffect(() => {
+    callbackRef.current = onHumanEdit;
+  }, [onHumanEdit]);
+
+  useEffect(() => {
+    const previous = previousRef.current;
+    previousRef.current = world;
+    if (!previous) return;
+    if (previous === world) return;
+    if (isAiEditRef.current) return;
+    const summary = summarizeWorldDiff(previous, world);
+    if (summary) {
+      callbackRef.current(summary);
+    }
+  }, [isAiEditRef, world]);
+}


### PR DESCRIPTION
## Summary

This PR introduces an AI co-editor chat interface for the GodMode world editor, allowing users to collaborate with an AI assistant to modify their 3D world. The AI can read world state and execute mutations through a sandboxed JavaScript execution environment.

## Key Changes

- **AiChatPanel component** (`client/src/pages/godmode/AiChatPanel.tsx`): A full-featured chat UI with:
  - Provider/model selection (OpenAI, Anthropic, Google Gemini)
  - API key management stored in localStorage
  - Message history with support for text, reasoning, tool calls, and tool results
  - Settings panel for configuration
  - Real-time streaming responses with stop capability

- **Chat infrastructure** (`client/src/ai/`):
  - `useGodModeChat.ts`: React hook managing chat state, message streaming, and tool execution
  - `chatTypes.ts`: Type definitions for chat messages and parts
  - `systemPrompt.ts`: Comprehensive system prompt defining the world model and tool capabilities
  - `providers.ts`: Multi-provider language model factory (OpenAI, Anthropic, Google)
  - `settingsStore.ts`: Persistent settings management for provider, model, and API keys

- **World editing system**:
  - `worldToolHelpers.ts`: `WorldCtx` API exposing read/write operations on the world document (entities, terrain, metadata)
  - `worldTool.ts`: AI tool definition for executing JavaScript code with world context
  - `sandbox.ts`: Safe in-process JavaScript execution with console capture and error handling
  - `worldDiffSummary.ts`: Automatic summarization of world changes for human edit tracking

- **Human edit tracking** (`useHumanEditTracker.ts`): Monitors world changes and summarizes human edits to share with the AI on subsequent messages

- **GodMode integration**: Updated `GodMode.tsx` to:
  - Instantiate the AI chat panel with world accessors
  - Track AI vs. human edits to avoid feedback loops
  - Forward human edit summaries to the chat interface

- **Dependencies**: Added `@ai-sdk/anthropic`, `@ai-sdk/google`, and `@ai-sdk/openai` for multi-provider LLM support

## Notable Implementation Details

- **Trust model**: No real sandbox—code executes in the same realm as the page. Users control their own API keys and explicitly choose the AI model, so this is treated like a developer console.
- **Streaming UI**: Chat messages update in real-time as the model streams responses, with separate tracking for text and reasoning blocks.
- **World mutations**: All AI edits are marked with `isAiEdit: true` to distinguish them from human changes and prevent the AI from reacting to its own modifications.
- **Bring-your-own-key**: API keys are stored locally in localStorage and sent directly to providers from the browser—no backend proxy.

https://claude.ai/code/session_01Yb6NQYjAv5VNt2vtT9i1Gx