### PR TITLE
Improve terrain modification preview visibility for lower operations

### DIFF
--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -1890,19 +1890,22 @@ function RampStencilPreview({
   return (
     <group position={[centerX, 0, centerZ]} rotation-y={yawRad}>
       <mesh
-        position={[0, Math.min(lowHeight, highHeight) + 0.02, outerCenterOffsetZ]}
+        position={[0, (mode === 'lower' ? Math.max(lowHeight, highHeight) : Math.min(lowHeight, highHeight)) + 0.02, outerCenterOffsetZ]}
         rotation-x={-Math.PI / 2}
         raycast={ignorePointerRaycast}
         renderOrder={1}
       >
         <planeGeometry args={[outerWidth, outerLength]} />
-        <meshBasicMaterial color={mode === 'raise' ? 0x4ca5ff : 0xffb25c} transparent opacity={0.08 + rampStrength * 0.1} side={THREE.DoubleSide} depthWrite={false} />
+        {/* depthTest={false} in lower mode so the footprint indicator shows through terrain */}
+        <meshBasicMaterial color={mode === 'raise' ? 0x4ca5ff : 0xffb25c} transparent opacity={0.08 + rampStrength * 0.1} side={THREE.DoubleSide} depthWrite={false} depthTest={mode === 'raise'} />
       </mesh>
       <mesh geometry={volumeGeometry} raycast={ignorePointerRaycast} renderOrder={2}>
-        <meshBasicMaterial color={mode === 'raise' ? 0x3f8ee8 : 0xe2a145} transparent opacity={0.16 + rampStrength * 0.12} side={THREE.DoubleSide} depthWrite={false} />
+        {/* depthTest={false} in lower mode so the volume walls are visible through terrain */}
+        <meshBasicMaterial color={mode === 'raise' ? 0x3f8ee8 : 0xe2a145} transparent opacity={0.16 + rampStrength * 0.12} side={THREE.DoubleSide} depthWrite={false} depthTest={mode === 'raise'} />
       </mesh>
       <mesh geometry={coreGeometry} raycast={ignorePointerRaycast} renderOrder={2}>
-        <meshBasicMaterial color={mode === 'raise' ? 0x75c8ff : 0xffc977} transparent opacity={0.25 + rampStrength * 0.2} side={THREE.DoubleSide} depthWrite={false} />
+        {/* depthTest={false} in lower mode so the ramp surface is visible through terrain */}
+        <meshBasicMaterial color={mode === 'raise' ? 0x75c8ff : 0xffc977} transparent opacity={0.25 + rampStrength * 0.2} side={THREE.DoubleSide} depthWrite={false} depthTest={mode === 'raise'} />
       </mesh>
       <lineSegments geometry={guideGeometry} raycast={ignorePointerRaycast} renderOrder={4}>
         <lineBasicMaterial color={mode === 'raise' ? 0xe7f5ff : 0xfff0d2} transparent opacity={0.9} />

--- a/client/src/pages/godmode/CustomStencilPanel.tsx
+++ b/client/src/pages/godmode/CustomStencilPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, type CSSProperties } from 'react';
 import Form from '@rjsf/core';
-import type { IChangeEvent, RJSFSchema, UiSchema } from '@rjsf/utils';
+import type { IChangeEvent } from '@rjsf/core';
+import type { RJSFSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import type { CustomStencilDefinition } from '../../ai/customStencil';
 import { unregisterStencil } from '../../ai/customStencilStore';

--- a/client/src/pages/godmode/CustomStencilPanel.tsx
+++ b/client/src/pages/godmode/CustomStencilPanel.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useRef, type CSSProperties } from 'react';
 import Form from '@rjsf/core';
-import type { IChangeEvent } from '@rjsf/core';
-import type { RJSFSchema, UiSchema } from '@rjsf/utils';
+import type { IChangeEvent, RJSFSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import type { CustomStencilDefinition } from '../../ai/customStencil';
 import { unregisterStencil } from '../../ai/customStencilStore';

--- a/client/src/pages/godmode/CustomStencilPreview.tsx
+++ b/client/src/pages/godmode/CustomStencilPreview.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import { computeCustomStencilDiff, type CustomStencilDefinition } from '../../ai/customStencil';
+import { computeCustomStencilDiff, type CustomStencilDefinition, type StencilDiffSample } from '../../ai/customStencil';
 import type { WorldDocument } from '../../world/worldDocument';
 
 const RAISE_COLOR = new THREE.Color(0x4ca5ff);
@@ -49,7 +49,7 @@ export function CustomStencilPreview({
     const raiseSamples = diff.samples.filter(s => s.deltaY > 0);
     const lowerSamples = diff.samples.filter(s => s.deltaY <= 0);
 
-    function buildGeo(samples: typeof diff.samples) {
+    function buildGeo(samples: StencilDiffSample[]) {
       if (samples.length === 0) return null;
       const positions = new Float32Array(samples.length * 4 * 3);
       const colors = new Float32Array(samples.length * 4 * 3);

--- a/client/src/pages/godmode/CustomStencilPreview.tsx
+++ b/client/src/pages/godmode/CustomStencilPreview.tsx
@@ -30,7 +30,7 @@ export function CustomStencilPreview({
   const qz = quantize(centerZ, QUANTIZE_STEP);
   const paramsKey = JSON.stringify(params);
 
-  const geometry = useMemo(() => {
+  const geometries = useMemo(() => {
     let diff;
     try {
       diff = computeCustomStencilDiff(world, stencilDef, params, qx, qz);
@@ -46,50 +46,57 @@ export function CustomStencilPreview({
     const sampleSpacing = gridSize > 1 ? side / (gridSize - 1) : 1;
     const halfQuad = sampleSpacing * 0.5;
 
-    const vertCount = diff.samples.length * 4;
-    const positions = new Float32Array(vertCount * 3);
-    const colors = new Float32Array(vertCount * 3);
-    const indices: number[] = [];
+    const raiseSamples = diff.samples.filter(s => s.deltaY > 0);
+    const lowerSamples = diff.samples.filter(s => s.deltaY <= 0);
 
-    for (let i = 0; i < diff.samples.length; i += 1) {
-      const s = diff.samples[i];
-      const y = s.afterY + 0.06; // slightly above terrain
-      const base = i * 4;
+    function buildGeo(samples: typeof diff.samples) {
+      if (samples.length === 0) return null;
+      const positions = new Float32Array(samples.length * 4 * 3);
+      const colors = new Float32Array(samples.length * 4 * 3);
+      const indices: number[] = [];
 
-      // Four vertices of a small quad centered at (s.x, y, s.z)
-      positions[base * 3 + 0] = s.x - halfQuad;
-      positions[base * 3 + 1] = y;
-      positions[base * 3 + 2] = s.z - halfQuad;
+      for (let i = 0; i < samples.length; i += 1) {
+        const s = samples[i];
+        const y = s.afterY + 0.06; // slightly above final terrain height
+        const base = i * 4;
 
-      positions[(base + 1) * 3 + 0] = s.x + halfQuad;
-      positions[(base + 1) * 3 + 1] = y;
-      positions[(base + 1) * 3 + 2] = s.z - halfQuad;
+        // Four vertices of a small quad centered at (s.x, y, s.z)
+        positions[base * 3 + 0] = s.x - halfQuad;
+        positions[base * 3 + 1] = y;
+        positions[base * 3 + 2] = s.z - halfQuad;
 
-      positions[(base + 2) * 3 + 0] = s.x - halfQuad;
-      positions[(base + 2) * 3 + 1] = y;
-      positions[(base + 2) * 3 + 2] = s.z + halfQuad;
+        positions[(base + 1) * 3 + 0] = s.x + halfQuad;
+        positions[(base + 1) * 3 + 1] = y;
+        positions[(base + 1) * 3 + 2] = s.z - halfQuad;
 
-      positions[(base + 3) * 3 + 0] = s.x + halfQuad;
-      positions[(base + 3) * 3 + 1] = y;
-      positions[(base + 3) * 3 + 2] = s.z + halfQuad;
+        positions[(base + 2) * 3 + 0] = s.x - halfQuad;
+        positions[(base + 2) * 3 + 1] = y;
+        positions[(base + 2) * 3 + 2] = s.z + halfQuad;
 
-      // Color based on direction and intensity
-      const color = s.deltaY > 0 ? RAISE_COLOR : LOWER_COLOR;
-      for (let v = 0; v < 4; v += 1) {
-        colors[(base + v) * 3 + 0] = color.r;
-        colors[(base + v) * 3 + 1] = color.g;
-        colors[(base + v) * 3 + 2] = color.b;
+        positions[(base + 3) * 3 + 0] = s.x + halfQuad;
+        positions[(base + 3) * 3 + 1] = y;
+        positions[(base + 3) * 3 + 2] = s.z + halfQuad;
+
+        // Color based on direction
+        const color = s.deltaY > 0 ? RAISE_COLOR : LOWER_COLOR;
+        for (let v = 0; v < 4; v += 1) {
+          colors[(base + v) * 3 + 0] = color.r;
+          colors[(base + v) * 3 + 1] = color.g;
+          colors[(base + v) * 3 + 2] = color.b;
+        }
+
+        // Two triangles per quad
+        indices.push(base, base + 2, base + 1, base + 1, base + 2, base + 3);
       }
 
-      // Two triangles per quad
-      indices.push(base, base + 2, base + 1, base + 1, base + 2, base + 3);
+      const geo = new THREE.BufferGeometry();
+      geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+      geo.setIndex(indices);
+      return geo;
     }
 
-    const geo = new THREE.BufferGeometry();
-    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-    geo.setIndex(indices);
-    return geo;
+    return { raiseGeo: buildGeo(raiseSamples), lowerGeo: buildGeo(lowerSamples) };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [world, stencilDef.id, stencilDef.applyFn, paramsKey, qx, qz]);
 
@@ -108,21 +115,41 @@ export function CustomStencilPreview({
 
   useEffect(() => {
     return () => {
-      if (geometry) geometry.dispose();
+      if (geometries?.raiseGeo) geometries.raiseGeo.dispose();
+      if (geometries?.lowerGeo) geometries.lowerGeo.dispose();
     };
-  }, [geometry]);
+  }, [geometries]);
 
-  if (!geometry) return null;
+  if (!geometries) return null;
+  const { raiseGeo, lowerGeo } = geometries;
 
   return (
-    <mesh geometry={geometry} raycast={ignorePointerRaycast} renderOrder={2}>
-      <meshBasicMaterial
-        vertexColors
-        transparent
-        opacity={opacity}
-        side={THREE.DoubleSide}
-        depthWrite={false}
-      />
-    </mesh>
+    <>
+      {raiseGeo && (
+        <mesh geometry={raiseGeo} raycast={ignorePointerRaycast} renderOrder={2}>
+          <meshBasicMaterial
+            vertexColors
+            transparent
+            opacity={opacity}
+            side={THREE.DoubleSide}
+            depthWrite={false}
+          />
+        </mesh>
+      )}
+      {lowerGeo && (
+        // depthTest={false} so the lowering shape (below original terrain) is always visible,
+        // letting users see the crater/hole shape even though it's beneath the terrain surface.
+        <mesh geometry={lowerGeo} raycast={ignorePointerRaycast} renderOrder={5}>
+          <meshBasicMaterial
+            vertexColors
+            transparent
+            opacity={opacity}
+            side={THREE.DoubleSide}
+            depthWrite={false}
+            depthTest={false}
+          />
+        </mesh>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Enhanced the visualization of terrain modification previews to better show the effects of lowering operations by separating raise and lower samples into distinct geometries with different depth testing behavior.

## Key Changes

**CustomStencilPreview.tsx:**
- Refactored geometry generation to create separate geometries for raise and lower samples instead of a single combined geometry
- Split `diff.samples` into `raiseSamples` and `lowerSamples` based on `deltaY` direction
- Extracted geometry building logic into a `buildGeo()` helper function to reduce duplication
- Render raise geometry with standard depth testing (`renderOrder={2}`)
- Render lower geometry with `depthTest={false}` and higher `renderOrder={5}` to ensure crater/hole shapes are visible even when beneath the terrain surface
- Updated cleanup logic to dispose both geometries separately

**GodMode.tsx (RampStencilPreview):**
- Modified footprint indicator position calculation to use `Math.max()` for lower mode (positioning above the higher terrain point) instead of always using `Math.min()`
- Added `depthTest={false}` to all three material meshes (footprint, volume, core) when in lower mode to ensure preview shapes remain visible through the terrain surface
- Added clarifying comments explaining the depth test behavior for lower mode operations

## Implementation Details
- The lower geometry uses `depthTest={false}` to render on top of terrain geometry, allowing users to see the crater/hole shape that would be created below the original terrain surface
- The raise geometry maintains standard depth testing since raised terrain naturally appears above the original surface
- Both geometries are properly disposed in the cleanup effect to prevent memory leaks

https://claude.ai/code/session_014ApxPrKaQedLpWtyGoriRW