### PR TITLE
Add world hosting and arena management system

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,6 +35,8 @@ import {
 type AppProps = {
   mode: GameMode;
   worldDocument?: WorldDocument;
+  /** Override the match ID for hosted worlds (e.g. "worldId:arenaId"). */
+  matchId?: string;
   overlay?: ReactNode;
   routeLabel?: string;
   autoConnect?: boolean;
@@ -94,6 +96,7 @@ function parseBenchmarkScenario(raw: string | null, matchId: string): LoadTestSc
 export function App({
   mode,
   worldDocument = DEFAULT_WORLD_DOCUMENT,
+  matchId,
   overlay,
   routeLabel,
   autoConnect = false,
@@ -685,6 +688,7 @@ export function App({
         <GameScene
           key={sessionKey}
           mode={mode}
+          matchId={matchId}
           worldDocument={effectiveWorldDocument}
           onWelcome={handleWelcome}
           onDisconnect={handleDisconnect}

--- a/client/src/app/routes.ts
+++ b/client/src/app/routes.ts
@@ -4,6 +4,7 @@ export type AppRoute =
   | { kind: 'launcher' }
   | { kind: 'game'; mode: GameMode }
   | { kind: 'sharedPractice'; id: string }
+  | { kind: 'hostedWorld'; worldId: string; arenaId?: string }
   | { kind: 'stats' }
   | { kind: 'loadtest' }
   | { kind: 'builder'; page: 'world'; publishedId?: string }
@@ -18,11 +19,22 @@ function normalizePathname(pathname: string): string {
 }
 
 const SHARED_PRACTICE_PREFIX = '/practice/shared/';
+const HOSTED_WORLD_PREFIX = '/play/world/';
 
 export function resolveAppRoute(pathname: string, search?: string): AppRoute {
   const params = new URLSearchParams(search ?? '');
   const publishedId = params.get('published') ?? undefined;
   const normalized = normalizePathname(pathname);
+
+  if (normalized.startsWith(HOSTED_WORLD_PREFIX)) {
+    const rest = normalized.slice(HOSTED_WORLD_PREFIX.length);
+    const parts = rest.split('/');
+    const worldId = decodeURIComponent(parts[0] ?? '');
+    const arenaId = parts[1] ? decodeURIComponent(parts[1]) : undefined;
+    if (worldId) {
+      return { kind: 'hostedWorld', worldId, arenaId };
+    }
+  }
 
   if (normalized.startsWith(SHARED_PRACTICE_PREFIX)) {
     const rest = normalized.slice(SHARED_PRACTICE_PREFIX.length);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,6 +7,7 @@ import { ServerStats } from './pages/ServerStats';
 import { GodModePage } from './pages/GodMode';
 import { GalleryPage } from './pages/Gallery';
 import { SharedPracticePage } from './pages/SharedPractice';
+import { HostedWorldPage } from './pages/HostedWorld';
 
 const root = createRoot(document.getElementById('root')!);
 
@@ -31,6 +32,9 @@ switch (route.kind) {
     break;
   case 'sharedPractice':
     root.render(<SharedPracticePage id={route.id} />);
+    break;
+  case 'hostedWorld':
+    root.render(<HostedWorldPage worldId={route.worldId} arenaId={route.arenaId} />);
     break;
   case 'builder':
     root.render(<GodModePage publishedId={route.publishedId} />);

--- a/client/src/net/netcodeClient.ts
+++ b/client/src/net/netcodeClient.ts
@@ -791,6 +791,10 @@ export class NetcodeClient {
         );
         this.config.onShotResult?.(packet);
         break;
+      case 'error':
+        console.error('[netcode] server error:', packet.errorCode, packet.message);
+        this.notifyDisconnect(`Server error: ${packet.message}`);
+        break;
       default:
         break;
     }

--- a/client/src/net/protocol.ts
+++ b/client/src/net/protocol.ts
@@ -19,6 +19,7 @@ import {
   PKT_DYNAMIC_BODY_META,
   PKT_PING,
   PKT_PONG,
+  PKT_ERROR,
   BTN_FORWARD,
   BTN_BACK,
   BTN_LEFT,
@@ -292,11 +293,13 @@ export type ServerReliablePacket =
   | PlayerRosterPacket
   | DynamicBodyMetaPacket
   | ServerPingPacket
-  | PongPacket;
+  | PongPacket
+  | ServerErrorPacket;
 export type ServerDatagramPacket = SnapshotPacket | SnapshotV2Packet;
 
 export type ServerPingPacket = { type: 'serverPing'; value: number };
 export type PongPacket = { type: 'pong'; value: number };
+export type ServerErrorPacket = { type: 'error'; errorCode: number; message: string };
 export type ServerWorldPacket = ChunkFullPacket | ChunkDiffPacket;
 export type ServerPacket =
   | WelcomePacket
@@ -308,7 +311,8 @@ export type ServerPacket =
   | PlayerRosterPacket
   | DynamicBodyMetaPacket
   | ServerPingPacket
-  | PongPacket;
+  | PongPacket
+  | ServerErrorPacket;
 
 export type InputCmd = InputFrame;
 
@@ -489,6 +493,13 @@ export function decodeServerReliablePacket(data: ArrayBuffer | Uint8Array): Serv
       return { type: 'serverPing', value: view.getUint32(o, true) };
     case PKT_PONG:
       return { type: 'pong', value: view.getUint32(o, true) };
+    case PKT_ERROR: {
+      const errorCode = view.getUint16(o, true); o += 2;
+      const msgLen = view.getUint16(o, true); o += 2;
+      const msgBytes = bytes.subarray(o, o + msgLen);
+      const message = new TextDecoder().decode(msgBytes);
+      return { type: 'error', errorCode, message };
+    }
     default:
       throw new Error(`unknown reliable packet kind: ${kind}`);
   }

--- a/client/src/net/sharedConstants.ts
+++ b/client/src/net/sharedConstants.ts
@@ -36,6 +36,7 @@ export const PKT_PONG = 111;
 export const PKT_SNAPSHOT_V2 = 112;
 export const PKT_PLAYER_ROSTER = 113;
 export const PKT_DYNAMIC_BODY_META = 114;
+export const PKT_ERROR = 120;
 
 // ── Weapon types ────────────────────────────────
 export const WEAPON_HITSCAN = 1;

--- a/client/src/pages/Gallery.tsx
+++ b/client/src/pages/Gallery.tsx
@@ -6,6 +6,25 @@ import {
   type GalleryWorldSummary,
 } from '../world/worldsCloud';
 import { loadPublishedHistory, type PublishedHistoryEntry } from '../world/publishedHistory';
+import { resolveMultiplayerBackend } from '../app/runtimeConfig';
+
+type ActiveWorldArena = {
+  arenaId: string;
+  playerCount: number;
+};
+
+type ActiveWorld = {
+  worldId: string;
+  worldName: string;
+  arenas: ActiveWorldArena[];
+};
+
+type ActiveWorldsResponse = {
+  worlds: ActiveWorld[];
+  defaultArenas: ActiveWorldArena[];
+  maxHostedArenas: number;
+  activeArenaCount: number;
+};
 
 const shellStyle: CSSProperties = {
   minHeight: '100%',
@@ -112,6 +131,43 @@ const mutedTextStyle: CSSProperties = {
   lineHeight: 1.6,
 };
 
+const onlineBadgeStyle: CSSProperties = {
+  display: 'inline-block',
+  padding: '3px 10px',
+  borderRadius: 999,
+  background: 'rgba(100, 200, 255, 0.18)',
+  border: '1px solid rgba(100, 200, 255, 0.35)',
+  color: '#9cd4ff',
+  fontSize: 11,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+};
+
+const arenaDropdownStyle: CSSProperties = {
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  marginTop: 4,
+  minWidth: 180,
+  background: 'rgba(8, 14, 24, 0.96)',
+  border: '1px solid rgba(145, 198, 255, 0.22)',
+  borderRadius: 12,
+  padding: '6px 0',
+  zIndex: 10,
+  boxShadow: '0 8px 24px rgba(0, 0, 0, 0.5)',
+};
+
+const arenaDropdownItemStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: 12,
+  padding: '8px 14px',
+  color: '#edf6ff',
+  textDecoration: 'none',
+  fontSize: 13,
+};
+
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'disabled' }
@@ -122,6 +178,24 @@ export function GalleryPage() {
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [publicUrl, setPublicUrl] = useState<string | null>(null);
   const [history, setHistory] = useState<PublishedHistoryEntry[]>(() => loadPublishedHistory());
+  const [activeWorlds, setActiveWorlds] = useState<ActiveWorldsResponse | null>(null);
+
+  // Fetch active worlds from the game server (optional — fails silently).
+  useEffect(() => {
+    let cancelled = false;
+    try {
+      const backend = resolveMultiplayerBackend();
+      fetch(`${backend.httpOrigin}/active-worlds`)
+        .then((r) => r.json())
+        .then((data: ActiveWorldsResponse) => {
+          if (!cancelled) setActiveWorlds(data);
+        })
+        .catch(() => {});
+    } catch {
+      // resolveMultiplayerBackend may throw in edge cases
+    }
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     // Refresh whenever the page regains focus so a publish in another tab
@@ -247,7 +321,7 @@ export function GalleryPage() {
               }}
             >
               {ownedSummaries.map((world) => (
-                <GalleryCard key={`own-${world.id}`} world={world} owned publicUrl={publicUrl} />
+                <GalleryCard key={`own-${world.id}`} world={world} owned publicUrl={publicUrl} activeWorlds={activeWorlds} />
               ))}
             </div>
           </section>
@@ -269,7 +343,7 @@ export function GalleryPage() {
               }}
             >
               {communitySummaries.map((world) => (
-                <GalleryCard key={world.id} world={world} publicUrl={publicUrl} />
+                <GalleryCard key={world.id} world={world} publicUrl={publicUrl} activeWorlds={activeWorlds} />
               ))}
             </div>
           </section>
@@ -279,11 +353,18 @@ export function GalleryPage() {
   );
 }
 
-function GalleryCard({ world, owned = false, publicUrl = null }: { world: GalleryWorldSummary; owned?: boolean; publicUrl?: string | null }) {
+function GalleryCard({ world, owned = false, publicUrl = null, activeWorlds = null }: { world: GalleryWorldSummary; owned?: boolean; publicUrl?: string | null; activeWorlds?: ActiveWorldsResponse | null }) {
   const [screenshotFailed, setScreenshotFailed] = useState(false);
-  const playHref = `/practice/shared/${encodeURIComponent(world.id)}`;
+  const [arenaDropdownOpen, setArenaDropdownOpen] = useState(false);
+  const soloHref = `/practice/shared/${encodeURIComponent(world.id)}`;
+  const onlineHref = `/play/world/${encodeURIComponent(world.id)}`;
   const editHref = `/builder/world?published=${encodeURIComponent(world.id)}`;
-  const previewHref = playHref;
+  const previewHref = soloHref;
+
+  // Find active arena info for this world.
+  const activeWorld = activeWorlds?.worlds.find((w) => w.worldId === world.id) ?? null;
+  const totalPlayers = activeWorld ? activeWorld.arenas.reduce((sum, a) => sum + a.playerCount, 0) : 0;
+
   return (
     <div style={cardStyle}>
       <a
@@ -307,7 +388,14 @@ function GalleryCard({ world, owned = false, publicUrl = null }: { world: Galler
         <div style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.18em', color: '#87d6ff' }}>
           {formatRelativeTime(world.createdAt)} · {formatSize(world.size)}
         </div>
-        {owned && <span style={ownedBadgeStyle}>yours</span>}
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {totalPlayers > 0 && (
+            <span style={onlineBadgeStyle}>
+              {totalPlayers} online
+            </span>
+          )}
+          {owned && <span style={ownedBadgeStyle}>yours</span>}
+        </div>
       </div>
       <h2 style={{ margin: '2px 0 4px', fontSize: 22 }}>{world.name || 'Untitled World'}</h2>
       <p
@@ -326,8 +414,38 @@ function GalleryCard({ world, owned = false, publicUrl = null }: { world: Galler
         {world.description || 'No description provided.'}
       </p>
       <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
-        <a href={playHref} style={primaryActionStyle}>Play</a>
+        <a href={onlineHref} style={primaryActionStyle}>Play Online</a>
+        <a href={soloHref} style={secondaryActionStyle}>Play Solo</a>
         <a href={editHref} style={secondaryActionStyle}>Edit in builder</a>
+        {activeWorld && activeWorld.arenas.length > 1 && (
+          <div style={{ position: 'relative' }}>
+            <button
+              onClick={() => setArenaDropdownOpen((v) => !v)}
+              style={{
+                ...secondaryActionStyle,
+                background: 'transparent',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              {activeWorld.arenas.length} arenas ▾
+            </button>
+            {arenaDropdownOpen && (
+              <div style={arenaDropdownStyle}>
+                {activeWorld.arenas.map((arena) => (
+                  <a
+                    key={arena.arenaId}
+                    href={`/play/world/${encodeURIComponent(world.id)}/${encodeURIComponent(arena.arenaId)}`}
+                    style={arenaDropdownItemStyle}
+                  >
+                    <span>{arena.arenaId}</span>
+                    <span style={{ color: '#79baf5' }}>{arena.playerCount} player{arena.playerCount === 1 ? '' : 's'}</span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
       <div style={{ fontSize: 12, color: 'rgba(237, 246, 255, 0.5)' }}>
         id <code>{world.id}</code>

--- a/client/src/pages/HostedWorld.tsx
+++ b/client/src/pages/HostedWorld.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { App } from '../App';
+import { resolveMultiplayerBackend } from '../app/runtimeConfig';
+
+type ActiveWorldArena = {
+  arenaId: string;
+  playerCount: number;
+};
+
+type ActiveWorld = {
+  worldId: string;
+  worldName: string;
+  arenas: ActiveWorldArena[];
+};
+
+type ActiveWorldsResponse = {
+  worlds: ActiveWorld[];
+  defaultArenas: ActiveWorldArena[];
+  maxHostedArenas: number;
+  activeArenaCount: number;
+};
+
+const shellStyle: CSSProperties = {
+  minHeight: '100%',
+  background:
+    'radial-gradient(circle at top, rgba(93, 215, 255, 0.14), transparent 32%), linear-gradient(180deg, #08111d 0%, #04070d 100%)',
+  color: '#edf6ff',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '32px',
+};
+
+const cardStyle: CSSProperties = {
+  width: 'min(520px, 100%)',
+  background: 'rgba(6, 12, 20, 0.86)',
+  border: '1px solid rgba(110, 190, 255, 0.2)',
+  borderRadius: 24,
+  padding: '32px',
+  textAlign: 'center',
+};
+
+const overlayStyle: CSSProperties = {
+  position: 'absolute',
+  top: 16,
+  right: 16,
+  display: 'flex',
+  gap: 12,
+  padding: '10px 14px',
+  borderRadius: 999,
+  background: 'rgba(6, 12, 20, 0.78)',
+  border: '1px solid rgba(110, 190, 255, 0.22)',
+  color: '#edf6ff',
+  fontSize: 13,
+  alignItems: 'center',
+  pointerEvents: 'auto',
+};
+
+type HostedWorldPageProps = {
+  worldId: string;
+  arenaId?: string;
+};
+
+export function HostedWorldPage({ worldId, arenaId }: HostedWorldPageProps) {
+  const backend = useMemo(() => resolveMultiplayerBackend(), []);
+  const [resolvedArenaId, setResolvedArenaId] = useState<string | null>(
+    arenaId ?? null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (arenaId) {
+      // Arena ID was explicitly provided in the URL, use it directly.
+      setResolvedArenaId(arenaId);
+      return;
+    }
+
+    // No arena ID — query the server for existing arenas for this world.
+    let cancelled = false;
+    fetch(`${backend.httpOrigin}/active-worlds`)
+      .then((r) => r.json())
+      .then((data: ActiveWorldsResponse) => {
+        if (cancelled) return;
+        const world = data.worlds.find((w) => w.worldId === worldId);
+        if (world && world.arenas.length > 0) {
+          // Pick the arena with the most players (most likely to be active).
+          const best = world.arenas.reduce((a, b) =>
+            b.playerCount > a.playerCount ? b : a,
+          );
+          setResolvedArenaId(best.arenaId);
+          window.history.replaceState(
+            null,
+            '',
+            `/play/world/${encodeURIComponent(worldId)}/${encodeURIComponent(best.arenaId)}`,
+          );
+        } else {
+          // No existing arena — create a new "main" arena.
+          setResolvedArenaId('main');
+          window.history.replaceState(
+            null,
+            '',
+            `/play/world/${encodeURIComponent(worldId)}/main`,
+          );
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // If the active-worlds endpoint fails (e.g., old server), fall back to "main".
+        setResolvedArenaId('main');
+        window.history.replaceState(
+          null,
+          '',
+          `/play/world/${encodeURIComponent(worldId)}/main`,
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [worldId, arenaId, backend.httpOrigin]);
+
+  if (error) {
+    return (
+      <div style={shellStyle}>
+        <div style={cardStyle}>
+          <div
+            style={{
+              letterSpacing: '0.28em',
+              fontSize: 12,
+              textTransform: 'uppercase',
+              color: '#ffb4a6',
+            }}
+          >
+            vibe-land
+          </div>
+          <h1 style={{ fontSize: 28, margin: '10px 0 12px' }}>
+            Could not join world
+          </h1>
+          <p
+            style={{
+              color: 'rgba(237, 246, 255, 0.78)',
+              margin: 0,
+              lineHeight: 1.5,
+            }}
+          >
+            {error}
+          </p>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              gap: 16,
+              marginTop: 18,
+              fontSize: 14,
+            }}
+          >
+            <a href="/gallery" style={{ color: '#9cd4ff' }}>
+              Back to gallery
+            </a>
+            <a href="/" style={{ color: '#9cd4ff' }}>
+              Home
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!resolvedArenaId) {
+    return (
+      <div style={shellStyle}>
+        <div style={cardStyle}>
+          <div
+            style={{
+              letterSpacing: '0.28em',
+              fontSize: 12,
+              textTransform: 'uppercase',
+              color: '#79baf5',
+            }}
+          >
+            vibe-land
+          </div>
+          <h1 style={{ fontSize: 32, margin: '10px 0 8px' }}>
+            Finding arena...
+          </h1>
+          <p style={{ color: 'rgba(237, 246, 255, 0.74)', margin: 0 }}>
+            Looking for active arenas for this world.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const matchId = `${worldId}:${resolvedArenaId}`;
+
+  return (
+    <App
+      mode="multiplayer"
+      matchId={matchId}
+      autoConnect
+      overlay={
+        <div style={overlayStyle}>
+          <span style={{ opacity: 0.75 }}>Online world</span>
+          <strong>{worldId.slice(0, 8)}...</strong>
+          <a
+            href="/gallery"
+            style={{ color: '#9cd4ff', textDecoration: 'none' }}
+          >
+            Gallery
+          </a>
+          <a href="/" style={{ color: '#9cd4ff', textDecoration: 'none' }}>
+            Home
+          </a>
+        </div>
+      }
+    />
+  );
+}

--- a/client/src/scene/GameScene.tsx
+++ b/client/src/scene/GameScene.tsx
@@ -10,6 +10,7 @@ import type { WorldDocument } from '../world/worldDocument';
 
 type GameSceneProps = {
   mode: GameMode;
+  matchId?: string;
   onWelcome: (id: number) => void;
   onDisconnect: (reason?: string) => void;
   onAimStateChange?: React.ComponentProps<typeof GameWorld>['onAimStateChange'];
@@ -32,6 +33,7 @@ type GameWorldDebugFrame = React.ComponentProps<typeof GameWorld>['onDebugFrame'
 
 export function GameScene({
   mode,
+  matchId,
   onWelcome,
   onDisconnect,
   onAimStateChange,
@@ -70,6 +72,7 @@ export function GameScene({
         <GameWorld
           mode={mode}
           worldDocument={worldDocument}
+          matchId={matchId}
           onWelcome={onWelcome}
           onDisconnect={onDisconnect}
           onAimStateChange={onAimStateChange}

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -169,6 +169,7 @@ type FrameDebugCallback = (
 type GameWorldProps = {
   mode: GameMode;
   worldDocument?: WorldDocument;
+  matchId?: string;
   onWelcome: (id: number) => void;
   onDisconnect: (reason?: string) => void;
   onAimStateChange?: (state: CrosshairAimState) => void;
@@ -375,6 +376,7 @@ function resolvedInputFromBotIntent(
 export function GameWorld({
   mode,
   worldDocument = DEFAULT_WORLD_DOCUMENT,
+  matchId: explicitMatchId,
   onWelcome,
   onDisconnect,
   onAimStateChange,
@@ -429,6 +431,7 @@ export function GameWorld({
     prediction.ready ? (vs: NetVehicleState, ackInputSeq: number) => {
       prediction.reconcileVehicle(vs, ackInputSeq);
     } : undefined,
+    explicitMatchId,
   );
   const { camera, gl } = useThree();
 

--- a/client/src/scene/useGameConnection.ts
+++ b/client/src/scene/useGameConnection.ts
@@ -44,10 +44,15 @@ export function useGameConnection(
   onLocalSnapshot?: (ackInputSeq: number, state: NetPlayerState) => void,
   onServerPacket?: (packet: ServerPacket) => void,
   onLocalVehicleSnapshot?: (vehicleState: NetVehicleState, ackInputSeq: number) => void,
+  /** Override the match ID (e.g. "worldId:arenaId" for hosted worlds). */
+  explicitMatchId?: string,
 ) {
   const practiceMode = isPracticeMode(mode);
   const multiplayerBackend = useMemo(() => resolveMultiplayerBackend(), []);
-  const multiplayerMatchId = useMemo(() => resolveRequestedMatchId(window.location.search), []);
+  const multiplayerMatchId = useMemo(
+    () => explicitMatchId ?? resolveRequestedMatchId(window.location.search),
+    [explicitMatchId],
+  );
   const clientRef = useRef<NetcodeClient | null>(null);
 
   // Keep callbacks in refs so the NetcodeClient doesn't need to be recreated

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,6 +3,7 @@ mod lag_comp;
 mod movement;
 mod protocol;
 mod voxel_world;
+mod world_cache;
 
 use std::{
     backtrace::Backtrace,
@@ -29,7 +30,7 @@ use axum::{
 use bytes::BufMut;
 use futures_util::{sink::SinkExt, stream::StreamExt, FutureExt};
 use sha2::{Digest, Sha256};
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, RwLock as AsyncRwLock};
 use tracing::{error, info, warn};
 use wtransport::{error::SendDatagramError, Connection, Endpoint, Identity, ServerConfig};
@@ -47,7 +48,12 @@ use crate::{
         SHOT_RESOLUTION_DYNAMIC, SHOT_RESOLUTION_MISS, SHOT_RESOLUTION_PLAYER,
     },
     voxel_world::VoxelWorld,
+    world_cache::{
+        fetch_world_document, parse_match_key, release_arena, run_cache_janitor, MatchKey,
+        WorldCache, WorldHostError,
+    },
 };
+use vibe_land_shared::world_document::WorldDocument;
 const SIM_HZ: u16 = 60;
 const SNAPSHOT_HZ: u16 = 30;
 const CHUNK_RADIUS_ON_JOIN: i32 = 4;
@@ -520,12 +526,22 @@ struct AppState {
     respawn_delay_ms: u32,
     stats_tx: Arc<tokio::sync::watch::Sender<GlobalStatsSnapshot>>,
     stats_registry: Arc<StdRwLock<HashMap<String, MatchStatsSnapshot>>>,
+    world_cache: Arc<AsyncRwLock<WorldCache>>,
+    max_hosted_arenas: usize,
 }
 
 #[derive(Clone)]
 struct MatchHandle {
     tx: mpsc::UnboundedSender<MatchEvent>,
     telemetry: Arc<MatchIoTelemetry>,
+    /// `None` for the built-in default world.
+    world_id: Option<String>,
+    /// Human-readable world name (from WorldDocument.meta.name).
+    world_name: String,
+    /// Arena ID portion of the compound key.
+    arena_id: String,
+    /// Live player count, updated atomically by the match loop.
+    player_count: Arc<AtomicU32>,
 }
 
 struct SpacetimeVerifier {
@@ -650,6 +666,10 @@ struct MatchState {
     player_handles: HashMap<u32, u8>,
     dynamic_body_handles: HashMap<u32, DynamicBodyMetaRuntime>,
     vehicle_handles: HashMap<u32, u8>,
+    /// Tracks when the arena became empty for idle cleanup.
+    empty_since: Option<Instant>,
+    /// Shared atomic counter read by the /active-worlds endpoint.
+    player_count: Arc<AtomicU32>,
 }
 
 #[tokio::main]
@@ -717,6 +737,21 @@ async fn main() -> Result<()> {
     let (stats_tx, _stats_rx) = tokio::sync::watch::channel(GlobalStatsSnapshot::default());
     let stats_tx = Arc::new(stats_tx);
 
+    let max_hosted_arenas: usize = std::env::var("VIBE_MAX_HOSTED_ARENAS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let worlds_api_url = std::env::var("WORLDS_API_URL").unwrap_or_default();
+    info!(max_hosted_arenas, %worlds_api_url, "world hosting config loaded");
+
+    let world_cache = Arc::new(AsyncRwLock::new(WorldCache::new(worlds_api_url)));
+
+    // Start world cache janitor (evicts idle cached world documents every 15s).
+    {
+        let cache = world_cache.clone();
+        tokio::spawn(run_cache_janitor(cache, 60));
+    }
+
     let state = SharedAppState {
         inner: Arc::new(AppState {
             matches: AsyncRwLock::new(HashMap::new()),
@@ -733,6 +768,8 @@ async fn main() -> Result<()> {
             respawn_delay_ms,
             stats_tx,
             stats_registry: Arc::new(StdRwLock::new(HashMap::new())),
+            world_cache,
+            max_hosted_arenas,
         }),
     };
 
@@ -781,6 +818,7 @@ async fn main() -> Result<()> {
     let app = Router::new()
         .route("/healthz", get(|| async { "ok" }))
         .route("/session-config", get(session_config_handler))
+        .route("/active-worlds", get(active_worlds_handler))
         .route("/ws/stats", get(ws_stats_handler))
         .route("/ws/:match_id", get(ws_handler))
         .layer(tower_http::cors::CorsLayer::permissive())
@@ -816,6 +854,79 @@ async fn session_config_handler(
         interpolation_delay_ms: (1000 / SNAPSHOT_HZ) * 2,
     };
     axum::Json(config)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Active-worlds endpoint
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ActiveWorldArena {
+    arena_id: String,
+    player_count: u32,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ActiveWorld {
+    world_id: String,
+    world_name: String,
+    arenas: Vec<ActiveWorldArena>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ActiveWorldsResponse {
+    worlds: Vec<ActiveWorld>,
+    default_arenas: Vec<ActiveWorldArena>,
+    max_hosted_arenas: usize,
+    active_arena_count: usize,
+}
+
+async fn active_worlds_handler(
+    State(state): State<SharedAppState>,
+) -> impl IntoResponse {
+    let matches = state.inner.matches.read().await;
+    let mut worlds_map: HashMap<String, (String, Vec<ActiveWorldArena>)> = HashMap::new();
+    let mut default_arenas = Vec::new();
+    let mut active_arena_count: usize = 0;
+
+    for handle in matches.values() {
+        let player_count = handle.player_count.load(Ordering::Relaxed);
+        let arena = ActiveWorldArena {
+            arena_id: handle.arena_id.clone(),
+            player_count,
+        };
+        match &handle.world_id {
+            Some(world_id) => {
+                active_arena_count += 1;
+                let entry = worlds_map
+                    .entry(world_id.clone())
+                    .or_insert_with(|| (handle.world_name.clone(), Vec::new()));
+                entry.1.push(arena);
+            }
+            None => {
+                default_arenas.push(arena);
+            }
+        }
+    }
+
+    let worlds: Vec<ActiveWorld> = worlds_map
+        .into_iter()
+        .map(|(world_id, (world_name, arenas))| ActiveWorld {
+            world_id,
+            world_name,
+            arenas,
+        })
+        .collect();
+
+    axum::Json(ActiveWorldsResponse {
+        worlds,
+        default_arenas,
+        max_hosted_arenas: state.inner.max_hosted_arenas,
+        active_arena_count,
+    })
 }
 
 async fn ws_stats_handler(
@@ -859,7 +970,18 @@ async fn handle_wt_session(app: Arc<AppState>, connection: Connection) -> Result
     let hello = decode_client_hello(&raw[4..4 + payload_len])?;
 
     let player_id = app.next_player_id.fetch_add(1, Ordering::Relaxed);
-    let handle = get_or_create_match(app.clone(), hello.match_id.clone()).await;
+    let handle = match get_or_create_match(app.clone(), hello.match_id.clone()).await {
+        Ok(h) => h,
+        Err(err) => {
+            warn!(player_id, match_id = %hello.match_id, error = %err, "world host error (WT)");
+            let error_pkt = protocol::encode_world_host_error(err.error_code(), &err.to_string());
+            let mut framed = Vec::with_capacity(4 + error_pkt.len());
+            framed.extend_from_slice(&(error_pkt.len() as u32).to_le_bytes());
+            framed.extend_from_slice(&error_pkt);
+            let _ = send_stream.write_all(&framed).await;
+            return Err(anyhow::anyhow!("world host error: {err}"));
+        }
+    };
 
     let (out_tx, mut out_rx) = mpsc::channel::<Vec<u8>>(PLAYER_OUTBOUND_QUEUE_CAPACITY);
 
@@ -1008,7 +1130,17 @@ async fn handle_socket(
     app.verifier.verify(&query.identity, &query.token).await?;
 
     let player_id = app.next_player_id.fetch_add(1, Ordering::Relaxed);
-    let handle = get_or_create_match(app.clone(), match_id.clone()).await;
+    let handle = match get_or_create_match(app.clone(), match_id.clone()).await {
+        Ok(h) => h,
+        Err(err) => {
+            warn!(player_id, %match_id, error = %err, "world host error (WS)");
+            let error_pkt = protocol::encode_world_host_error(err.error_code(), &err.to_string());
+            let (mut ws_tx, _) = socket.split();
+            let _ = ws_tx.send(Message::Binary(error_pkt.into())).await;
+            let _ = ws_tx.close().await;
+            return Err(anyhow::anyhow!("world host error: {err}"));
+        }
+    };
 
     let (mut ws_tx, mut ws_rx) = socket.split();
     let (out_tx, mut out_rx) = mpsc::channel::<Vec<u8>>(PLAYER_OUTBOUND_QUEUE_CAPACITY);
@@ -1079,33 +1211,89 @@ async fn handle_socket(
     Ok(())
 }
 
-async fn get_or_create_match(app: Arc<AppState>, match_id: String) -> MatchHandle {
-    if let Some(existing) = app.matches.read().await.get(&match_id).cloned() {
+async fn get_or_create_match(
+    app: Arc<AppState>,
+    match_id: String,
+) -> Result<MatchHandle, WorldHostError> {
+    let key = parse_match_key(&match_id);
+    let composite = key.composite_key();
+
+    if let Some(existing) = app.matches.read().await.get(&composite).cloned() {
         if !existing.tx.is_closed() {
-            return existing;
+            return Ok(existing);
         }
-        warn!(%match_id, "dropping stale closed match handle from read cache");
+        warn!(%composite, "dropping stale closed match handle from read cache");
     }
 
     let mut write = app.matches.write().await;
-    if let Some(existing) = write.get(&match_id).cloned() {
+    if let Some(existing) = write.get(&composite).cloned() {
         if !existing.tx.is_closed() {
-            return existing;
+            return Ok(existing);
         }
-        warn!(%match_id, "dropping stale closed match handle before recreating match");
-        write.remove(&match_id);
+        warn!(%composite, "dropping stale closed match handle before recreating match");
+        write.remove(&composite);
     }
+
+    // Resolve the world document for this arena.
+    let (world_document, world_name, world_id_opt, arena_id) = match &key {
+        MatchKey::Default { arena_id } => {
+            (None, "Default World".to_string(), None, arena_id.clone())
+        }
+        MatchKey::Hosted { world_id, arena_id } => {
+            if app.max_hosted_arenas == 0 {
+                return Err(WorldHostError::Disabled);
+            }
+            // Drop the write lock before the async fetch.
+            drop(write);
+            let (doc, name) = fetch_world_document(
+                &app.world_cache,
+                world_id,
+                app.max_hosted_arenas,
+            )
+            .await?;
+            // Re-acquire write lock after fetch.
+            write = app.matches.write().await;
+            // Double-check: another task may have created this match while we fetched.
+            if let Some(existing) = write.get(&composite).cloned() {
+                if !existing.tx.is_closed() {
+                    // Release the arena_count we just incremented since we won't use it.
+                    release_arena(&app.world_cache, world_id).await;
+                    return Ok(existing);
+                }
+                write.remove(&composite);
+            }
+            (
+                Some(doc),
+                name,
+                Some(world_id.clone()),
+                arena_id.clone(),
+            )
+        }
+    };
 
     let (tx, rx) = mpsc::unbounded_channel();
     let telemetry = Arc::new(MatchIoTelemetry::default());
+    let player_count = Arc::new(AtomicU32::new(0));
     let handle = MatchHandle {
         tx: tx.clone(),
         telemetry: telemetry.clone(),
+        world_id: world_id_opt,
+        world_name,
+        arena_id,
+        player_count: player_count.clone(),
     };
-    write.insert(match_id.clone(), handle.clone());
+    write.insert(composite.clone(), handle.clone());
     drop(write);
-    spawn_match_loop(app, match_id, handle.clone(), rx, telemetry);
-    handle
+    spawn_match_loop(
+        app,
+        composite,
+        handle.clone(),
+        rx,
+        telemetry,
+        world_document,
+        player_count,
+    );
+    Ok(handle)
 }
 
 async fn run_match_loop(
@@ -1117,10 +1305,17 @@ async fn run_match_loop(
     stats_tx: Arc<tokio::sync::watch::Sender<GlobalStatsSnapshot>>,
     telemetry: Arc<MatchIoTelemetry>,
     stats_registry: Arc<StdRwLock<HashMap<String, MatchStatsSnapshot>>>,
+    world_document: Option<Arc<WorldDocument>>,
+    player_count: Arc<AtomicU32>,
 ) {
     let mut arena = PhysicsArena::with_player_kcc_mode(MoveConfig::default(), player_kcc_mode);
     let world = VoxelWorld::new();
-    seed_default_world(&mut arena).expect("default world document should instantiate");
+    match &world_document {
+        Some(doc) => doc
+            .instantiate(&mut arena)
+            .expect("hosted world document should instantiate"),
+        None => seed_default_world(&mut arena).expect("default world document should instantiate"),
+    };
     let dynamic_body_handles = arena
         .snapshot_dynamic_bodies()
         .into_iter()
@@ -1169,6 +1364,8 @@ async fn run_match_loop(
         player_handles: HashMap::new(),
         dynamic_body_handles,
         vehicle_handles,
+        empty_since: Some(Instant::now()),
+        player_count,
     };
 
     let mut tick = tokio::time::interval(Duration::from_secs_f64(1.0 / SIM_HZ as f64));
@@ -1177,7 +1374,10 @@ async fn run_match_loop(
     loop {
         tokio::select! {
             _ = tick.tick() => {
-                state.tick();
+                if state.tick_and_check_idle() {
+                    info!(match_id = %state.id, "arena idle for 60s with 0 players, shutting down");
+                    break;
+                }
             }
             Some(event) = rx.recv() => {
                 state.handle_event(event);
@@ -1202,8 +1402,11 @@ fn spawn_match_loop(
     handle: MatchHandle,
     rx: mpsc::UnboundedReceiver<MatchEvent>,
     telemetry: Arc<MatchIoTelemetry>,
+    world_document: Option<Arc<WorldDocument>>,
+    player_count: Arc<AtomicU32>,
 ) {
-    info!(%match_id, "spawning match loop");
+    info!(%match_id, world_id = ?handle.world_id, "spawning match loop");
+    let world_id_for_cleanup = handle.world_id.clone();
     tokio::spawn(async move {
         let outcome = std::panic::AssertUnwindSafe(run_match_loop(
             match_id.clone(),
@@ -1214,6 +1417,8 @@ fn spawn_match_loop(
             app.stats_tx.clone(),
             telemetry,
             app.stats_registry.clone(),
+            world_document,
+            player_count,
         ))
         .catch_unwind()
         .await;
@@ -1243,6 +1448,12 @@ fn spawn_match_loop(
         };
         if removed {
             warn!(%match_id, "removed dead match handle after match loop termination");
+        }
+
+        // Release the world cache arena count so the janitor can eventually
+        // evict the cached world document.
+        if let Some(world_id) = &world_id_for_cleanup {
+            release_arena(&app.world_cache, world_id).await;
         }
 
         {
@@ -1398,6 +1609,8 @@ impl MatchState {
                     active_players = self.players.len(),
                     "player connected to match"
                 );
+                self.player_count.fetch_add(1, Ordering::Relaxed);
+                self.empty_since = None;
 
                 let server_time_us = (self.server_tick as u64) * (1_000_000 / SIM_HZ as u64);
                 let welcome = ServerPacket::Welcome(WelcomePacket {
@@ -1465,6 +1678,10 @@ impl MatchState {
                         active_players = self.players.len(),
                         "player disconnected from match"
                     );
+                }
+                self.player_count.fetch_sub(1, Ordering::Relaxed);
+                if self.players.is_empty() {
+                    self.empty_since = Some(Instant::now());
                 }
                 self.queue_roster_sync();
             }
@@ -1566,6 +1783,18 @@ impl MatchState {
                 }
             }
         }
+    }
+
+    /// Run one simulation tick and return `true` if the arena should shut down
+    /// due to being idle (0 players for > 60 seconds).
+    fn tick_and_check_idle(&mut self) -> bool {
+        self.tick();
+        if let Some(since) = self.empty_since {
+            if since.elapsed() > Duration::from_secs(60) {
+                return true;
+            }
+        }
+        false
     }
 
     fn tick(&mut self) {

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -6,6 +6,10 @@ pub use vibe_land_shared::constants::*;
 pub use vibe_land_shared::protocol::*;
 pub use vibe_land_shared::unit_conv::*;
 
+// ── Server-only constants ────────────
+
+pub const PKT_ERROR: u8 = 120;
+
 // ── Server-only types ───────────────────────────
 
 #[derive(Clone, Debug)]
@@ -763,6 +767,18 @@ pub fn encode_server_packet(packet: &ServerPacket) -> Vec<u8> {
         }
     }
     out.to_vec()
+}
+
+/// Encode a world-host error packet: `[PKT_ERROR, error_code_le16, msg_len_le16, utf8_msg...]`
+pub fn encode_world_host_error(error_code: u16, message: &str) -> Vec<u8> {
+    let msg_bytes = message.as_bytes();
+    let msg_len = msg_bytes.len().min(u16::MAX as usize) as u16;
+    let mut buf = Vec::with_capacity(1 + 2 + 2 + msg_len as usize);
+    buf.push(PKT_ERROR);
+    buf.extend_from_slice(&error_code.to_le_bytes());
+    buf.extend_from_slice(&msg_len.to_le_bytes());
+    buf.extend_from_slice(&msg_bytes[..msg_len as usize]);
+    buf
 }
 
 #[cfg(test)]

--- a/server/src/world_cache.rs
+++ b/server/src/world_cache.rs
@@ -1,0 +1,343 @@
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::Arc,
+    time::Instant,
+};
+
+use tokio::sync::RwLock as AsyncRwLock;
+use tracing::{info, warn};
+use vibe_land_shared::world_document::{WorldDocument, WorldDocumentError};
+
+// ---------------------------------------------------------------------------
+// MatchKey – parsed compound key from the raw match_id string
+// ---------------------------------------------------------------------------
+
+/// Parsed form of the flat `match_id` string that flows through the protocol.
+///
+/// Format: `"<world_id>:<arena_id>"` for hosted worlds, or a plain string
+/// (no colon) for the built-in default world.
+#[derive(Debug, Clone)]
+pub enum MatchKey {
+    /// The built-in default world (e.g. `"default"`).
+    Default { arena_id: String },
+    /// A hosted/published world loaded by world_id.
+    Hosted { world_id: String, arena_id: String },
+}
+
+impl MatchKey {
+    /// Reconstruct the flat composite key used as a HashMap key in `AppState.matches`.
+    pub fn composite_key(&self) -> String {
+        match self {
+            MatchKey::Default { arena_id } => arena_id.clone(),
+            MatchKey::Hosted { world_id, arena_id } => format!("{world_id}:{arena_id}"),
+        }
+    }
+
+    pub fn world_id(&self) -> Option<&str> {
+        match self {
+            MatchKey::Default { .. } => None,
+            MatchKey::Hosted { world_id, .. } => Some(world_id),
+        }
+    }
+}
+
+/// Parse a raw match_id string into a `MatchKey`.
+///
+/// If the string contains a `:`, the portion before the first colon is the
+/// world_id and the remainder is the arena_id.  Otherwise the entire string
+/// is treated as a default-world arena_id.
+pub fn parse_match_key(raw: &str) -> MatchKey {
+    if let Some((world_id, arena_id)) = raw.split_once(':') {
+        if world_id.is_empty() || arena_id.is_empty() {
+            return MatchKey::Default {
+                arena_id: raw.to_string(),
+            };
+        }
+        MatchKey::Hosted {
+            world_id: world_id.to_string(),
+            arena_id: arena_id.to_string(),
+        }
+    } else {
+        MatchKey::Default {
+            arena_id: raw.to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WorldHostError
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum WorldHostError {
+    /// World hosting is disabled (max_hosted_arenas == 0 or no API URL configured).
+    Disabled,
+    /// The server has reached its maximum number of hosted arenas.
+    LimitReached,
+    /// The world could not be found (HTTP 404).
+    WorldNotFound,
+    /// An HTTP or network error occurred while fetching the world.
+    FetchFailed(String),
+    /// The world JSON could not be parsed.
+    InvalidJson(String),
+    /// The world document failed to instantiate into a physics arena.
+    InstantiationFailed(WorldDocumentError),
+}
+
+impl WorldHostError {
+    /// Numeric error code sent in the PKT_ERROR packet.
+    pub fn error_code(&self) -> u16 {
+        match self {
+            WorldHostError::Disabled => 1,
+            WorldHostError::LimitReached => 2,
+            WorldHostError::WorldNotFound => 3,
+            WorldHostError::FetchFailed(_) => 4,
+            WorldHostError::InstantiationFailed(_) => 5,
+            WorldHostError::InvalidJson(_) => 4,
+        }
+    }
+}
+
+impl fmt::Display for WorldHostError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WorldHostError::Disabled => write!(f, "World hosting is not enabled on this server"),
+            WorldHostError::LimitReached => {
+                write!(f, "Server is at capacity, try again later")
+            }
+            WorldHostError::WorldNotFound => write!(f, "World not found"),
+            WorldHostError::FetchFailed(msg) => write!(f, "Could not load world: {msg}"),
+            WorldHostError::InvalidJson(msg) => write!(f, "World data is corrupted: {msg}"),
+            WorldHostError::InstantiationFailed(err) => {
+                write!(f, "World instantiation failed: {err}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WorldHostError {}
+
+// ---------------------------------------------------------------------------
+// WorldCache
+// ---------------------------------------------------------------------------
+
+pub struct CachedWorld {
+    pub document: Arc<WorldDocument>,
+    /// Number of active arenas currently using this world.
+    pub arena_count: usize,
+    /// When `arena_count` hit zero.  `None` while arenas are active.
+    pub last_arena_dropped: Option<Instant>,
+}
+
+pub struct WorldCache {
+    pub worlds: HashMap<String, CachedWorld>,
+    http_client: reqwest::Client,
+    worlds_api_url: String,
+}
+
+impl WorldCache {
+    pub fn new(worlds_api_url: String) -> Self {
+        Self {
+            worlds: HashMap::new(),
+            http_client: reqwest::Client::new(),
+            worlds_api_url,
+        }
+    }
+
+    /// Total number of arenas across all cached worlds.
+    pub fn total_arena_count(&self) -> usize {
+        self.worlds.values().map(|cw| cw.arena_count).sum()
+    }
+}
+
+/// Fetch (or return cached) a `WorldDocument` by world_id.
+///
+/// Increments the cached entry's `arena_count` on success so the caller
+/// must call `release_arena` when the arena shuts down.
+pub async fn fetch_world_document(
+    cache: &AsyncRwLock<WorldCache>,
+    world_id: &str,
+    max_hosted_arenas: usize,
+) -> Result<(Arc<WorldDocument>, String), WorldHostError> {
+    // Fast path: cache hit under read lock.
+    {
+        let mut cache_w = cache.write().await;
+        if let Some(entry) = cache_w.worlds.get_mut(world_id) {
+            entry.arena_count += 1;
+            entry.last_arena_dropped = None;
+            let doc = Arc::clone(&entry.document);
+            let name = doc.meta.name.clone();
+            return Ok((doc, name));
+        }
+
+        // Check capacity before fetching.
+        if cache_w.total_arena_count() >= max_hosted_arenas {
+            return Err(WorldHostError::LimitReached);
+        }
+    }
+
+    // Cache miss — fetch from the worlds API.
+    let cache_r = cache.read().await;
+    // World IDs are UUIDs (URL-safe characters only) so no encoding needed.
+    let url = format!(
+        "{}/api/worlds/{}",
+        cache_r.worlds_api_url.trim_end_matches('/'),
+        world_id,
+    );
+    let client = cache_r.http_client.clone();
+    drop(cache_r);
+
+    info!(%world_id, %url, "fetching world document from API");
+
+    let response = client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await
+        .map_err(|e| WorldHostError::FetchFailed(e.to_string()))?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(WorldHostError::WorldNotFound);
+    }
+    if !response.status().is_success() {
+        return Err(WorldHostError::FetchFailed(format!(
+            "HTTP {}",
+            response.status()
+        )));
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| WorldHostError::FetchFailed(e.to_string()))?;
+
+    let document: WorldDocument =
+        serde_json::from_str(&body).map_err(|e| WorldHostError::InvalidJson(e.to_string()))?;
+
+    let world_name = document.meta.name.clone();
+    let doc = Arc::new(document);
+
+    // Insert into cache under write lock (double-check for races).
+    let mut cache_w = cache.write().await;
+    if let Some(entry) = cache_w.worlds.get_mut(world_id) {
+        // Another task inserted it while we were fetching.
+        entry.arena_count += 1;
+        entry.last_arena_dropped = None;
+        return Ok((Arc::clone(&entry.document), entry.document.meta.name.clone()));
+    }
+
+    // Re-check capacity after the fetch (another arena may have been created).
+    if cache_w.total_arena_count() >= max_hosted_arenas {
+        return Err(WorldHostError::LimitReached);
+    }
+
+    cache_w.worlds.insert(
+        world_id.to_string(),
+        CachedWorld {
+            document: Arc::clone(&doc),
+            arena_count: 1,
+            last_arena_dropped: None,
+        },
+    );
+
+    info!(%world_id, %world_name, "cached world document");
+    Ok((doc, world_name))
+}
+
+/// Decrement the arena count for a world after an arena shuts down.
+///
+/// If the count reaches zero, records the drop time so the background
+/// janitor can evict the document after a grace period.
+pub async fn release_arena(cache: &AsyncRwLock<WorldCache>, world_id: &str) {
+    let mut cache_w = cache.write().await;
+    if let Some(entry) = cache_w.worlds.get_mut(world_id) {
+        entry.arena_count = entry.arena_count.saturating_sub(1);
+        if entry.arena_count == 0 {
+            entry.last_arena_dropped = Some(Instant::now());
+            info!(%world_id, "world arena count reached 0, starting eviction timer");
+        }
+    }
+}
+
+/// Background task that periodically evicts cached worlds that have had
+/// no active arenas for longer than the grace period.
+pub async fn run_cache_janitor(cache: Arc<AsyncRwLock<WorldCache>>, grace_period_secs: u64) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
+    let grace = std::time::Duration::from_secs(grace_period_secs);
+    loop {
+        interval.tick().await;
+        let mut cache_w = cache.write().await;
+        cache_w.worlds.retain(|world_id, entry| {
+            if entry.arena_count == 0 {
+                if let Some(dropped_at) = entry.last_arena_dropped {
+                    if dropped_at.elapsed() > grace {
+                        info!(%world_id, "evicting cached world document (no arenas for {}s)", grace_period_secs);
+                        return false;
+                    }
+                }
+            }
+            true
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_match_key() {
+        let key = parse_match_key("default");
+        assert!(matches!(key, MatchKey::Default { arena_id } if arena_id == "default"));
+        assert_eq!(key.composite_key(), "default");
+        assert!(key.world_id().is_none());
+    }
+
+    #[test]
+    fn parse_hosted_match_key() {
+        let key = parse_match_key("abc-123:main");
+        match &key {
+            MatchKey::Hosted { world_id, arena_id } => {
+                assert_eq!(world_id, "abc-123");
+                assert_eq!(arena_id, "main");
+            }
+            _ => panic!("expected Hosted"),
+        }
+        assert_eq!(key.composite_key(), "abc-123:main");
+        assert_eq!(key.world_id(), Some("abc-123"));
+    }
+
+    #[test]
+    fn parse_hosted_with_multiple_colons() {
+        let key = parse_match_key("world:arena:extra");
+        match &key {
+            MatchKey::Hosted { world_id, arena_id } => {
+                assert_eq!(world_id, "world");
+                assert_eq!(arena_id, "arena:extra");
+            }
+            _ => panic!("expected Hosted"),
+        }
+    }
+
+    #[test]
+    fn parse_empty_parts_treated_as_default() {
+        // ":foo" has empty world_id
+        let key = parse_match_key(":foo");
+        assert!(matches!(key, MatchKey::Default { .. }));
+
+        // "foo:" has empty arena_id
+        let key = parse_match_key("foo:");
+        assert!(matches!(key, MatchKey::Default { .. }));
+    }
+
+    #[test]
+    fn parse_empty_string() {
+        let key = parse_match_key("");
+        assert!(matches!(key, MatchKey::Default { arena_id } if arena_id.is_empty()));
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements a complete world hosting system that allows players to join published worlds through a new multiplayer experience. The system includes world document caching, arena management, and an active worlds endpoint for discovering existing arenas.

## Key Changes

### Server-side (`server/src/`)
- **New `world_cache.rs` module**: Implements world document caching with:
  - `MatchKey` enum to parse compound match IDs (`world_id:arena_id` format)
  - `WorldCache` for storing and managing cached world documents
  - `fetch_world_document()` to fetch worlds from an API with capacity limits
  - `release_arena()` to decrement arena counts when matches close
  - `run_cache_janitor()` background task to evict idle cached worlds after a grace period
  - `WorldHostError` enum with error codes for protocol-level error reporting

- **Updated `main.rs`**:
  - Integrated world caching into `AppState` with `max_hosted_arenas` configuration
  - Modified `MatchHandle` to track world metadata (world_id, world_name, arena_id, player_count)
  - Updated `get_or_create_match()` to resolve world documents and handle hosting errors
  - Modified `run_match_loop()` to instantiate hosted worlds or default world based on document
  - Added `/active-worlds` HTTP endpoint to expose active arenas and player counts
  - Enhanced connection handlers to send world host errors to clients on failure

- **Updated `protocol.rs`**:
  - Added `PKT_ERROR` constant (120) for world hosting errors
  - Added `encode_world_host_error()` function to encode error packets with code and message

### Client-side (`client/src/`)
- **New `HostedWorldPage.tsx`**: 
  - Resolves arena IDs by querying `/active-worlds` endpoint
  - Joins existing arenas with most players or creates new "main" arena
  - Displays loading state and error handling

- **Updated `Gallery.tsx`**:
  - Fetches active worlds data to show online player counts
  - Displays "online" badge with player count on world cards
  - Added arena dropdown for worlds with multiple active arenas
  - Split play action into "Play Online" and "Play Solo" options

- **Updated `routes.ts`**:
  - Added `hostedWorld` route kind with worldId and optional arenaId

- **Updated `protocol.ts`**:
  - Added `ServerErrorPacket` type for error handling
  - Updated packet union types to include error packets

- **Updated `App.tsx`, `GameScene.tsx`, `GameWorld.tsx`**:
  - Added optional `matchId` prop to override match ID for hosted worlds

- **Updated `netcodeClient.ts`**:
  - Added error packet handler to log server errors

- **Updated `sharedConstants.ts`**:
  - Exported `PKT_ERROR` constant

## Notable Implementation Details

- **Capacity management**: Server enforces `max_hosted_arenas` limit with double-check pattern during concurrent fetches
- **Graceful degradation**: Client falls back to "main" arena if `/active-worlds` endpoint is unavailable
- **Arena lifecycle**: Player count tracked atomically per arena; worlds evicted after 60-second grace period with no active arenas
- **Error propagation**: World hosting errors sent as protocol packets with numeric codes and human-readable messages
- **Configuration**: World hosting controlled via `VIBE_MAX_HOSTED_ARENAS` and `WORLDS_API_URL` environment variables

https://claude.ai/code/session_01UbmLuwea87aLmiYTCy3cmF