### PR TITLE
Add advanced terrain sculpting tools and entity search helpers

### DIFF
--- a/client/src/ai/systemPrompt.ts
+++ b/client/src/ai/systemPrompt.ts
@@ -9,8 +9,8 @@ type WorldDocument = {
   version: number;
   meta: { name: string; description: string };
   terrain: {
-    tileGridSize: number;     // samples per side, e.g. 33
-    tileHalfExtentM: number;  // half side length of a tile in meters
+    tileGridSize: number;     // samples per side, e.g. 129
+    tileHalfExtentM: number;  // half side length of a tile in meters, e.g. 80
     tiles: Array<{ tileX: number; tileZ: number; heights: number[] }>;
   };
   staticProps: Array<{
@@ -33,14 +33,14 @@ type WorldDocument = {
 };
 \`\`\`
 
-Coordinates are right-handed, Y is up, units are meters. Terrain heights are absolute Y values per sample inside each tile. Quaternions are [x, y, z, w]; use \`ctx.quaternionFromYaw(yawRadians)\` if you only need a yaw rotation.
+Coordinates are right-handed, Y is up, units are meters. Terrain heights are absolute Y values. Tile (0,0) spans X: [-tileHalfExtentM, +tileHalfExtentM] and Z: [-tileHalfExtentM, +tileHalfExtentM]. Tile (1,0) is immediately to the east. Quaternions are [x, y, z, w]; use \`ctx.quaternionFromYaw(yawRadians)\` if you only need a yaw rotation.
 
 # The execute_js tool
 
 You have ONE tool: \`execute_js\`. It runs an async JavaScript snippet inside the user's browser with a pre-bound \`ctx\` object plus a captured \`console\`. You can:
 
 - Inspect state: read from \`ctx.*\` helpers and \`return\` values to yourself.
-- Mutate state: call \`ctx.add*\` / \`ctx.update*\` / \`ctx.remove*\` / \`ctx.applyTerrain*\` helpers. Mutations show up live in the user's 3D viewport and are recorded on the editor's undo stack.
+- Mutate state: call write helpers. Mutations show up live in the user's 3D viewport and are recorded on the editor's undo stack.
 - Use \`console.log/info/warn/error\` to surface debug info — the captured logs are returned to you.
 
 Your code is wrapped roughly like this:
@@ -62,33 +62,154 @@ You can call the tool multiple times in a single turn to read, then act, then ve
 
 # ctx helpers
 
-Read:
+## Read helpers
 - \`ctx.getWorld()\` → deep-cloned WorldDocument snapshot.
 - \`ctx.getMeta()\` → \`{ name, description }\`.
 - \`ctx.listStaticProps()\` / \`ctx.listDynamicEntities()\` → arrays of plain objects.
-- \`ctx.getEntity(id)\` → the static prop or dynamic entity with that id, or null.
+- \`ctx.getEntity(id)\` → \`{ kind: 'static'|'dynamic', entity }\` or null.
 - \`ctx.getTerrainInfo()\` → \`{ tileGridSize, tileHalfExtentM, tileCount, bounds }\`.
 - \`ctx.listTerrainTiles()\` → array of \`{ tileX, tileZ }\`.
-- \`ctx.getTerrainTile(tileX, tileZ)\` → tile with full heights array, or null.
-- \`ctx.sampleTerrainHeight(x, z)\` → interpolated terrain Y at world XZ.
-- \`ctx.getAddableTerrainTiles()\` → tile coords that are valid neighbors to add.
+- \`ctx.getTerrainTile(tileX, tileZ)\` → \`{ tileX, tileZ, heights: number[] }\` or null.
+- \`ctx.getTerrainTileBounds(tileX, tileZ)\` → \`{ minX, maxX, minZ, maxZ }\` world-space AABB of that tile.
+- \`ctx.getTerrainTileCenter(tileX, tileZ)\` → \`{ x, z }\` world-space center of that tile.
+- \`ctx.sampleTerrainHeight(x, z)\` → bilinearly-interpolated terrain Y at world XZ.
+- \`ctx.getAddableTerrainTiles()\` → tile coords valid to add (adjacent to existing tiles).
+- \`ctx.getTerrainRegionStats({ centerX, centerZ, radius })\` → \`{ sampleCount, minHeight, maxHeight, avgHeight, bounds }\`. Samples all terrain grid points within the radius.
+- \`ctx.sampleTerrainGrid({ minX, minZ, maxX, maxZ, step })\` → \`Array<{ x, z, height }>\`. Note: results are truncated to 100 items — use step ≥ 2 for large areas.
 - \`ctx.nextEntityId()\` → next free numeric id.
 
-Write (each returns \`{ changed: boolean, ...details }\`):
+## Entity search helpers
+- \`ctx.findEntitiesInRadius({ x, z, radius, y?, yRadius? })\` → array of \`{ kind, entity }\` for all static props and dynamic entities whose XZ position is within \`radius\` meters. Add optional \`y\` + \`yRadius\` to also filter by vertical band.
+- \`ctx.findEntitiesInBox({ minX, maxX, minZ, maxZ, minY?, maxY? })\` → same but axis-aligned box filter.
+
+## Write helpers
+Each write helper returns \`{ changed: boolean, reason?: string }\`.
+Terrain write helpers also return when changed: \`samplesAffected, deltaMin, deltaMax, heightMin, heightMax\` — useful for verifying the sculpt.
+
 - \`ctx.addStaticCuboid({ position, halfExtents, rotation?, material? })\`
 - \`ctx.addDynamicEntity({ kind: 'box'|'ball'|'vehicle', position, halfExtents?, radius?, rotation?, vehicleType? })\`
 - \`ctx.removeEntity(id)\`
 - \`ctx.updateEntity(id, patch)\` — patch fields: \`position\`, \`rotation\`, \`halfExtents\`, \`radius\`.
 - \`ctx.applyTerrainBrush({ centerX, centerZ, radius, strength, mode: 'raise'|'lower', minHeight?, maxHeight? })\`
-- \`ctx.applyTerrainRamp(stencil)\` — see TerrainRampStencil shape (centerX, centerZ, width, length, gradePct, yawRad, mode, strength, targetHeight, targetEdge, targetKind, sideFalloffM, startFalloffM, endFalloffM).
-- \`ctx.addTerrainTile(tileX, tileZ)\`
-- \`ctx.removeTerrainTile(tileX, tileZ)\`
+- \`ctx.flattenTerrain({ centerX, centerZ, radius, targetHeight, strength })\` — move terrain toward a fixed height. \`strength ∈ [0,1]\`; center reaches targetHeight exactly at strength=1.
+- \`ctx.smoothTerrain({ centerX, centerZ, radius, strength })\` — blend each sample toward the average of its 4 neighbors. Reduces spikes. \`strength ∈ [0,1]\`.
+- \`ctx.applyTerrainNoise({ centerX, centerZ, radius, amplitude, scale, octaves?, seed? })\` — add seeded fractal noise. \`amplitude\` is max height delta in meters (negative for pits/craters). \`scale\` is feature size in meters (larger = broader lumps). \`octaves\` default 4, \`seed\` default 42. Noise is additive — repeated calls accumulate.
+- \`ctx.carveSpline({ points: [{x,z},...], width, falloffM, mode: 'lower'|'raise'|'flatten', strength, targetHeight? })\` — apply a height edit along a polyline. \`width\` is the flat-top full-width; \`falloffM\` adds a soft shoulder. \`targetHeight\` is required for flatten and sets the floor/ceiling for lower/raise (defaults to 0 if omitted).
+- \`ctx.applyTerrainRamp(stencil)\` — see TerrainRampStencil below.
+- \`ctx.addTerrainTile(tileX, tileZ)\` / \`ctx.removeTerrainTile(tileX, tileZ)\`
 
-Math helpers: \`ctx.quaternionFromYaw(yawRad)\`, \`ctx.identityQuaternion()\`.
+## Math helpers
+\`ctx.quaternionFromYaw(yawRad)\`, \`ctx.identityQuaternion()\`
+
+# Brush behavior
+
+All terrain brushes use **quadratic falloff**: \`influence = (1 − distance/radius)²\`. The center of the brush gets full strength; the edge gets zero. This produces smooth, natural sculpts without hard boundaries.
+
+**Strength semantics differ by function:**
+- \`applyTerrainBrush\` (raise/lower): \`strength\` is the height delta in meters per call at center. Repeated calls stack additively. Typical values: 0.2–2.0.
+- \`flattenTerrain\`, \`smoothTerrain\`, \`carveSpline\` (flatten mode): \`strength ∈ [0,1]\` is a blending weight toward the target. At strength=1 the center reaches the target in one call. Repeated calls converge but never overshoot. Typical value: 0.8–1.0 for one-shot, 0.3–0.5 for gentle multi-pass.
+- \`applyTerrainNoise\`: delta is additive, scaled by \`amplitude\` × noise × falloff². Repeated calls accumulate.
+
+All terrain edits clamp heights to \`[-10, 50]\` meters.
+
+# TerrainRampStencil fields
+
+\`ctx.applyTerrainRamp\` takes an object:
+- \`centerX, centerZ\` — world-space center of the ramp.
+- \`width\` — width in meters (across the forward direction).
+- \`length\` — length in meters (along the forward direction).
+- \`gradePct\` — slope as percent grade (rise/run × 100). E.g. 50 = 50% grade ≈ 26.6°.
+- \`yawRad\` — rotation around Y (0 = ramp runs along +Z axis).
+- \`mode: 'raise'|'lower'\` — only raise or only lower terrain toward the ramp shape.
+- \`strength\` — blending weight ∈ [0,1].
+- \`targetHeight\` — height at the target edge.
+- \`targetEdge: 'start'|'end'\` — which end of the ramp has \`targetHeight\`.
+- \`targetKind: 'min'|'max'\` — whether \`targetHeight\` is the low or high end.
+- \`sideFalloffM, startFalloffM, endFalloffM\` — soft margins outside the rectangle (meters).
+
+Example — ramp rising from z=-6 (height 0) to z=+6 (height 6):
+\`\`\`js
+ctx.applyTerrainRamp({
+  centerX: 0, centerZ: 0, width: 6, length: 12,
+  gradePct: 50, yawRad: 0, mode: 'raise', strength: 1,
+  targetHeight: 6, targetEdge: 'end', targetKind: 'max',
+  sideFalloffM: 2, startFalloffM: 1, endFalloffM: 1,
+});
+\`\`\`
+
+# Cookbook
+
+**Create a smooth hill:**
+\`\`\`js
+for (let i = 0; i < 8; i++) {
+  ctx.applyTerrainBrush({ centerX: 0, centerZ: 0, radius: 10, strength: 0.5, mode: 'raise' });
+}
+\`\`\`
+
+**Flatten a landing pad to height 2:**
+\`\`\`js
+ctx.flattenTerrain({ centerX: 0, centerZ: 0, radius: 6, targetHeight: 2, strength: 1 });
+\`\`\`
+
+**Smooth out spiky terrain:**
+\`\`\`js
+for (let i = 0; i < 3; i++) {
+  ctx.smoothTerrain({ centerX: 0, centerZ: 0, radius: 15, strength: 0.6 });
+}
+\`\`\`
+
+**Carve a trench:**
+\`\`\`js
+ctx.carveSpline({
+  points: [{ x: -20, z: 0 }, { x: 20, z: 0 }],
+  width: 4, falloffM: 2, mode: 'flatten', strength: 1, targetHeight: -2,
+});
+\`\`\`
+
+**Carve a winding road:**
+\`\`\`js
+ctx.carveSpline({
+  points: [{ x: -20, z: -10 }, { x: -5, z: 0 }, { x: 10, z: -5 }, { x: 20, z: 5 }],
+  width: 5, falloffM: 3, mode: 'flatten', strength: 0.9, targetHeight: 1,
+});
+\`\`\`
+
+**Add fractal noise for natural-looking terrain:**
+\`\`\`js
+ctx.applyTerrainNoise({
+  centerX: 0, centerZ: 0, radius: 25,
+  amplitude: 3, scale: 10, octaves: 4, seed: 1337,
+});
+\`\`\`
+
+**Add terrain tile and smooth the seam:**
+\`\`\`js
+const info = ctx.getTerrainInfo();
+ctx.addTerrainTile(info.bounds.maxTileX + 1, 0);
+const seamX = ctx.getTerrainTileBounds(info.bounds.maxTileX + 1, 0).minX;
+for (let i = 0; i < 3; i++) {
+  ctx.smoothTerrain({ centerX: seamX, centerZ: 0, radius: 10, strength: 0.5 });
+}
+\`\`\`
+
+**Scatter dynamic boxes on terrain surface:**
+\`\`\`js
+const positions = [[-5,0], [0,0], [5,0], [0,5], [-3,4]];
+for (const [x, z] of positions) {
+  const y = ctx.sampleTerrainHeight(x, z);
+  ctx.addDynamicEntity({ kind: 'box', position: [x, y + 0.5, z], halfExtents: [0.5, 0.5, 0.5] });
+}
+\`\`\`
+
+**Inspect terrain region before sculpting:**
+\`\`\`js
+return ctx.getTerrainRegionStats({ centerX: 0, centerZ: 0, radius: 15 });
+// → { sampleCount, minHeight, maxHeight, avgHeight, bounds }
+\`\`\`
 
 # Collaboration etiquette
 
-- Before destructive or sweeping changes, briefly say what you're about to do and wait for confirmation if it's risky (deleting many entities, flattening terrain).
+- Before destructive or sweeping changes, briefly say what you're about to do and wait for confirmation if it's risky (deleting many entities, flattening large areas).
 - Use small focused tool calls. Read state first if you're unsure what's there.
 - Between turns, the human may have edited the world manually. If they did, the user message will start with a "<context>Human edits since last turn: …</context>" block summarizing what changed.
 - When you finish a tool plan, write a short natural-language summary of what you did so the human can follow along.

--- a/client/src/ai/worldToolHelpers.test.ts
+++ b/client/src/ai/worldToolHelpers.test.ts
@@ -138,4 +138,163 @@ describe('buildWorldCtx', () => {
     const after = env.current().terrain.tiles[0].heights;
     expect(after.some((h) => h > 0)).toBe(true);
   });
+
+  it('applyTerrainBrush returns rich stats payload', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    const result = ctx.applyTerrainBrush({
+      centerX: 0, centerZ: 0, radius: 12, strength: 2, mode: 'raise',
+    });
+    expect(result.changed).toBe(true);
+    expect(typeof result.samplesAffected).toBe('number');
+    expect((result.samplesAffected ?? 0) > 0).toBe(true);
+    expect(typeof result.deltaMin).toBe('number');
+    expect(typeof result.deltaMax).toBe('number');
+    expect(typeof result.heightMin).toBe('number');
+    expect(typeof result.heightMax).toBe('number');
+  });
+
+  it('flattenTerrain moves heights toward targetHeight', () => {
+    const initial = blankWorld();
+    // Start with all heights at 10
+    initial.terrain.tiles[0].heights = initial.terrain.tiles[0].heights.map(() => 10);
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+    const result = ctx.flattenTerrain({ centerX: 0, centerZ: 0, radius: 20, targetHeight: 2, strength: 1 });
+    expect(result.changed).toBe(true);
+    // Center sample should have moved toward 2 (all heights were 10)
+    const after = env.current().terrain.tiles[0].heights;
+    const centerIdx = 4; // center of 3x3 grid
+    expect(after[centerIdx]).toBeLessThan(10);
+    expect(after[centerIdx]).toBeGreaterThanOrEqual(2);
+    expect(result.samplesAffected).toBeGreaterThan(0);
+  });
+
+  it('flattenTerrain returns changed:false when terrain already at target', () => {
+    const env = makeAccessors(blankWorld()); // all heights = 0
+    const ctx = buildWorldCtx(env.accessors);
+    const result = ctx.flattenTerrain({ centerX: 0, centerZ: 0, radius: 20, targetHeight: 0, strength: 1 });
+    expect(result.changed).toBe(false);
+  });
+
+  it('smoothTerrain reduces a spike', () => {
+    const initial = blankWorld();
+    // Set center height to 10, all others 0
+    const centerIdx = 4; // row=1, col=1 in 3x3 grid
+    initial.terrain.tiles[0].heights[centerIdx] = 10;
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+    const result = ctx.smoothTerrain({ centerX: 0, centerZ: 0, radius: 20, strength: 1 });
+    expect(result.changed).toBe(true);
+    const after = env.current().terrain.tiles[0].heights;
+    // Center spike should be reduced
+    expect(after[centerIdx]).toBeLessThan(10);
+  });
+
+  it('applyTerrainNoise changes heights inside radius, leaves outside unchanged', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    const before = [...env.current().terrain.tiles[0].heights];
+    // Use a small radius so we know some samples fall outside
+    ctx.applyTerrainNoise({ centerX: 0, centerZ: 0, radius: 2, amplitude: 5, scale: 5, octaves: 2, seed: 99 });
+    const after = env.current().terrain.tiles[0].heights;
+    // At least some heights should differ
+    const changed = after.filter((h, i) => Math.abs(h - before[i]) > 1e-6).length;
+    expect(changed).toBeGreaterThan(0);
+  });
+
+  it('carveSpline flatten mode sets heights along the path toward targetHeight', () => {
+    const initial = blankWorld();
+    // Start all heights at 5
+    initial.terrain.tiles[0].heights = initial.terrain.tiles[0].heights.map(() => 5);
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+    const result = ctx.carveSpline({
+      points: [{ x: -20, z: 0 }, { x: 20, z: 0 }],
+      width: 20, falloffM: 0, mode: 'flatten', strength: 1, targetHeight: 0,
+    });
+    expect(result.changed).toBe(true);
+    // Heights should have moved toward 0
+    const after = env.current().terrain.tiles[0].heights;
+    expect(after.some((h) => h < 5)).toBe(true);
+  });
+
+  it('carveSpline returns changed:false with fewer than 2 points', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    // @ts-expect-error testing runtime guard
+    const result = ctx.carveSpline({ points: [{ x: 0, z: 0 }], width: 5, falloffM: 1, mode: 'flatten', strength: 1 });
+    expect(result.changed).toBe(false);
+  });
+
+  it('findEntitiesInRadius returns only entities within radius', () => {
+    const initial = blankWorld();
+    initial.staticProps.push(
+      { id: 1, kind: 'cuboid', position: [0, 0, 0], rotation: identityQuaternion(), halfExtents: [1, 1, 1] },
+      { id: 2, kind: 'cuboid', position: [100, 0, 100], rotation: identityQuaternion(), halfExtents: [1, 1, 1] },
+    );
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+    const results = ctx.findEntitiesInRadius({ x: 0, z: 0, radius: 5 });
+    expect(results).toHaveLength(1);
+    expect(results[0].entity.id).toBe(1);
+  });
+
+  it('findEntitiesInRadius with y/yRadius filters by vertical band', () => {
+    const initial = blankWorld();
+    initial.dynamicEntities.push(
+      { id: 10, kind: 'ball', position: [0, 1, 0], rotation: identityQuaternion(), radius: 0.5 },
+      { id: 11, kind: 'ball', position: [0, 50, 0], rotation: identityQuaternion(), radius: 0.5 },
+    );
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+    const results = ctx.findEntitiesInRadius({ x: 0, z: 0, radius: 5, y: 1, yRadius: 2 });
+    expect(results).toHaveLength(1);
+    expect(results[0].entity.id).toBe(10);
+  });
+
+  it('findEntitiesInBox returns only entities within box', () => {
+    const initial = blankWorld();
+    initial.staticProps.push(
+      { id: 1, kind: 'cuboid', position: [2, 0, 2], rotation: identityQuaternion(), halfExtents: [1, 1, 1] },
+      { id: 2, kind: 'cuboid', position: [50, 0, 50], rotation: identityQuaternion(), halfExtents: [1, 1, 1] },
+    );
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+    const results = ctx.findEntitiesInBox({ minX: -5, maxX: 5, minZ: -5, maxZ: 5 });
+    expect(results).toHaveLength(1);
+    expect(results[0].entity.id).toBe(1);
+  });
+
+  it('getTerrainTileBounds returns correct world-space AABB', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    // blankWorld has tileHalfExtentM: 8, tile at (0,0)
+    const bounds = ctx.getTerrainTileBounds(0, 0);
+    expect(bounds.minX).toBe(-8);
+    expect(bounds.maxX).toBe(8);
+    expect(bounds.minZ).toBe(-8);
+    expect(bounds.maxZ).toBe(8);
+  });
+
+  it('getTerrainTileCenter returns correct world-space center', () => {
+    const env = makeAccessors(blankWorld());
+    const ctx = buildWorldCtx(env.accessors);
+    // tileHalfExtentM: 8, so side=16; tile (1,0) center = (16, 0)
+    const center = ctx.getTerrainTileCenter(1, 0);
+    expect(center.x).toBe(16);
+    expect(center.z).toBe(0);
+  });
+
+  it('getTerrainRegionStats returns correct min/max/avg', () => {
+    const initial = blankWorld();
+    initial.terrain.tiles[0].heights = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const env = makeAccessors(initial);
+    const ctx = buildWorldCtx(env.accessors);
+    const stats = ctx.getTerrainRegionStats({ centerX: 0, centerZ: 0, radius: 100 });
+    expect(stats.sampleCount).toBe(9);
+    expect(stats.minHeight).toBe(1);
+    expect(stats.maxHeight).toBe(9);
+    expect(stats.avgHeight).toBeCloseTo(5, 5);
+  });
 });

--- a/client/src/ai/worldToolHelpers.ts
+++ b/client/src/ai/worldToolHelpers.ts
@@ -1,16 +1,24 @@
 import {
   addTerrainTile,
   applyTerrainBrush,
+  applyTerrainNoiseBrush,
   applyTerrainRampStencil,
+  carveTerrainSpline,
   cloneWorldDocument,
+  flattenTerrainBrush,
   getAddableTerrainTiles,
   getNextWorldEntityId,
+  getTerrainRegionStats,
   getTerrainTile,
+  getTerrainTileBounds,
+  getTerrainTileCenter,
   getTerrainWorldBounds,
   identityQuaternion,
   quaternionFromYaw,
   removeTerrainTile,
   sampleTerrainHeightAtWorldPosition,
+  sampleTerrainHeightGrid,
+  smoothTerrainBrush,
   type DynamicEntity,
   type Quaternion,
   type StaticProp,
@@ -26,6 +34,14 @@ export type WorldEditOptions = { isAiEdit?: boolean };
 export type WorldAccessors = {
   getWorld: () => WorldDocument;
   commitEdit: (updater: WorldEditUpdater, options?: WorldEditOptions) => boolean;
+};
+
+type TerrainMutationStats = {
+  samplesAffected: number;
+  deltaMin: number;
+  deltaMax: number;
+  heightMin: number;
+  heightMax: number;
 };
 
 export type WorldCtx = {
@@ -47,9 +63,40 @@ export type WorldCtx = {
     tileZ: number;
     heights: number[];
   } | null;
+  getTerrainTileBounds(tileX: number, tileZ: number): { minX: number; maxX: number; minZ: number; maxZ: number };
+  getTerrainTileCenter(tileX: number, tileZ: number): { x: number; z: number };
   sampleTerrainHeight(x: number, z: number): number;
   getAddableTerrainTiles(): Array<{ tileX: number; tileZ: number }>;
+  getTerrainRegionStats(spec: {
+    centerX: number;
+    centerZ: number;
+    radius: number;
+  }): { sampleCount: number; minHeight: number; maxHeight: number; avgHeight: number; bounds: { minX: number; maxX: number; minZ: number; maxZ: number } };
+  sampleTerrainGrid(spec: {
+    minX: number;
+    minZ: number;
+    maxX: number;
+    maxZ: number;
+    step: number;
+  }): Array<{ x: number; z: number; height: number }>;
   nextEntityId(): number;
+
+  // ---- ENTITY SEARCH ----
+  findEntitiesInRadius(spec: {
+    x: number;
+    z: number;
+    radius: number;
+    y?: number;
+    yRadius?: number;
+  }): Array<{ kind: 'static' | 'dynamic'; entity: StaticProp | DynamicEntity }>;
+  findEntitiesInBox(spec: {
+    minX: number;
+    maxX: number;
+    minZ: number;
+    maxZ: number;
+    minY?: number;
+    maxY?: number;
+  }): Array<{ kind: 'static' | 'dynamic'; entity: StaticProp | DynamicEntity }>;
 
   // ---- WRITE ----
   addStaticCuboid(spec: {
@@ -85,8 +132,38 @@ export type WorldCtx = {
     mode: 'raise' | 'lower';
     minHeight?: number;
     maxHeight?: number;
-  }): { changed: boolean };
+  }): { changed: boolean } & Partial<TerrainMutationStats>;
   applyTerrainRamp(stencil: TerrainRampStencil): { changed: boolean };
+  flattenTerrain(spec: {
+    centerX: number;
+    centerZ: number;
+    radius: number;
+    targetHeight: number;
+    strength: number;
+  }): { changed: boolean } & Partial<TerrainMutationStats>;
+  smoothTerrain(spec: {
+    centerX: number;
+    centerZ: number;
+    radius: number;
+    strength: number;
+  }): { changed: boolean } & Partial<TerrainMutationStats>;
+  applyTerrainNoise(spec: {
+    centerX: number;
+    centerZ: number;
+    radius: number;
+    amplitude: number;
+    scale: number;
+    octaves?: number;
+    seed?: number;
+  }): { changed: boolean } & Partial<TerrainMutationStats>;
+  carveSpline(spec: {
+    points: Array<{ x: number; z: number }>;
+    width: number;
+    falloffM: number;
+    mode: 'lower' | 'raise' | 'flatten';
+    strength: number;
+    targetHeight?: number;
+  }): { changed: boolean } & Partial<TerrainMutationStats>;
   addTerrainTile(tileX: number, tileZ: number): { changed: boolean };
   removeTerrainTile(tileX: number, tileZ: number): { changed: boolean };
 
@@ -156,14 +233,67 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
       if (!tile) return null;
       return { tileX: tile.tileX, tileZ: tile.tileZ, heights: [...tile.heights] };
     },
+    getTerrainTileBounds(tileX, tileZ) {
+      return getTerrainTileBounds(accessors.getWorld(), tileX, tileZ);
+    },
+    getTerrainTileCenter(tileX, tileZ) {
+      const [x, z] = getTerrainTileCenter(accessors.getWorld(), tileX, tileZ);
+      return { x, z };
+    },
     sampleTerrainHeight(x, z) {
       return sampleTerrainHeightAtWorldPosition(accessors.getWorld(), x, z);
     },
     getAddableTerrainTiles() {
       return getAddableTerrainTiles(accessors.getWorld()).map(({ tileX, tileZ }) => ({ tileX, tileZ }));
     },
+    getTerrainRegionStats(spec) {
+      return getTerrainRegionStats(accessors.getWorld(), spec.centerX, spec.centerZ, spec.radius);
+    },
+    sampleTerrainGrid(spec) {
+      return sampleTerrainHeightGrid(accessors.getWorld(), spec.minX, spec.minZ, spec.maxX, spec.maxZ, spec.step);
+    },
     nextEntityId() {
       return getNextWorldEntityId(accessors.getWorld());
+    },
+
+    findEntitiesInRadius(spec) {
+      const world = accessors.getWorld();
+      const { x, z, radius, y, yRadius } = spec;
+      const results: Array<{ kind: 'static' | 'dynamic'; entity: StaticProp | DynamicEntity }> = [];
+      for (const entity of world.staticProps) {
+        if (Math.hypot(entity.position[0] - x, entity.position[2] - z) > radius) continue;
+        if (typeof y === 'number' && typeof yRadius === 'number') {
+          if (Math.abs(entity.position[1] - y) > yRadius) continue;
+        }
+        results.push({ kind: 'static', entity: cloneJson(entity) });
+      }
+      for (const entity of world.dynamicEntities) {
+        if (Math.hypot(entity.position[0] - x, entity.position[2] - z) > radius) continue;
+        if (typeof y === 'number' && typeof yRadius === 'number') {
+          if (Math.abs(entity.position[1] - y) > yRadius) continue;
+        }
+        results.push({ kind: 'dynamic', entity: cloneJson(entity) });
+      }
+      return results;
+    },
+    findEntitiesInBox(spec) {
+      const world = accessors.getWorld();
+      const { minX, maxX, minZ, maxZ, minY, maxY } = spec;
+      const results: Array<{ kind: 'static' | 'dynamic'; entity: StaticProp | DynamicEntity }> = [];
+      function inBox(pos: Vec3): boolean {
+        if (pos[0] < minX || pos[0] > maxX) return false;
+        if (pos[2] < minZ || pos[2] > maxZ) return false;
+        if (typeof minY === 'number' && pos[1] < minY) return false;
+        if (typeof maxY === 'number' && pos[1] > maxY) return false;
+        return true;
+      }
+      for (const entity of world.staticProps) {
+        if (inBox(entity.position)) results.push({ kind: 'static', entity: cloneJson(entity) });
+      }
+      for (const entity of world.dynamicEntities) {
+        if (inBox(entity.position)) results.push({ kind: 'dynamic', entity: cloneJson(entity) });
+      }
+      return results;
     },
 
     addStaticCuboid(spec) {
@@ -279,6 +409,7 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
       if (typeof spec?.centerX !== 'number' || typeof spec?.centerZ !== 'number') {
         return { changed: false };
       }
+      const before = accessors.getWorld();
       const changed = aiEdit((current) =>
         applyTerrainBrush(
           current,
@@ -290,7 +421,8 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
           { minHeight: spec.minHeight, maxHeight: spec.maxHeight },
         ),
       );
-      return { changed };
+      if (!changed) return { changed: false };
+      return { changed: true, ...computeTerrainMutationStats(before, accessors.getWorld()) };
     },
 
     applyTerrainRamp(stencil) {
@@ -299,6 +431,63 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
       }
       const changed = aiEdit((current) => applyTerrainRampStencil(current, stencil));
       return { changed };
+    },
+
+    flattenTerrain(spec) {
+      if (typeof spec?.centerX !== 'number' || typeof spec?.centerZ !== 'number') {
+        return { changed: false };
+      }
+      const before = accessors.getWorld();
+      const changed = aiEdit((current) =>
+        flattenTerrainBrush(current, spec.centerX, spec.centerZ, spec.radius, spec.targetHeight, spec.strength),
+      );
+      if (!changed) return { changed: false };
+      return { changed: true, ...computeTerrainMutationStats(before, accessors.getWorld()) };
+    },
+
+    smoothTerrain(spec) {
+      if (typeof spec?.centerX !== 'number' || typeof spec?.centerZ !== 'number') {
+        return { changed: false };
+      }
+      const before = accessors.getWorld();
+      const changed = aiEdit((current) =>
+        smoothTerrainBrush(current, spec.centerX, spec.centerZ, spec.radius, spec.strength),
+      );
+      if (!changed) return { changed: false };
+      return { changed: true, ...computeTerrainMutationStats(before, accessors.getWorld()) };
+    },
+
+    applyTerrainNoise(spec) {
+      if (typeof spec?.centerX !== 'number' || typeof spec?.centerZ !== 'number') {
+        return { changed: false };
+      }
+      const before = accessors.getWorld();
+      const changed = aiEdit((current) =>
+        applyTerrainNoiseBrush(
+          current,
+          spec.centerX,
+          spec.centerZ,
+          spec.radius,
+          spec.amplitude,
+          spec.scale,
+          spec.octaves ?? 4,
+          spec.seed ?? 42,
+        ),
+      );
+      if (!changed) return { changed: false };
+      return { changed: true, ...computeTerrainMutationStats(before, accessors.getWorld()) };
+    },
+
+    carveSpline(spec) {
+      if (!Array.isArray(spec?.points) || spec.points.length < 2) {
+        return { changed: false };
+      }
+      const before = accessors.getWorld();
+      const changed = aiEdit((current) =>
+        carveTerrainSpline(current, spec.points, spec.width, spec.falloffM, spec.mode, spec.strength, spec.targetHeight),
+      );
+      if (!changed) return { changed: false };
+      return { changed: true, ...computeTerrainMutationStats(before, accessors.getWorld()) };
     },
 
     addTerrainTile(tileX, tileZ) {
@@ -318,6 +507,39 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
       return identityQuaternion();
     },
   };
+}
+
+function computeTerrainMutationStats(before: WorldDocument, after: WorldDocument): TerrainMutationStats {
+  let samplesAffected = 0;
+  let deltaMin = Number.POSITIVE_INFINITY;
+  let deltaMax = Number.NEGATIVE_INFINITY;
+  let heightMin = Number.POSITIVE_INFINITY;
+  let heightMax = Number.NEGATIVE_INFINITY;
+
+  for (const afterTile of after.terrain.tiles) {
+    const beforeTile = before.terrain.tiles.find(
+      (t) => t.tileX === afterTile.tileX && t.tileZ === afterTile.tileZ,
+    );
+    // Reference equality: unchanged tiles share the same object in copy-on-write pattern
+    if (!beforeTile || beforeTile === afterTile) continue;
+    for (let i = 0; i < afterTile.heights.length; i += 1) {
+      const prev = beforeTile.heights[i] ?? 0;
+      const next = afterTile.heights[i] ?? 0;
+      const delta = next - prev;
+      if (Math.abs(delta) > 1e-7) {
+        samplesAffected += 1;
+        if (delta < deltaMin) deltaMin = delta;
+        if (delta > deltaMax) deltaMax = delta;
+      }
+      if (next < heightMin) heightMin = next;
+      if (next > heightMax) heightMax = next;
+    }
+  }
+
+  if (samplesAffected === 0) {
+    return { samplesAffected: 0, deltaMin: 0, deltaMax: 0, heightMin: 0, heightMax: 0 };
+  }
+  return { samplesAffected, deltaMin, deltaMax, heightMin, heightMax };
 }
 
 function validateVec3(name: string, value: unknown): string | null {

--- a/client/src/world/worldDocument.ts
+++ b/client/src/world/worldDocument.ts
@@ -502,6 +502,294 @@ export function applyTerrainRampStencil(world: WorldDocument, ramp: TerrainRampS
   return mutated ? next : world;
 }
 
+export function flattenTerrainBrush(
+  world: WorldDocument,
+  centerX: number,
+  centerZ: number,
+  radius: number,
+  targetHeight: number,
+  strength: number,
+): WorldDocument {
+  const next: WorldDocument = {
+    ...world,
+    terrain: { ...world.terrain, tiles: [...world.terrain.tiles] },
+  };
+  const clampedTarget = clampNumber(targetHeight, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+  const clampedStrength = clampNumber(strength, 0, 1);
+  let mutated = false;
+
+  for (let tileIndex = 0; tileIndex < world.terrain.tiles.length; tileIndex += 1) {
+    const sourceTile = world.terrain.tiles[tileIndex];
+    let nextTile = next.terrain.tiles[tileIndex];
+    for (let row = 0; row < next.terrain.tileGridSize; row += 1) {
+      for (let col = 0; col < next.terrain.tileGridSize; col += 1) {
+        const [x, z] = getTerrainTileWorldPosition(next, sourceTile, row, col);
+        const distance = Math.hypot(x - centerX, z - centerZ);
+        if (distance > radius) {
+          continue;
+        }
+        const falloff = 1 - distance / radius;
+        const index = row * next.terrain.tileGridSize + col;
+        const currentHeight = sourceTile.heights[index] ?? 0;
+        const delta = clampedStrength * falloff * falloff * (clampedTarget - currentHeight);
+        const nextHeight = clampNumber(currentHeight + delta, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+        if (Math.abs(nextHeight - currentHeight) <= 1e-6) {
+          continue;
+        }
+        if (nextTile === sourceTile) {
+          nextTile = { ...sourceTile, heights: [...sourceTile.heights] };
+          next.terrain.tiles[tileIndex] = nextTile;
+        }
+        nextTile.heights[index] = nextHeight;
+        mutated = true;
+      }
+    }
+  }
+  return mutated ? next : world;
+}
+
+export function smoothTerrainBrush(
+  world: WorldDocument,
+  centerX: number,
+  centerZ: number,
+  radius: number,
+  strength: number,
+): WorldDocument {
+  const next: WorldDocument = {
+    ...world,
+    terrain: { ...world.terrain, tiles: [...world.terrain.tiles] },
+  };
+  const clampedStrength = clampNumber(strength, 0, 1);
+  const step = terrainTileSideLength(world) / (world.terrain.tileGridSize - 1);
+  let mutated = false;
+
+  for (let tileIndex = 0; tileIndex < world.terrain.tiles.length; tileIndex += 1) {
+    const sourceTile = world.terrain.tiles[tileIndex];
+    let nextTile = next.terrain.tiles[tileIndex];
+    for (let row = 0; row < next.terrain.tileGridSize; row += 1) {
+      for (let col = 0; col < next.terrain.tileGridSize; col += 1) {
+        const [x, z] = getTerrainTileWorldPosition(next, sourceTile, row, col);
+        const distance = Math.hypot(x - centerX, z - centerZ);
+        if (distance > radius) {
+          continue;
+        }
+        const falloff = 1 - distance / radius;
+        const index = row * next.terrain.tileGridSize + col;
+        const currentHeight = sourceTile.heights[index] ?? 0;
+        // Read 4 cardinal neighbors from the ORIGINAL world to avoid directional bias
+        const nH = sampleTerrainHeightAtWorldPosition(world, x, z - step);
+        const sH = sampleTerrainHeightAtWorldPosition(world, x, z + step);
+        const wH = sampleTerrainHeightAtWorldPosition(world, x - step, z);
+        const eH = sampleTerrainHeightAtWorldPosition(world, x + step, z);
+        const avg = (nH + sH + wH + eH) * 0.25;
+        const delta = clampedStrength * falloff * falloff * (avg - currentHeight);
+        const nextHeight = clampNumber(currentHeight + delta, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+        if (Math.abs(nextHeight - currentHeight) <= 1e-6) {
+          continue;
+        }
+        if (nextTile === sourceTile) {
+          nextTile = { ...sourceTile, heights: [...sourceTile.heights] };
+          next.terrain.tiles[tileIndex] = nextTile;
+        }
+        nextTile.heights[index] = nextHeight;
+        mutated = true;
+      }
+    }
+  }
+  return mutated ? next : world;
+}
+
+export function applyTerrainNoiseBrush(
+  world: WorldDocument,
+  centerX: number,
+  centerZ: number,
+  radius: number,
+  amplitude: number,
+  scale: number,
+  octaves: number,
+  seed: number,
+): WorldDocument {
+  const next: WorldDocument = {
+    ...world,
+    terrain: { ...world.terrain, tiles: [...world.terrain.tiles] },
+  };
+  const clampedOctaves = Math.max(1, Math.min(8, Math.round(octaves)));
+  const safeScale = scale > 0 ? scale : 1;
+  let mutated = false;
+
+  for (let tileIndex = 0; tileIndex < world.terrain.tiles.length; tileIndex += 1) {
+    const sourceTile = world.terrain.tiles[tileIndex];
+    let nextTile = next.terrain.tiles[tileIndex];
+    for (let row = 0; row < next.terrain.tileGridSize; row += 1) {
+      for (let col = 0; col < next.terrain.tileGridSize; col += 1) {
+        const [x, z] = getTerrainTileWorldPosition(next, sourceTile, row, col);
+        const distance = Math.hypot(x - centerX, z - centerZ);
+        if (distance > radius) {
+          continue;
+        }
+        const falloff = 1 - distance / radius;
+        const noiseVal = fbmNoise2D(x / safeScale, z / safeScale, clampedOctaves, seed | 0);
+        const delta = amplitude * noiseVal * falloff * falloff;
+        const index = row * next.terrain.tileGridSize + col;
+        const currentHeight = sourceTile.heights[index] ?? 0;
+        const nextHeight = clampNumber(currentHeight + delta, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+        if (Math.abs(nextHeight - currentHeight) <= 1e-6) {
+          continue;
+        }
+        if (nextTile === sourceTile) {
+          nextTile = { ...sourceTile, heights: [...sourceTile.heights] };
+          next.terrain.tiles[tileIndex] = nextTile;
+        }
+        nextTile.heights[index] = nextHeight;
+        mutated = true;
+      }
+    }
+  }
+  return mutated ? next : world;
+}
+
+export function sampleTerrainHeightGrid(
+  world: WorldDocument,
+  minX: number,
+  minZ: number,
+  maxX: number,
+  maxZ: number,
+  step: number,
+): Array<{ x: number; z: number; height: number }> {
+  const safeStep = Math.max(0.01, step);
+  const results: Array<{ x: number; z: number; height: number }> = [];
+  for (let z = minZ; z <= maxZ + 1e-9; z += safeStep) {
+    for (let x = minX; x <= maxX + 1e-9; x += safeStep) {
+      results.push({ x, z, height: sampleTerrainHeightAtWorldPosition(world, x, z) });
+    }
+  }
+  return results;
+}
+
+export function getTerrainRegionStats(
+  world: WorldDocument,
+  centerX: number,
+  centerZ: number,
+  radius: number,
+): {
+  sampleCount: number;
+  minHeight: number;
+  maxHeight: number;
+  avgHeight: number;
+  bounds: { minX: number; maxX: number; minZ: number; maxZ: number };
+} {
+  let sampleCount = 0;
+  let minHeight = Number.POSITIVE_INFINITY;
+  let maxHeight = Number.NEGATIVE_INFINITY;
+  let heightSum = 0;
+
+  for (const tile of world.terrain.tiles) {
+    for (let row = 0; row < world.terrain.tileGridSize; row += 1) {
+      for (let col = 0; col < world.terrain.tileGridSize; col += 1) {
+        const [x, z] = getTerrainTileWorldPosition(world, tile, row, col);
+        if (Math.hypot(x - centerX, z - centerZ) > radius) {
+          continue;
+        }
+        const height = tile.heights[row * world.terrain.tileGridSize + col] ?? 0;
+        sampleCount += 1;
+        if (height < minHeight) minHeight = height;
+        if (height > maxHeight) maxHeight = height;
+        heightSum += height;
+      }
+    }
+  }
+
+  const bounds = { minX: centerX - radius, maxX: centerX + radius, minZ: centerZ - radius, maxZ: centerZ + radius };
+  if (sampleCount === 0) {
+    return { sampleCount: 0, minHeight: 0, maxHeight: 0, avgHeight: 0, bounds };
+  }
+  return { sampleCount, minHeight, maxHeight, avgHeight: heightSum / sampleCount, bounds };
+}
+
+export function carveTerrainSpline(
+  world: WorldDocument,
+  points: Array<{ x: number; z: number }>,
+  width: number,
+  falloffM: number,
+  mode: 'lower' | 'raise' | 'flatten',
+  strength: number,
+  targetHeight?: number,
+): WorldDocument {
+  if (points.length < 2) {
+    return world;
+  }
+  const next: WorldDocument = {
+    ...world,
+    terrain: { ...world.terrain, tiles: [...world.terrain.tiles] },
+  };
+  const clampedStrength = clampNumber(strength, 0, 1);
+  const halfWidth = Math.max(0, width) * 0.5;
+  const safeFalloff = Math.max(0, falloffM);
+  const safeTarget = clampNumber(targetHeight ?? 0, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+  const totalInfluenceWidth = halfWidth + safeFalloff;
+  let mutated = false;
+
+  for (let tileIndex = 0; tileIndex < world.terrain.tiles.length; tileIndex += 1) {
+    const sourceTile = world.terrain.tiles[tileIndex];
+    let nextTile = next.terrain.tiles[tileIndex];
+    for (let row = 0; row < next.terrain.tileGridSize; row += 1) {
+      for (let col = 0; col < next.terrain.tileGridSize; col += 1) {
+        const [x, z] = getTerrainTileWorldPosition(next, sourceTile, row, col);
+
+        let minDist = Number.POSITIVE_INFINITY;
+        for (let i = 0; i < points.length - 1; i += 1) {
+          const d = distanceToSegment(x, z, points[i].x, points[i].z, points[i + 1].x, points[i + 1].z);
+          if (d < minDist) minDist = d;
+        }
+        if (minDist > totalInfluenceWidth) {
+          continue;
+        }
+
+        let influence: number;
+        if (minDist <= halfWidth) {
+          influence = 1;
+        } else {
+          const beyond = minDist - halfWidth;
+          const t = clampNumber(1 - beyond / Math.max(1e-9, safeFalloff), 0, 1);
+          influence = t * t;
+        }
+
+        const index = row * next.terrain.tileGridSize + col;
+        const currentHeight = sourceTile.heights[index] ?? 0;
+        let nextHeight = currentHeight;
+
+        if (mode === 'flatten') {
+          const delta = clampedStrength * influence * (safeTarget - currentHeight);
+          nextHeight = clampNumber(currentHeight + delta, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+        } else if (mode === 'lower') {
+          if (currentHeight <= safeTarget) {
+            continue;
+          }
+          const delta = clampedStrength * influence * (safeTarget - currentHeight);
+          nextHeight = clampNumber(currentHeight + delta, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+        } else {
+          if (currentHeight >= safeTarget) {
+            continue;
+          }
+          const delta = clampedStrength * influence * (safeTarget - currentHeight);
+          nextHeight = clampNumber(currentHeight + delta, TERRAIN_MIN_HEIGHT, TERRAIN_MAX_HEIGHT);
+        }
+
+        if (Math.abs(nextHeight - currentHeight) <= 1e-6) {
+          continue;
+        }
+        if (nextTile === sourceTile) {
+          nextTile = { ...sourceTile, heights: [...sourceTile.heights] };
+          next.terrain.tiles[tileIndex] = nextTile;
+        }
+        nextTile.heights[index] = nextHeight;
+        mutated = true;
+      }
+    }
+  }
+  return mutated ? next : world;
+}
+
 export function getTerrainRampEndpointHeights(ramp: Pick<TerrainRampStencil, 'length' | 'gradePct' | 'targetHeight' | 'targetEdge' | 'targetKind'>): {
   startHeight: number;
   endHeight: number;
@@ -873,6 +1161,57 @@ function normalizeQuaternion(value: unknown): Quaternion {
     return [value[0], value[1], value[2], value[3]];
   }
   return identityQuaternion();
+}
+
+function distanceToSegment(
+  px: number, pz: number,
+  ax: number, az: number,
+  bx: number, bz: number,
+): number {
+  const abx = bx - ax;
+  const abz = bz - az;
+  const lenSq = abx * abx + abz * abz;
+  if (lenSq < 1e-12) {
+    return Math.hypot(px - ax, pz - az);
+  }
+  const t = clampNumber(((px - ax) * abx + (pz - az) * abz) / lenSq, 0, 1);
+  return Math.hypot(px - (ax + t * abx), pz - (az + t * abz));
+}
+
+function hashSeed(seed: number, ix: number, iz: number): number {
+  let h = (seed ^ (ix * 374761393) ^ (iz * 668265263)) | 0;
+  h = (h ^ (h >>> 13)) | 0;
+  h = Math.imul(h, 1274126177) | 0;
+  h = h ^ (h >>> 16);
+  return (h & 0x7fffffff) / 0x7fffffff;
+}
+
+function valueNoise2D(x: number, z: number, seed: number): number {
+  const ix = Math.floor(x);
+  const iz = Math.floor(z);
+  const fx = x - ix;
+  const fz = z - iz;
+  const ux = fx * fx * fx * (fx * (fx * 6 - 15) + 10);
+  const uz = fz * fz * fz * (fz * (fz * 6 - 15) + 10);
+  const v00 = hashSeed(seed, ix, iz);
+  const v10 = hashSeed(seed, ix + 1, iz);
+  const v01 = hashSeed(seed, ix, iz + 1);
+  const v11 = hashSeed(seed, ix + 1, iz + 1);
+  return lerp(lerp(v00, v10, ux), lerp(v01, v11, ux), uz);
+}
+
+function fbmNoise2D(x: number, z: number, octaves: number, seed: number): number {
+  let value = 0;
+  let amplitude = 1;
+  let frequency = 1;
+  let maxValue = 0;
+  for (let i = 0; i < octaves; i += 1) {
+    value += (valueNoise2D(x * frequency, z * frequency, seed + i * 127) - 0.5) * amplitude;
+    maxValue += amplitude * 0.5;
+    amplitude *= 0.5;
+    frequency *= 2;
+  }
+  return maxValue > 0 ? value / maxValue : 0;
 }
 
 function clamp(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary
This PR adds four new terrain sculpting brushes, entity search utilities, and terrain analysis helpers to the world editing API. It significantly expands the terrain manipulation capabilities available to AI agents and provides better introspection into world state.

## Key Changes

### New Terrain Sculpting Functions
- **`flattenTerrainBrush`**: Moves terrain heights toward a target height with quadratic falloff. Useful for creating plateaus and leveling areas.
- **`smoothTerrainBrush`**: Blends each sample toward the average of its 4 cardinal neighbors, reducing spikes and smoothing rough terrain.
- **`applyTerrainNoiseBrush`**: Adds seeded fractal Brownian motion (FBM) noise to terrain. Supports configurable octaves, amplitude, and scale for procedural detail.
- **`carveTerrainSpline`**: Applies height edits along a polyline path with configurable width, falloff, and mode (raise/lower/flatten). Useful for roads, rivers, and terrain features.

### New Terrain Analysis Helpers
- **`sampleTerrainHeightGrid`**: Samples terrain heights across a rectangular region at a specified step interval.
- **`getTerrainRegionStats`**: Computes min/max/average heights and bounds for a circular region.

### New Entity Search Helpers
- **`findEntitiesInRadius`**: Locates all static props and dynamic entities within a circular radius, with optional vertical band filtering.
- **`findEntitiesInBox`**: Locates entities within an axis-aligned bounding box, with optional Y-range filtering.

### Enhanced WorldCtx API
- Added `getTerrainTileBounds` and `getTerrainTileCenter` for tile geometry queries.
- All terrain write operations now return rich mutation statistics: `samplesAffected`, `deltaMin`, `deltaMax`, `heightMin`, `heightMax`.
- New context methods wrap the sculpting functions with proper validation and stats computation.

### Implementation Details
- **Noise generation**: Implemented `hashSeed`, `valueNoise2D`, and `fbmNoise2D` for deterministic procedural noise.
- **Distance calculation**: Added `distanceToSegment` for efficient polyline proximity testing.
- **Copy-on-write pattern**: Terrain mutations use reference equality checks to avoid unnecessary tile clones.
- **Quadratic falloff**: All brushes use `(1 - distance/radius)²` for smooth, natural-looking sculpts.
- **Height clamping**: All edits respect terrain bounds `[-10, 50]` meters.
- **Mutation tracking**: `computeTerrainMutationStats` compares before/after tile references to efficiently compute statistics.

### Documentation Updates
- Expanded `systemPrompt.ts` with detailed descriptions of all new helpers, brush behavior semantics, and usage examples.
- Added cookbook examples for common terrain sculpting patterns.
- Clarified coordinate system and terrain tile layout.

### Test Coverage
- Added 13 new test cases covering flatten, smooth, noise, spline carving, entity search, and terrain analysis functions.
- Tests verify correct behavior, edge cases (no-op operations), and stats computation.

https://claude.ai/code/session_01GDpR7XeHEBS1Gm9KG9vzp6