### PR TITLE
Add image paste support to AI chat textarea

### DIFF
--- a/client/src/pages/godmode/AiChatPanel.tsx
+++ b/client/src/pages/godmode/AiChatPanel.tsx
@@ -9,6 +9,7 @@ import {
   type ChangeEvent,
   type ForwardedRef,
   type FormEvent,
+  type ClipboardEvent as ReactClipboardEvent,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import { forwardRef } from 'react';
@@ -94,6 +95,24 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
   const onClearKeys = useCallback(() => {
     clearStoredApiKeys();
     setSettings((current) => ({ ...current, apiKeys: {} }));
+  }, []);
+
+  const onPaste = useCallback((event: ReactClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(event.clipboardData.items);
+    const imageItems = items.filter((item) => item.type.startsWith('image/'));
+    if (imageItems.length === 0) return;
+    for (const item of imageItems) {
+      const file = item.getAsFile();
+      if (!file) continue;
+      const reader = new FileReader();
+      reader.onload = () => {
+        setAttachments((prev) => [
+          ...prev,
+          { dataUrl: reader.result as string, mediaType: item.type },
+        ]);
+      };
+      reader.readAsDataURL(file);
+    }
   }, []);
 
   const onFileChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
@@ -298,6 +317,7 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={onKeyDown}
+          onPaste={onPaste}
           placeholder={placeholderHint}
           rows={3}
           style={textareaStyle}


### PR DESCRIPTION
## Summary
Added support for pasting images directly into the AI chat panel's textarea. Users can now paste images from their clipboard, and they will be automatically converted to data URLs and added to the attachments list.

## Key Changes
- Imported `ClipboardEvent` type from React for proper TypeScript support
- Implemented `onPaste` callback handler that:
  - Extracts image files from clipboard data
  - Converts each image file to a data URL using FileReader
  - Adds converted images to the attachments state with their media type
- Connected the `onPaste` handler to the textarea element

## Implementation Details
- The handler filters clipboard items to only process images (items with `type.startsWith('image/')`)
- Uses FileReader API to asynchronously convert image files to base64 data URLs
- Preserves the original media type of each pasted image for proper handling downstream
- Non-image paste events are ignored, allowing normal text paste functionality to continue working

https://claude.ai/code/session_01RVhUexb66Cvo4KpJqKjxAy