### PR TITLE
Add image attachment support to AI chat panel

### DIFF
--- a/client/src/ai/chatTypes.ts
+++ b/client/src/ai/chatTypes.ts
@@ -15,12 +15,14 @@ export type ChatToolResultPart = {
   output: unknown;
   isError?: boolean;
 };
+export type ChatImagePart = { type: 'image'; dataUrl: string; mediaType: string };
 
 export type ChatPart =
   | ChatTextPart
   | ChatReasoningPart
   | ChatToolCallPart
-  | ChatToolResultPart;
+  | ChatToolResultPart
+  | ChatImagePart;
 
 export type ChatRole = 'user' | 'assistant';
 
@@ -47,8 +49,8 @@ export function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
   const out: ModelMessage[] = [];
   for (const msg of messages) {
     if (msg.role === 'user') {
-      const text = renderUserContent(msg);
-      out.push({ role: 'user', content: text });
+      const content = renderUserContent(msg);
+      out.push({ role: 'user', content });
       continue;
     }
     // assistant message — content can be a mix of text/reasoning/tool-call parts
@@ -94,15 +96,23 @@ export function toModelMessages(messages: ChatMessage[]): ModelMessage[] {
   return out;
 }
 
-function renderUserContent(msg: ChatMessage): string {
+function renderUserContent(
+  msg: ChatMessage,
+): string | Array<{ type: 'text'; text: string } | { type: 'image'; image: string; mimeType: string }> {
+  const imageParts = msg.parts.filter((p): p is ChatImagePart => p.type === 'image');
   const visible = msg.parts
     .filter((p): p is ChatTextPart => p.type === 'text')
     .map((p) => p.text)
     .join('');
-  if (msg.hiddenContext && msg.hiddenContext.length > 0) {
-    return `${msg.hiddenContext}\n\n${visible}`;
-  }
-  return visible;
+  const fullText =
+    msg.hiddenContext && msg.hiddenContext.length > 0
+      ? `${msg.hiddenContext}\n\n${visible}`
+      : visible;
+  if (imageParts.length === 0) return fullText;
+  return [
+    { type: 'text', text: fullText },
+    ...imageParts.map((img) => ({ type: 'image' as const, image: img.dataUrl, mimeType: img.mediaType })),
+  ];
 }
 
 function stringifyForModel(value: unknown): string {

--- a/client/src/ai/useGodModeChat.ts
+++ b/client/src/ai/useGodModeChat.ts
@@ -4,6 +4,7 @@ import {
   makeChatId,
   toModelMessages,
   type ChatMessage,
+  type ChatImagePart,
   type ChatPart,
 } from './chatTypes';
 import { createLanguageModel, type ProviderId } from './providers';
@@ -20,13 +21,15 @@ export type GodModeChatOptions = {
   apiKey: string | undefined;
 };
 
+export type ImageAttachment = { dataUrl: string; mediaType: string };
+
 export type GodModeChatHandle = {
   messages: ChatMessage[];
   status: ChatStatus;
   error: Error | null;
   pendingHumanEdits: number;
   canSend: boolean;
-  sendMessage(text: string): Promise<void>;
+  sendMessage(text: string, attachments?: ImageAttachment[]): Promise<void>;
   stop(): void;
   clear(): void;
   pushHumanEdit(summary: string): void;
@@ -79,9 +82,9 @@ export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
   const canSend = Boolean(apiKey) && status === 'idle';
 
   const sendMessage = useCallback(
-    async (text: string) => {
+    async (text: string, attachments?: ImageAttachment[]) => {
       const trimmed = text.trim();
-      if (trimmed.length === 0) return;
+      if (trimmed.length === 0 && (!attachments || attachments.length === 0)) return;
       if (!apiKey) {
         setError(new Error(`Add an API key for ${provider} first.`));
         setStatus('error');
@@ -97,10 +100,19 @@ export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
       }
       setPendingHumanEdits([]);
 
+      const parts: ChatPart[] = [{ type: 'text', text: trimmed }];
+      if (attachments && attachments.length > 0) {
+        const imageParts: ChatImagePart[] = attachments.map((att) => ({
+          type: 'image',
+          dataUrl: att.dataUrl,
+          mediaType: att.mediaType,
+        }));
+        parts.push(...imageParts);
+      }
       const userMessage: ChatMessage = {
         id: makeChatId(),
         role: 'user',
-        parts: [{ type: 'text', text: trimmed }],
+        parts,
         createdAt: Date.now(),
         hiddenContext,
       };

--- a/client/src/pages/godmode/AiChatPanel.tsx
+++ b/client/src/pages/godmode/AiChatPanel.tsx
@@ -12,7 +12,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import { forwardRef } from 'react';
-import type { ChatMessage, ChatPart } from '../../ai/chatTypes';
+import type { ChatImagePart, ChatMessage, ChatPart } from '../../ai/chatTypes';
 import {
   MODELS,
   PROVIDER_LABELS,
@@ -26,7 +26,7 @@ import {
   saveSettings,
   type AiChatSettings,
 } from '../../ai/settingsStore';
-import { useGodModeChat } from '../../ai/useGodModeChat';
+import { useGodModeChat, type ImageAttachment } from '../../ai/useGodModeChat';
 import type { WorldAccessors } from '../../ai/worldToolHelpers';
 
 export type AiChatPanelHandle = {
@@ -96,8 +96,26 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
     setSettings((current) => ({ ...current, apiKeys: {} }));
   }, []);
 
+  const onFileChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = '';
+    for (const file of files) {
+      if (!file.type.startsWith('image/')) continue;
+      const reader = new FileReader();
+      reader.onload = () => {
+        setAttachments((prev) => [
+          ...prev,
+          { dataUrl: reader.result as string, mediaType: file.type },
+        ]);
+      };
+      reader.readAsDataURL(file);
+    }
+  }, []);
+
   const [draft, setDraft] = useState('');
   const [settingsOpen, setSettingsOpen] = useState(!apiKey);
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const messageListRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -112,10 +130,12 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
       event.preventDefault();
       if (!chat.canSend) return;
       const text = draft;
+      const atts = attachments;
       setDraft('');
-      void chat.sendMessage(text);
+      setAttachments([]);
+      void chat.sendMessage(text, atts.length > 0 ? atts : undefined);
     },
-    [chat, draft],
+    [attachments, chat, draft],
   );
 
   const onKeyDown = useCallback(
@@ -124,11 +144,13 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
         event.preventDefault();
         if (!chat.canSend) return;
         const text = draft;
+        const atts = attachments;
         setDraft('');
-        void chat.sendMessage(text);
+        setAttachments([]);
+        void chat.sendMessage(text, atts.length > 0 ? atts : undefined);
       }
     },
-    [chat, draft],
+    [attachments, chat, draft],
   );
 
   const modelOptions = useMemo(() => MODELS[settings.provider], [settings.provider]);
@@ -247,6 +269,31 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
       )}
 
       <form onSubmit={onSubmit} style={composerStyle}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          style={{ display: 'none' }}
+          onChange={onFileChange}
+        />
+        {attachments.length > 0 && (
+          <div style={thumbnailStripStyle}>
+            {attachments.map((att, i) => (
+              <div key={i} style={thumbnailWrapStyle}>
+                <img src={att.dataUrl} style={thumbnailStyle} alt="" />
+                <button
+                  type="button"
+                  onClick={() => setAttachments((prev) => prev.filter((_, j) => j !== i))}
+                  style={thumbnailRemoveStyle}
+                  title="Remove"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         <textarea
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
@@ -262,13 +309,27 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
               Stop
             </button>
           ) : (
-            <button
-              type="submit"
-              disabled={!chat.canSend || draft.trim().length === 0}
-              style={chat.canSend && draft.trim().length > 0 ? primaryButtonStyle : disabledButtonStyle}
-            >
-              Send
-            </button>
+            <>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                style={secondaryButtonStyle}
+                title="Attach image"
+              >
+                Attach
+              </button>
+              <button
+                type="submit"
+                disabled={!chat.canSend || (draft.trim().length === 0 && attachments.length === 0)}
+                style={
+                  chat.canSend && (draft.trim().length > 0 || attachments.length > 0)
+                    ? primaryButtonStyle
+                    : disabledButtonStyle
+                }
+              >
+                Send
+              </button>
+            </>
           )}
         </div>
       </form>
@@ -294,6 +355,9 @@ function PartView({ part }: { part: ChatPart }) {
   }
   if (part.type === 'reasoning') {
     return <div style={reasoningPartStyle}>{part.text}</div>;
+  }
+  if (part.type === 'image') {
+    return <img src={(part as ChatImagePart).dataUrl} style={attachedImageStyle} alt="Attached image" />;
   }
   if (part.type === 'tool-call') {
     const code = extractCode(part.input);
@@ -654,4 +718,55 @@ const textareaStyle: CSSProperties = {
   fontSize: 13,
   fontFamily: 'inherit',
   lineHeight: 1.4,
+};
+
+const thumbnailStripStyle: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 6,
+};
+
+const thumbnailWrapStyle: CSSProperties = {
+  position: 'relative',
+  width: 52,
+  height: 52,
+  flexShrink: 0,
+};
+
+const thumbnailStyle: CSSProperties = {
+  width: 52,
+  height: 52,
+  objectFit: 'cover',
+  borderRadius: 6,
+  border: '1px solid rgba(116, 212, 255, 0.3)',
+  display: 'block',
+};
+
+const thumbnailRemoveStyle: CSSProperties = {
+  position: 'absolute',
+  top: -6,
+  right: -6,
+  width: 16,
+  height: 16,
+  borderRadius: '50%',
+  background: 'rgba(255, 133, 115, 0.9)',
+  color: '#38130e',
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: 11,
+  lineHeight: '16px',
+  textAlign: 'center',
+  padding: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontWeight: 700,
+};
+
+const attachedImageStyle: CSSProperties = {
+  maxWidth: '100%',
+  maxHeight: 200,
+  borderRadius: 8,
+  border: '1px solid rgba(116, 212, 255, 0.2)',
+  display: 'block',
 };


### PR DESCRIPTION
## Summary
This PR adds the ability to attach and send images with chat messages in the AI chat panel. Users can now select image files, preview them as thumbnails, and include them when sending messages to AI models that support image input.

## Key Changes
- **Image attachment UI**: Added file input, thumbnail strip with remove buttons, and "Attach" button to the chat composer
- **Attachment state management**: Introduced `attachments` state to track selected images and `fileInputRef` to control the hidden file input
- **File handling**: Implemented `onFileChange` callback to read image files as data URLs and filter for image types only
- **Message sending**: Updated `sendMessage` calls to include attachments, with validation allowing messages with images but no text
- **Type definitions**: Added `ChatImagePart` type to represent image content in messages and `ImageAttachment` export type for the hook
- **Content rendering**: Modified `renderUserContent` to return structured content (text + images) for models that support multimodal input
- **Message display**: Added `PartView` handler to render attached images in the chat history
- **Styling**: Added CSS styles for thumbnail strip, individual thumbnails, remove buttons, and attached image display

## Implementation Details
- Images are converted to data URLs using FileReader API for easy transmission and storage
- The send button is disabled only when both text and attachments are empty
- Attachments are cleared after sending, and the file input is reset to allow re-selecting the same file
- Image parts are included in the message structure and properly converted to the model's expected format in `toModelMessages`
- Thumbnail removal is handled via array filtering with index-based deletion

https://claude.ai/code/session_01KJmZzC435wHFMW95FUVQ8H