### PR TITLE
Enhance CustomStencilPanel with custom form widgets and improved styling

### DIFF
--- a/client/src/pages/godmode/CustomStencilPanel.tsx
+++ b/client/src/pages/godmode/CustomStencilPanel.tsx
@@ -1,45 +1,260 @@
-import { useCallback, useRef, type CSSProperties } from 'react';
+import { useCallback, useRef, type CSSProperties, type ComponentType } from 'react';
 import Form from '@rjsf/core';
-import type { IChangeEvent } from '@rjsf/core';
+import type { IChangeEvent, WidgetProps } from '@rjsf/core';
 import type { RJSFSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import type { CustomStencilDefinition } from '../../ai/customStencil';
 import { unregisterStencil } from '../../ai/customStencilStore';
 
 // ---------------------------------------------------------------------------
+// Custom Widgets
+// ---------------------------------------------------------------------------
+
+const sliderContainerStyle: CSSProperties = {
+  display: 'flex',
+  gap: 10,
+  alignItems: 'center',
+};
+
+const numberInputStyle: CSSProperties = {
+  width: 70,
+  padding: '6px 8px',
+  borderRadius: 6,
+  border: '1px solid rgba(167, 208, 237, 0.3)',
+  background: 'rgba(30, 40, 50, 0.8)',
+  color: 'rgba(238, 247, 255, 0.9)',
+  fontSize: 12,
+  fontFamily: 'monospace',
+  textAlign: 'center',
+  transition: 'border-color 0.2s',
+};
+
+const CustomSliderNumberWidget = (props: WidgetProps) => {
+  const { value, onChange, schema } = props;
+  const min = typeof schema.minimum !== 'undefined' ? schema.minimum : 0;
+  const max = typeof schema.maximum !== 'undefined' ? schema.maximum : 100;
+  const step = typeof schema.multipleOf !== 'undefined' ? schema.multipleOf : 0.1;
+
+  const handleSliderChange = (e: { target: { value: string } }) => {
+    onChange(Number(e.target.value));
+  };
+
+  const handleInputChange = (e: { target: { value: string } }) => {
+    const newVal = parseFloat(e.target.value);
+    if (!isNaN(newVal)) {
+      onChange(Math.max(min, Math.min(max, newVal)));
+    }
+  };
+
+  const displayValue = typeof value === 'number' ? value.toFixed(2) : '0.00';
+
+  return (
+    <div style={sliderContainerStyle}>
+      <style>{`
+        .stencil-range-slider {
+          flex: 1;
+          height: 6px;
+          border-radius: 3px;
+          outline: none;
+          cursor: pointer;
+          -webkit-appearance: none;
+          appearance: none;
+          background: linear-gradient(to right, rgba(100, 150, 200, 0.3), rgba(100, 150, 200, 0.5));
+          transition: box-shadow 0.2s ease;
+        }
+        .stencil-range-slider:hover {
+          box-shadow: 0 0 8px rgba(100, 150, 200, 0.4);
+        }
+        .stencil-range-slider::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          appearance: none;
+          width: 16px;
+          height: 16px;
+          border-radius: 50%;
+          background: linear-gradient(135deg, #a7d0ed 0%, #8ab5d9 100%);
+          border: 2px solid rgba(167, 208, 237, 0.5);
+          cursor: pointer;
+          box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+          transition: all 0.2s ease;
+        }
+        .stencil-range-slider::-webkit-slider-thumb:hover {
+          background: linear-gradient(135deg, #c0ddf5 0%, #a7d0ed 100%);
+          border-color: rgba(167, 208, 237, 0.8);
+          box-shadow: 0 4px 10px rgba(167, 208, 237, 0.3);
+        }
+        .stencil-range-slider::-moz-range-thumb {
+          width: 16px;
+          height: 16px;
+          border-radius: 50%;
+          background: linear-gradient(135deg, #a7d0ed 0%, #8ab5d9 100%);
+          border: 2px solid rgba(167, 208, 237, 0.5);
+          cursor: pointer;
+          box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+          transition: all 0.2s ease;
+        }
+        .stencil-range-slider::-moz-range-thumb:hover {
+          background: linear-gradient(135deg, #c0ddf5 0%, #a7d0ed 100%);
+          border-color: rgba(167, 208, 237, 0.8);
+          box-shadow: 0 4px 10px rgba(167, 208, 237, 0.3);
+        }
+      `}</style>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value ?? min}
+        onChange={handleSliderChange}
+        className="stencil-range-slider"
+      />
+      <input
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value ?? ''}
+        onChange={handleInputChange}
+        style={numberInputStyle}
+      />
+    </div>
+  );
+};
+
+// Custom text input widget with better styling
+const CustomTextWidget = (props: WidgetProps) => {
+  const { value, onChange } = props;
+
+  const handleChange = (e: { target: { value: string } }) => {
+    onChange(e.target.value || undefined);
+  };
+
+  return (
+    <input
+      type="text"
+      value={value ?? ''}
+      onChange={handleChange}
+      style={{
+        width: '100%',
+        padding: '8px 10px',
+        borderRadius: 6,
+        border: '1px solid rgba(167, 208, 237, 0.3)',
+        background: 'rgba(30, 40, 50, 0.8)',
+        color: 'rgba(238, 247, 255, 0.9)',
+        fontSize: 12,
+        fontFamily: 'monospace',
+        transition: 'border-color 0.2s, background-color 0.2s',
+      }}
+      onFocus={(e) => {
+        e.currentTarget.style.borderColor = 'rgba(167, 208, 237, 0.6)';
+        e.currentTarget.style.background = 'rgba(30, 40, 50, 1)';
+      }}
+      onBlur={(e) => {
+        e.currentTarget.style.borderColor = 'rgba(167, 208, 237, 0.3)';
+        e.currentTarget.style.background = 'rgba(30, 40, 50, 0.8)';
+      }}
+    />
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Styles (matching GodMode sidebar conventions)
 // ---------------------------------------------------------------------------
 
-const fieldStackStyle: CSSProperties = {
+const containerStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
-  gap: 10,
+  gap: 16,
 };
 
-const mutedTextStyle: CSSProperties = {
+const descriptionStyle: CSSProperties = {
   fontSize: 13,
+  color: 'rgba(238, 247, 255, 0.7)',
+  lineHeight: 1.5,
+  padding: '10px 0',
+  borderBottom: '1px solid rgba(167, 208, 237, 0.1)',
+};
+
+const formSectionStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+  padding: '12px 0',
+};
+
+const formFieldStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const fieldLabelStyle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'rgba(238, 247, 255, 0.85)',
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+};
+
+const fieldHintStyle: CSSProperties = {
+  fontSize: 11,
+  color: 'rgba(238, 247, 255, 0.5)',
+  fontStyle: 'italic',
+};
+
+const helpTextStyle: CSSProperties = {
+  fontSize: 12,
   color: 'rgba(238, 247, 255, 0.6)',
+  lineHeight: 1.4,
+  padding: '8px 0',
 };
 
 const baseButtonStyle: CSSProperties = {
-  borderRadius: 10,
-  padding: '10px 12px',
+  borderRadius: 8,
+  padding: '10px 14px',
   border: '1px solid rgba(167, 208, 237, 0.16)',
   cursor: 'pointer',
   fontWeight: 600,
+  fontSize: 12,
+  transition: 'all 0.2s ease',
+  fontFamily: 'monospace',
 };
 
 const dangerButtonStyle: CSSProperties = {
   ...baseButtonStyle,
-  background: '#ff8573',
-  color: '#38130e',
-  fontSize: 13,
+  background: 'linear-gradient(135deg, #ff8573 0%, #ff7060 100%)',
+  color: '#fff',
+  border: '1px solid #ff6a4f',
+  boxShadow: '0 4px 12px rgba(255, 133, 115, 0.2)',
 };
 
-// Minimal dark-theme overrides for rjsf form elements
-const formContainerStyle: CSSProperties = {
+// Custom form wrapper to style rjsf elements
+const formWrapperStyle: CSSProperties = {
   fontSize: 13,
   color: 'rgba(238, 247, 255, 0.82)',
+};
+
+// ---------------------------------------------------------------------------
+// Custom Form Template
+// ---------------------------------------------------------------------------
+
+const CustomFieldTemplate = (props: any) => {
+  const { classNames, label, help, required, children, description } = props;
+
+  return (
+    <div style={formFieldStyle} className={classNames}>
+      {label && (
+        <label style={fieldLabelStyle}>
+          {label}
+          {required && <span style={{ color: '#ff8573' }}>*</span>}
+        </label>
+      )}
+      {description && (
+        <div style={fieldHintStyle}>{description}</div>
+      )}
+      {children}
+      {help && <div style={fieldHintStyle}>{help}</div>}
+    </div>
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -72,14 +287,19 @@ export function CustomStencilPanel({
     && typeof stencil.parameterSchema === 'object'
     && Object.keys(stencil.parameterSchema).length > 0;
 
+  const widgets = {
+    SliderNumberWidget: CustomSliderNumberWidget,
+    text: CustomTextWidget,
+  } as Record<string, ComponentType<WidgetProps>>;
+
   return (
-    <div style={fieldStackStyle}>
+    <div style={containerStyle}>
       {stencil.description && (
-        <div style={mutedTextStyle}>{stencil.description}</div>
+        <div style={descriptionStyle}>{stencil.description}</div>
       )}
 
       {hasSchema && (
-        <div style={formContainerStyle} className="custom-stencil-form">
+        <div style={formWrapperStyle} className="custom-stencil-form">
           <Form
             schema={stencil.parameterSchema as RJSFSchema}
             uiSchema={{
@@ -90,21 +310,37 @@ export function CustomStencilPanel({
             onChange={handleFormChange}
             validator={validator}
             liveValidate={false}
+            widgets={widgets}
+            templates={{ FieldTemplate: CustomFieldTemplate }}
           />
         </div>
       )}
 
       {!hasSchema && (
-        <div style={mutedTextStyle}>
+        <div style={helpTextStyle}>
           This stencil has no configurable parameters. Click and drag on terrain to apply.
         </div>
       )}
 
-      <div style={mutedTextStyle}>
-        Hold and drag to apply. The preview shows what will change.
+      <div style={helpTextStyle}>
+        💡 Hold and drag to apply. The preview shows what will change.
       </div>
 
-      <button type="button" style={dangerButtonStyle} onClick={handleRemove}>
+      <button
+        type="button"
+        style={dangerButtonStyle}
+        onClick={handleRemove}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = 'linear-gradient(135deg, #ff7060 0%, #ff5a47 100%)';
+          e.currentTarget.style.boxShadow = '0 6px 16px rgba(255, 133, 115, 0.3)';
+          e.currentTarget.style.transform = 'translateY(-1px)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = 'linear-gradient(135deg, #ff8573 0%, #ff7060 100%)';
+          e.currentTarget.style.boxShadow = '0 4px 12px rgba(255, 133, 115, 0.2)';
+          e.currentTarget.style.transform = 'translateY(0)';
+        }}
+      >
         Remove Stencil
       </button>
     </div>

--- a/client/src/pages/godmode/CustomStencilPanel.tsx
+++ b/client/src/pages/godmode/CustomStencilPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, type CSSProperties, type ComponentType } from 'react';
 import Form from '@rjsf/core';
-import type { IChangeEvent, WidgetProps } from '@rjsf/core';
-import type { RJSFSchema, UiSchema } from '@rjsf/utils';
+import type { IChangeEvent } from '@rjsf/core';
+import type { RJSFSchema, UiSchema, WidgetProps } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import type { CustomStencilDefinition } from '../../ai/customStencil';
 import { unregisterStencil } from '../../ai/customStencilStore';

--- a/client/src/pages/godmode/CustomStencilPanel.tsx
+++ b/client/src/pages/godmode/CustomStencilPanel.tsx
@@ -46,8 +46,6 @@ const CustomSliderNumberWidget = (props: WidgetProps) => {
     }
   };
 
-  const displayValue = typeof value === 'number' ? value.toFixed(2) : '0.00';
-
   return (
     <div style={sliderContainerStyle}>
       <style>{`
@@ -172,13 +170,6 @@ const descriptionStyle: CSSProperties = {
   lineHeight: 1.5,
   padding: '10px 0',
   borderBottom: '1px solid rgba(167, 208, 237, 0.1)',
-};
-
-const formSectionStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 14,
-  padding: '12px 0',
 };
 
 const formFieldStyle: CSSProperties = {

--- a/client/src/pages/godmode/CustomStencilPanel.tsx
+++ b/client/src/pages/godmode/CustomStencilPanel.tsx
@@ -291,6 +291,11 @@ export function CustomStencilPanel({
 
       {hasSchema && (
         <div style={formWrapperStyle} className="custom-stencil-form">
+          <style>{`
+            .custom-stencil-form fieldset {
+              border-color: transparent;
+            }
+          `}</style>
           <Form
             schema={stencil.parameterSchema as RJSFSchema}
             uiSchema={{


### PR DESCRIPTION
## Summary
This PR significantly improves the CustomStencilPanel component by introducing custom form widgets for better user interaction and applying comprehensive styling enhancements to match the GodMode design system.

## Key Changes

- **Custom Form Widgets**: Added two new custom widgets for the RJSF form:
  - `CustomSliderNumberWidget`: A dual-input widget combining a range slider with a number input field for precise numeric parameter control
  - `CustomTextWidget`: A styled text input widget with focus/blur state transitions

- **Custom Field Template**: Implemented `CustomFieldTemplate` to provide consistent field rendering with labels, descriptions, hints, and required field indicators

- **Enhanced Styling**: 
  - Expanded and refined the style definitions to support the new widgets and form elements
  - Added comprehensive inline CSS for slider styling (webkit and moz vendor prefixes)
  - Improved button styling with gradient backgrounds and hover effects with smooth transitions
  - Added visual hierarchy with updated typography (font sizes, weights, letter spacing)
  - Enhanced color consistency using the existing dark theme palette

- **Interactive Enhancements**:
  - Added hover state handlers to the Remove button with gradient transitions and shadow effects
  - Improved form field styling with better spacing and visual separation
  - Added focus/blur state styling for text inputs

- **Code Organization**: Added clear section comments to organize custom widgets, styles, and the custom field template

## Implementation Details

The custom slider widget extracts min/max/step values from the JSON schema and provides real-time synchronization between the slider and number input. The styling uses CSS-in-JS with inline styles and a `<style>` tag for complex selector rules (slider thumb styling across browsers).

All new styles follow the existing GodMode sidebar conventions with the dark theme color palette (blues and grays with transparency).

https://claude.ai/code/session_01TUX5DTX6z2eviCt9eGL2X2