### PR TITLE
fix(godmode): restore camera navigation on WebGL canvas

### DIFF
--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type CSSProperties } from 'react';
-import { Sky, TransformControls } from '@react-three/drei';
-import { Canvas, type ThreeEvent } from '@react-three/fiber';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type CSSProperties } from 'react';
+import { TransformControls } from '@react-three/drei';
+import { Canvas, useThree, type ThreeEvent } from '@react-three/fiber';
 import * as THREE from 'three';
 import { App } from '../App';
 import { WorldTerrain } from '../scene/WorldTerrain';
@@ -1203,6 +1203,20 @@ export function GodModePage() {
   );
 }
 
+/** Solid backdrop + fog — avoids Drei Sky (large atmosphere shader) on drivers where it fails to draw. */
+function GodModeSceneBackground() {
+  const { scene } = useThree();
+  useEffect(() => {
+    scene.background = new THREE.Color(0x7ab8e8);
+    scene.fog = new THREE.FogExp2(0xa8cfe8, 0.012);
+    return () => {
+      scene.background = null;
+      scene.fog = null;
+    };
+  }, [scene]);
+  return null;
+}
+
 function GodModeEditorScene({
   world,
   tool,
@@ -1499,7 +1513,7 @@ function GodModeEditorScene({
 
   return (
     <Canvas
-      shadows
+      gl={{ alpha: false, antialias: true, stencil: false, depth: true }}
       camera={{ fov: 55, near: 0.1, far: 600, position: [28, 28, 28] }}
       style={{ width: '100%', height: '100%' }}
       onCreated={(state) => {
@@ -1523,10 +1537,12 @@ function GodModeEditorScene({
         }
       }}
     >
-      <ambientLight intensity={0.55} />
-      <directionalLight position={[32, 48, 12]} intensity={1.4} castShadow shadow-mapSize-width={2048} shadow-mapSize-height={2048} />
-      <Sky sunPosition={[24, 12, 8]} />
-      <WorldTerrain
+      <Suspense fallback={null}>
+        <GodModeSceneBackground />
+        <ambientLight intensity={0.55} />
+        <hemisphereLight args={[0xb8d4ff, 0x3a4a38, 0.35]} position={[0, 48, 0]} />
+        <directionalLight position={[32, 48, 12]} intensity={1.15} />
+        <WorldTerrain
         world={world}
         onPointerDown={handleTerrainPointerDown}
         onPointerMove={handleTerrainPointerMove}
@@ -1609,8 +1625,6 @@ function GodModeEditorScene({
             ref={(object) => registerSelectableObject(`static:${entity.id}`, object)}
             position={entity.position}
             quaternion={new THREE.Quaternion(...entity.rotation)}
-            castShadow
-            receiveShadow
             onPointerDown={(event) => {
               event.stopPropagation();
               if (event.button !== 0 || event.altKey) return;
@@ -1627,8 +1641,6 @@ function GodModeEditorScene({
             ref={(object) => registerSelectableObject(`dynamic:${entity.id}`, object)}
             position={entity.position}
             quaternion={new THREE.Quaternion(...entity.rotation)}
-            castShadow
-            receiveShadow
             onPointerDown={(event) => {
               event.stopPropagation();
               if (event.button !== 0 || event.altKey) return;
@@ -1676,6 +1688,7 @@ function GodModeEditorScene({
           <meshBasicMaterial color={brushMode === 'raise' ? 0x77ff9b : 0xffa875} transparent opacity={0.65} side={THREE.DoubleSide} />
         </mesh>
       )}
+      </Suspense>
       <GodModeCameraControls tool={tool} />
     </Canvas>
   );

--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -1502,6 +1502,14 @@ function GodModeEditorScene({
       shadows
       camera={{ fov: 55, near: 0.1, far: 600, position: [28, 28, 28] }}
       style={{ width: '100%', height: '100%' }}
+      onCreated={(state) => {
+        // R3F attaches pointer events to the outer wrapper by default (`events.connected`).
+        // Drei's OrbitControls uses that same element, but `offsetX`/`offsetY` are relative to
+        // the event target — not the WebGL canvas — so orbit/pan/zoom deltas are wrong when the
+        // canvas does not fill the wrapper pixel-for-pixel. Listen on the canvas instead.
+        state.events.disconnect?.();
+        state.events.connect?.(state.gl.domElement);
+      }}
       onPointerUp={handleTerrainPointerUp}
       onPointerMissed={() => {
         const wasEditing = paintingRef.current || isRampApplying;

--- a/client/src/pages/godmode/GodModeCameraControls.tsx
+++ b/client/src/pages/godmode/GodModeCameraControls.tsx
@@ -198,6 +198,7 @@ export function GodModeCameraControls({ tool }: { tool: EditorTool }) {
       <OrbitControls
         ref={setOrbitRef}
         makeDefault
+        domElement={gl.domElement}
         enableDamping={false}
         maxDistance={180}
         mouseButtons={{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Godmode **viewport appearing completely black** on some browsers/GPUs (including SwiftShader and strict WebGL stacks) while preserving correct **camera input** (events on `gl.domElement` + Drei `OrbitControls` `domElement`).

## Changes

1. **Opaque WebGL buffer** — `gl={{ alpha: false, ... }}` so the default framebuffer is opaque and the canvas composites reliably (transparent WebGL + page background can read as a “dead” black viewport).

2. **Replace Drei `Sky`** with a **solid `scene.background`** and **`FogExp2`** — avoids the large Preetham-style sky shader that can fail to draw on some drivers, leaving only clear color (black/void).

3. **Editor scene: no shadow maps** — removed `shadows` from Canvas, directional light `castShadow`, and mesh `castShadow`/`receiveShadow` in Godmode editor only — reduces GPU pressure and avoids shadow pass issues on weaker stacks.

4. **`Suspense`** around scene children for safer loading boundaries.

5. **Prior commit (still in branch):** reconnect R3F pointer events to `gl.domElement` and pass `domElement={gl.domElement}` to `OrbitControls` so MMB/RMB/scroll use correct coordinates.

## Verification

- `npm run lint` in `client/` passes.
- Headless Chrome + SwiftShader against dev server shows terrain + sky-colored background after these changes (local agent run).

If anything still looks wrong on your machine, please note GPU/OS and whether hardware acceleration is on.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dba2882d-a4ce-4194-8e27-81a39b32d060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dba2882d-a4ce-4194-8e27-81a39b32d060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

