### PR TITLE
Fix vehicle smoothing diagnostics and default to raw vehicle pose

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -154,6 +154,7 @@ export function App({
   const [inputFamilyMode, setInputFamilyMode] = useState<InputFamilyMode>('auto');
   const [controlsOpen, setControlsOpen] = useState(false);
   const [localRenderSmoothingEnabled, setLocalRenderSmoothingEnabled] = useState(true);
+  const [vehicleSmoothingEnabled, setVehicleSmoothingEnabled] = useState(false);
   const [inputBindings, setInputBindings] = useState<InputBindings>(() => loadInputBindings());
   const {
     visible: debugVisible,
@@ -517,6 +518,7 @@ export function App({
         userAgent: navigator.userAgent,
         renderStatsText: renderStatsParentRef.current?.innerText ?? '',
         localRenderSmoothingEnabled,
+        vehicleSmoothingEnabled,
         deepCaptureEnabled,
         deepCaptureReport: getDeepCaptureMarkdown(),
       });
@@ -546,7 +548,7 @@ export function App({
         window.clearTimeout(copyNoticeTimerRef.current);
       }
     };
-  }, [connected, deepCaptureEnabled, getDeepCaptureMarkdown, getStatsSnapshot, localRenderSmoothingEnabled, status]);
+  }, [connected, deepCaptureEnabled, getDeepCaptureMarkdown, getStatsSnapshot, localRenderSmoothingEnabled, status, vehicleSmoothingEnabled]);
 
   const crosshairColor =
     crosshairState === 'head'
@@ -734,6 +736,8 @@ export function App({
           visible={debugVisible}
           localRenderSmoothingEnabled={localRenderSmoothingEnabled}
           onToggleLocalRenderSmoothing={() => setLocalRenderSmoothingEnabled((enabled) => !enabled)}
+          vehicleSmoothingEnabled={vehicleSmoothingEnabled}
+          onToggleVehicleSmoothing={() => setVehicleSmoothingEnabled((enabled) => !enabled)}
           deepCaptureEnabled={deepCaptureEnabled}
           deepCaptureSampleCount={deepCaptureSampleCount}
         />
@@ -767,6 +771,7 @@ export function App({
           showRenderStats={debugVisible}
           benchmarkAutopilot={benchmarkAutopilot}
           localRenderSmoothingEnabled={localRenderSmoothingEnabled}
+          vehicleSmoothingEnabled={vehicleSmoothingEnabled}
           sceneExtras={calibrationSceneExtras}
         />
       )}

--- a/client/src/net/localPracticeClient.ts
+++ b/client/src/net/localPracticeClient.ts
@@ -52,7 +52,7 @@ export class LocalPracticeClient {
   private readonly vehicleServerTimeUs = new Map<number, number>();
   private readonly debugTelemetry = new NetDebugTelemetry();
   private session: WasmLocalSessionInstance | null = null;
-  private tickHandle: ReturnType<typeof setInterval> | null = null;
+  private frameHandle: number | null = null;
   private tickAccumulatorSec = 0;
   private lastTickTimeMs = 0;
   private closedByClient = false;
@@ -79,9 +79,9 @@ export class LocalPracticeClient {
 
   disconnect(): void {
     this.closedByClient = true;
-    if (this.tickHandle) {
-      clearInterval(this.tickHandle);
-      this.tickHandle = null;
+    if (this.frameHandle != null) {
+      cancelAnimationFrame(this.frameHandle);
+      this.frameHandle = null;
     }
     this.tickAccumulatorSec = 0;
     this.lastTickTimeMs = 0;
@@ -239,11 +239,10 @@ export class LocalPracticeClient {
 
   private startTickLoop(): void {
     this.lastTickTimeMs = performance.now();
-    this.tickHandle = setInterval(() => {
+    const step = (nowMs: number) => {
       if (!this.session || this.closedByClient) {
         return;
       }
-      const nowMs = performance.now();
       const elapsedSec = Math.min(Math.max((nowMs - this.lastTickTimeMs) / 1000, 0), 0.1);
       this.lastTickTimeMs = nowMs;
       this.tickAccumulatorSec += elapsedSec;
@@ -259,7 +258,9 @@ export class LocalPracticeClient {
       if (ticks > 0) {
         this.syncFromSession(true);
       }
-    }, 1000 / SIM_HZ);
+      this.frameHandle = requestAnimationFrame(step);
+    };
+    this.frameHandle = requestAnimationFrame(step);
   }
 
   private syncFromSession(emitCallbacks: boolean): void {

--- a/client/src/scene/GameScene.tsx
+++ b/client/src/scene/GameScene.tsx
@@ -25,6 +25,7 @@ type GameSceneProps = {
   worldDocument?: WorldDocument;
   benchmarkAutopilot?: React.ComponentProps<typeof GameWorld>['benchmarkAutopilot'];
   localRenderSmoothingEnabled?: boolean;
+  vehicleSmoothingEnabled?: boolean;
   sceneExtras?: ReactNode;
 };
 
@@ -46,6 +47,7 @@ export function GameScene({
   worldDocument,
   benchmarkAutopilot,
   localRenderSmoothingEnabled = true,
+  vehicleSmoothingEnabled = false,
   sceneExtras,
 }: GameSceneProps) {
   const touchMode = isTouchDevice();
@@ -81,6 +83,7 @@ export function GameScene({
           rapierDebugModeBits={rapierDebugModeBits}
           benchmarkAutopilot={benchmarkAutopilot}
           localRenderSmoothingEnabled={localRenderSmoothingEnabled}
+          vehicleSmoothingEnabled={vehicleSmoothingEnabled}
           sceneExtras={sceneExtras}
         />
       </Suspense>

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -300,6 +300,7 @@ type GameWorldProps = {
     scenario: LoadTestScenario;
   };
   localRenderSmoothingEnabled?: boolean;
+  vehicleSmoothingEnabled?: boolean;
   // Optional children rendered inside the R3F scene. Used by the calibration
   // wizard to inject drill targets (FlickDrill / TrackDrill) into the live
   // firing-range scene, so the player's feel during drills is identical to
@@ -958,6 +959,7 @@ export function GameWorld({
   rapierDebugModeBits = 0,
   benchmarkAutopilot,
   localRenderSmoothingEnabled = true,
+  vehicleSmoothingEnabled = false,
   sceneExtras,
 }: GameWorldProps) {
   const practiceMode = isPracticeMode(mode);
@@ -1222,18 +1224,23 @@ export function GameWorld({
     let localVehicleSuspensionLengthDeltaM = 0;
     let localVehicleSuspensionForceDeltaN = 0;
     if (localControlledVehiclePose && drivenVehicleId != null) {
-      const result = updateLocalVehicleMeshPose(
-        localVehicleVisualPoseRef.current,
-        drivenVehicleId,
-        localControlledVehiclePose,
-        frameDelta,
-        localVehicleDebug?.speedMs ?? 0,
-        localVehicleDebug?.groundedWheels ?? 0,
-        localAuthorityTransport ? 'practice' : 'multiplayer',
-      );
-      localVehicleVisualPose = result.pose;
-      localVehicleMeshDeltaM = result.metrics.positionDeltaM;
-      localVehicleMeshRotDeltaRad = result.metrics.rotationDeltaRad;
+      if (vehicleSmoothingEnabled) {
+        const result = updateLocalVehicleMeshPose(
+          localVehicleVisualPoseRef.current,
+          drivenVehicleId,
+          localControlledVehiclePose,
+          frameDelta,
+          localVehicleDebug?.speedMs ?? 0,
+          localVehicleDebug?.groundedWheels ?? 0,
+          localAuthorityTransport ? 'practice' : 'multiplayer',
+        );
+        localVehicleVisualPose = result.pose;
+        localVehicleMeshDeltaM = result.metrics.positionDeltaM;
+        localVehicleMeshRotDeltaRad = result.metrics.rotationDeltaRad;
+      } else {
+        resetLocalVehicleMeshPose(localVehicleVisualPoseRef.current);
+        localVehicleVisualPose = localControlledVehiclePose;
+      }
     } else {
       resetLocalVehicleMeshPose(localVehicleVisualPoseRef.current);
     }
@@ -1874,24 +1881,36 @@ export function GameWorld({
       const orbitPitch = vehicleCameraPitchRef.current;
       const focusY = chassisPos[1] + 1.0;
       const followDistance = 6.0;
-      const focusSmoothRate = Math.min(frameDelta * 12.0, 1.0);
-      smoothVehicleFocus.current.set(
-        smoothVehicleFocus.current.x + (chassisPos[0] - smoothVehicleFocus.current.x) * focusSmoothRate,
-        smoothVehicleFocus.current.y + (focusY - smoothVehicleFocus.current.y) * focusSmoothRate,
-        smoothVehicleFocus.current.z + (chassisPos[2] - smoothVehicleFocus.current.z) * focusSmoothRate,
-      );
-      const targetX = smoothVehicleFocus.current.x - Math.sin(orbitYaw) * Math.cos(orbitPitch) * followDistance;
-      const targetY = smoothVehicleFocus.current.y + Math.sin(orbitPitch) * followDistance + 1.0;
-      const targetZ = smoothVehicleFocus.current.z - Math.cos(orbitYaw) * Math.cos(orbitPitch) * followDistance;
+      if (vehicleSmoothingEnabled) {
+        const focusSmoothRate = Math.min(frameDelta * 12.0, 1.0);
+        smoothVehicleFocus.current.set(
+          smoothVehicleFocus.current.x + (chassisPos[0] - smoothVehicleFocus.current.x) * focusSmoothRate,
+          smoothVehicleFocus.current.y + (focusY - smoothVehicleFocus.current.y) * focusSmoothRate,
+          smoothVehicleFocus.current.z + (chassisPos[2] - smoothVehicleFocus.current.z) * focusSmoothRate,
+        );
+        const targetX = smoothVehicleFocus.current.x - Math.sin(orbitYaw) * Math.cos(orbitPitch) * followDistance;
+        const targetY = smoothVehicleFocus.current.y + Math.sin(orbitPitch) * followDistance + 1.0;
+        const targetZ = smoothVehicleFocus.current.z - Math.cos(orbitYaw) * Math.cos(orbitPitch) * followDistance;
 
-      const smoothRate = Math.min(frameDelta * 18.0, 1.0);
-      smoothCamPos.current.set(
-        smoothCamPos.current.x + (targetX - smoothCamPos.current.x) * smoothRate,
-        smoothCamPos.current.y + (targetY - smoothCamPos.current.y) * smoothRate,
-        smoothCamPos.current.z + (targetZ - smoothCamPos.current.z) * smoothRate,
-      );
-      camera.position.copy(smoothCamPos.current);
-      camera.lookAt(smoothVehicleFocus.current);
+        const smoothRate = Math.min(frameDelta * 18.0, 1.0);
+        smoothCamPos.current.set(
+          smoothCamPos.current.x + (targetX - smoothCamPos.current.x) * smoothRate,
+          smoothCamPos.current.y + (targetY - smoothCamPos.current.y) * smoothRate,
+          smoothCamPos.current.z + (targetZ - smoothCamPos.current.z) * smoothRate,
+        );
+        camera.position.copy(smoothCamPos.current);
+        camera.lookAt(smoothVehicleFocus.current);
+      } else {
+        const focusX = chassisPos[0];
+        const focusZ = chassisPos[2];
+        const targetX = focusX - Math.sin(orbitYaw) * Math.cos(orbitPitch) * followDistance;
+        const targetY = focusY + Math.sin(orbitPitch) * followDistance + 1.0;
+        const targetZ = focusZ - Math.cos(orbitYaw) * Math.cos(orbitPitch) * followDistance;
+        smoothVehicleFocus.current.set(focusX, focusY, focusZ);
+        smoothCamPos.current.set(targetX, targetY, targetZ);
+        camera.position.copy(smoothCamPos.current);
+        camera.lookAt(focusX, focusY, focusZ);
+      }
     } else {
       const eyeHeight = PLAYER_EYE_HEIGHT;
       camera.position.set(pos[0], pos[1] + eyeHeight, pos[2]);

--- a/client/src/ui/DebugOverlay.tsx
+++ b/client/src/ui/DebugOverlay.tsx
@@ -410,6 +410,7 @@ type DebugMarkdownExtras = {
   userAgent?: string;
   renderStatsText?: string;
   localRenderSmoothingEnabled?: boolean;
+  vehicleSmoothingEnabled?: boolean;
   deepCaptureEnabled?: boolean;
   deepCaptureReport?: string | null;
 };
@@ -452,6 +453,7 @@ export function debugStatsToMarkdown(stats: DebugStats, extras: DebugMarkdownExt
     `- status: ${extras.status ?? 'unknown'}`,
     `- user-agent: ${extras.userAgent ?? (typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown')}`,
     `- local_render_smoothing: ${extras.localRenderSmoothingEnabled == null ? 'unknown' : extras.localRenderSmoothingEnabled ? 'on' : 'off'}`,
+    `- vehicle_smoothing: ${extras.vehicleSmoothingEnabled == null ? 'unknown' : extras.vehicleSmoothingEnabled ? 'on' : 'off'}`,
     '',
     '## Rendering',
     `- fps: ${fmt(stats.fps, 0)}`,
@@ -687,6 +689,8 @@ export function DebugOverlay({
   visible,
   localRenderSmoothingEnabled = true,
   onToggleLocalRenderSmoothing,
+  vehicleSmoothingEnabled = false,
+  onToggleVehicleSmoothing,
   deepCaptureEnabled = false,
   deepCaptureSampleCount = 0,
 }: {
@@ -694,6 +698,8 @@ export function DebugOverlay({
   visible: boolean;
   localRenderSmoothingEnabled?: boolean;
   onToggleLocalRenderSmoothing?: () => void;
+  vehicleSmoothingEnabled?: boolean;
+  onToggleVehicleSmoothing?: () => void;
   deepCaptureEnabled?: boolean;
   deepCaptureSampleCount?: number;
 }) {
@@ -706,6 +712,13 @@ export function DebugOverlay({
     ? 'linear-gradient(180deg, rgba(18, 54, 31, 0.72), rgba(9, 28, 17, 0.78))'
     : 'linear-gradient(180deg, rgba(36, 40, 46, 0.72), rgba(18, 21, 26, 0.78))';
   const smoothingBorder = localRenderSmoothingEnabled
+    ? 'rgba(118, 255, 170, 0.28)'
+    : 'rgba(228, 234, 241, 0.18)';
+  const vehicleSmoothingAccent = vehicleSmoothingEnabled ? '#98ffbc' : '#d8dee6';
+  const vehicleSmoothingBackground = vehicleSmoothingEnabled
+    ? 'linear-gradient(180deg, rgba(18, 54, 31, 0.72), rgba(9, 28, 17, 0.78))'
+    : 'linear-gradient(180deg, rgba(36, 40, 46, 0.72), rgba(18, 21, 26, 0.78))';
+  const vehicleSmoothingBorder = vehicleSmoothingEnabled
     ? 'rgba(118, 255, 170, 0.28)'
     : 'rgba(228, 234, 241, 0.18)';
 
@@ -843,6 +856,66 @@ export function DebugOverlay({
             {localRenderSmoothingEnabled
               ? 'High-refresh monitors render the local pose between 60Hz simulation steps.'
               : 'Uses the raw 60Hz local pose so you can compare against the smoothed path.'}
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'grid',
+            gap: 8,
+            padding: '10px 12px',
+            borderRadius: 10,
+            background: vehicleSmoothingBackground,
+            border: `1px solid ${vehicleSmoothingBorder}`,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 10,
+              flexWrap: 'wrap',
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  color: '#f0fff4',
+                  fontSize: 13,
+                  fontWeight: 700,
+                  marginBottom: 2,
+                }}
+              >
+                Vehicle Smoothing
+              </div>
+              <div style={{ color: '#94b69f', fontSize: 11 }}>
+                Toggle local driven vehicle mesh and chase camera smoothing.
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-pressed={vehicleSmoothingEnabled}
+              onClick={onToggleVehicleSmoothing}
+              style={{
+                background: vehicleSmoothingEnabled ? 'rgba(137, 255, 186, 0.18)' : 'rgba(255, 255, 255, 0.08)',
+                border: `1px solid ${vehicleSmoothingEnabled ? 'rgba(137, 255, 186, 0.48)' : 'rgba(255, 255, 255, 0.2)'}`,
+                color: vehicleSmoothingAccent,
+                borderRadius: 999,
+                cursor: onToggleVehicleSmoothing ? 'pointer' : 'default',
+                font: 'inherit',
+                fontWeight: 700,
+                letterSpacing: '0.03em',
+                padding: '6px 12px',
+                boxShadow: vehicleSmoothingEnabled ? 'inset 0 0 0 1px rgba(137, 255, 186, 0.08)' : 'none',
+              }}
+            >
+              {`Vehicle Smooth ${vehicleSmoothingEnabled ? 'ON' : 'OFF'}`}
+            </button>
+          </div>
+          <div style={{ color: '#a9cab2', fontSize: 11, lineHeight: 1.35 }}>
+            {vehicleSmoothingEnabled
+              ? 'Renders the driven vehicle and chase camera from the filtered visual pose.'
+              : 'Uses the raw local vehicle pose so you can verify whether the filter is causing the wobble.'}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add a dedicated Vehicle Smooth debug toggle and thread it through App, GameScene, GameWorld, and DebugOverlay so local vehicle presentation can be evaluated independently from the existing local render smoothing toggle.

When vehicle smoothing is disabled, render the driven vehicle directly from the authoritative/local controlled pose instead of the filtered mesh pose, and bypass the chase-camera smoothing branch so the raw vehicle/camera path can be compared against the filtered path during debugging.

Switch the browser-local practice session tick loop from setInterval to requestAnimationFrame with the existing fixed-step accumulator. This keeps the 60 Hz local Rust session aligned with the display clock and reduces timer-scheduling jitter in /practice.

Record the new vehicle_smoothing flag in copied debug markdown and default vehicle smoothing to off, since the raw path currently behaves better than the filtered path in both /play and /practice.