### PR TITLE
Migrate chat storage from localStorage to IndexedDB with multi-chat support

### DIFF
--- a/client/src/ai/chatStore.ts
+++ b/client/src/ai/chatStore.ts
@@ -1,17 +1,150 @@
-import type { ChatMessage, ChatPart, ChatRole, ChatUsage } from './chatTypes';
-
-const CHAT_STORAGE_KEY = 'vibe-land:godmode-ai-chat:v1';
-const CHAT_COMPOSER_DRAFT_KEY = 'vibe-land:godmode-ai-chat-draft:v1';
+import { makeChatId, type ChatMessage, type ChatPart, type ChatRole, type ChatTextPart, type ChatUsage } from './chatTypes';
 
 export type PersistedChatState = {
   messages: ChatMessage[];
   pendingHumanEdits: string[];
 };
 
-function safeStorage(): Storage | null {
-  if (typeof window === 'undefined') {
-    return null;
+export type ChatMeta = {
+  id: string;
+  createdAt: number;
+  updatedAt: number;
+  preview: string;
+  messageCount: number;
+};
+
+type StoredChat = {
+  id: string;
+  createdAt: number;
+  messages: ChatMessage[];
+  pendingHumanEdits: string[];
+};
+
+const DB_NAME = 'vibe-land-godmode-chats';
+const DB_VERSION = 1;
+const STORE_CHATS = 'chats';
+const STORE_META = 'chatMeta';
+const STORE_DRAFTS = 'drafts';
+const STORE_SETTINGS = 'settings';
+
+const ACTIVE_CHAT_SETTING_KEY = 'activeChatId';
+const LEGACY_MIGRATION_FLAG = 'legacyChatMigrated';
+
+const LEGACY_CHAT_KEY = 'vibe-land:godmode-ai-chat:v1';
+const LEGACY_DRAFT_KEY = 'vibe-land:godmode-ai-chat-draft:v1';
+
+const PREVIEW_MAX_LENGTH = 120;
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+let migrationPromise: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function openChatDatabase(): Promise<IDBDatabase | null> {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve) => {
+      if (typeof window === 'undefined' || !('indexedDB' in window)) {
+        resolve(null);
+        return;
+      }
+      const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE_CHATS)) db.createObjectStore(STORE_CHATS);
+        if (!db.objectStoreNames.contains(STORE_META)) db.createObjectStore(STORE_META);
+        if (!db.objectStoreNames.contains(STORE_DRAFTS)) db.createObjectStore(STORE_DRAFTS);
+        if (!db.objectStoreNames.contains(STORE_SETTINGS)) db.createObjectStore(STORE_SETTINGS);
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => {
+        console.warn('Failed to open Godmode chat IndexedDB', request.error);
+        resolve(null);
+      };
+    });
   }
+  return dbPromise;
+}
+
+async function idbGet<T>(storeName: string, key: IDBValidKey): Promise<T | null> {
+  const db = await openChatDatabase();
+  if (!db) return null;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(storeName, 'readonly');
+      const req = tx.objectStore(storeName).get(key);
+      req.onsuccess = () => resolve((req.result as T | undefined) ?? null);
+      req.onerror = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+async function idbPut(storeName: string, key: IDBValidKey, value: unknown): Promise<void> {
+  const db = await openChatDatabase();
+  if (!db) return;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(storeName, 'readwrite');
+      tx.objectStore(storeName).put(value, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+      tx.onabort = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+async function idbDelete(storeName: string, key: IDBValidKey): Promise<void> {
+  const db = await openChatDatabase();
+  if (!db) return;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(storeName, 'readwrite');
+      tx.objectStore(storeName).delete(key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+      tx.onabort = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+async function idbGetAll<T>(storeName: string): Promise<T[]> {
+  const db = await openChatDatabase();
+  if (!db) return [];
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(storeName, 'readonly');
+      const req = tx.objectStore(storeName).getAll();
+      req.onsuccess = () => resolve((req.result as T[]) ?? []);
+      req.onerror = () => resolve([]);
+    } catch {
+      resolve([]);
+    }
+  });
+}
+
+export function subscribeToChats(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function emitChatsChanged(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // ignore listener errors
+    }
+  }
+}
+
+function safeLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
   try {
     return window.localStorage;
   } catch {
@@ -19,112 +152,218 @@ function safeStorage(): Storage | null {
   }
 }
 
-export function loadPersistedChatState(): PersistedChatState {
-  const storage = safeStorage();
-  if (!storage) {
-    return { messages: [], pendingHumanEdits: [] };
-  }
+function readLegacyChatState(): PersistedChatState | null {
+  const storage = safeLocalStorage();
+  if (!storage) return null;
+  let raw: string | null;
   try {
-    const raw = storage.getItem(CHAT_STORAGE_KEY);
-    if (!raw) {
-      return { messages: [], pendingHumanEdits: [] };
-    }
+    raw = storage.getItem(LEGACY_CHAT_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
     const parsed = JSON.parse(raw) as Partial<PersistedChatState> | null;
-    if (!parsed || typeof parsed !== 'object') {
-      return { messages: [], pendingHumanEdits: [] };
-    }
+    if (!parsed || typeof parsed !== 'object') return null;
     return {
       messages: normalizeMessages(parsed.messages),
       pendingHumanEdits: normalizePendingHumanEdits(parsed.pendingHumanEdits),
     };
   } catch {
-    return { messages: [], pendingHumanEdits: [] };
+    return null;
   }
 }
 
-export function savePersistedChatState(state: PersistedChatState): void {
-  const storage = safeStorage();
-  if (!storage) {
-    return;
-  }
+function readLegacyComposerDraft(): string {
+  const storage = safeLocalStorage();
+  if (!storage) return '';
   try {
-    storage.setItem(CHAT_STORAGE_KEY, JSON.stringify(state));
-  } catch {
-    // Ignore quota/privacy errors — chat just won't persist.
-  }
-}
-
-export function clearPersistedChatState(): void {
-  const storage = safeStorage();
-  if (!storage) {
-    return;
-  }
-  try {
-    storage.removeItem(CHAT_STORAGE_KEY);
-  } catch {
-    // Ignore storage errors.
-  }
-}
-
-export function loadPersistedComposerDraft(): string {
-  const storage = safeStorage();
-  if (!storage) {
-    return '';
-  }
-  try {
-    const raw = storage.getItem(CHAT_COMPOSER_DRAFT_KEY);
+    const raw = storage.getItem(LEGACY_DRAFT_KEY);
     return typeof raw === 'string' ? raw : '';
   } catch {
     return '';
   }
 }
 
-export function savePersistedComposerDraft(draft: string): void {
-  const storage = safeStorage();
-  if (!storage) {
-    return;
-  }
+function clearLegacyChat(): void {
+  const storage = safeLocalStorage();
+  if (!storage) return;
   try {
-    if (draft.length === 0) {
-      storage.removeItem(CHAT_COMPOSER_DRAFT_KEY);
-      return;
-    }
-    storage.setItem(CHAT_COMPOSER_DRAFT_KEY, draft);
+    storage.removeItem(LEGACY_CHAT_KEY);
+    storage.removeItem(LEGACY_DRAFT_KEY);
   } catch {
-    // Ignore quota/privacy errors — draft just won't persist.
+    // ignore
   }
 }
 
-export function clearPersistedComposerDraft(): void {
-  const storage = safeStorage();
-  if (!storage) {
+async function ensureLegacyMigration(): Promise<void> {
+  if (!migrationPromise) {
+    migrationPromise = (async () => {
+      const alreadyMigrated = await idbGet<boolean>(STORE_SETTINGS, LEGACY_MIGRATION_FLAG);
+      if (alreadyMigrated) return;
+      const legacy = readLegacyChatState();
+      if (legacy && legacy.messages.length > 0) {
+        const id = makeChatId();
+        const now = Date.now();
+        const stored: StoredChat = {
+          id,
+          createdAt: now,
+          messages: legacy.messages,
+          pendingHumanEdits: legacy.pendingHumanEdits,
+        };
+        await idbPut(STORE_CHATS, id, stored);
+        await idbPut(STORE_META, id, computeMeta(stored));
+        await idbPut(STORE_SETTINGS, ACTIVE_CHAT_SETTING_KEY, id);
+        const draft = readLegacyComposerDraft();
+        if (draft) {
+          await idbPut(STORE_DRAFTS, id, draft);
+        }
+      }
+      await idbPut(STORE_SETTINGS, LEGACY_MIGRATION_FLAG, true);
+      clearLegacyChat();
+    })();
+  }
+  return migrationPromise;
+}
+
+function computePreview(messages: ChatMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    const text = msg.parts
+      .filter((p): p is ChatTextPart => p.type === 'text')
+      .map((p) => p.text)
+      .join(' ')
+      .trim();
+    if (text.length > 0) {
+      return text.length > PREVIEW_MAX_LENGTH ? `${text.slice(0, PREVIEW_MAX_LENGTH)}…` : text;
+    }
+  }
+  return '';
+}
+
+function computeMeta(stored: StoredChat): ChatMeta {
+  const updatedAt = stored.messages.length > 0
+    ? Math.max(...stored.messages.map((m) => m.createdAt))
+    : stored.createdAt;
+  return {
+    id: stored.id,
+    createdAt: stored.createdAt,
+    updatedAt,
+    preview: computePreview(stored.messages),
+    messageCount: stored.messages.length,
+  };
+}
+
+export async function listChatMeta(): Promise<ChatMeta[]> {
+  await ensureLegacyMigration();
+  const items = await idbGetAll<unknown>(STORE_META);
+  const metas: ChatMeta[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const candidate = item as Record<string, unknown>;
+    if (typeof candidate.id !== 'string') continue;
+    const createdAt = typeof candidate.createdAt === 'number' ? candidate.createdAt : 0;
+    const updatedAt = typeof candidate.updatedAt === 'number' ? candidate.updatedAt : createdAt;
+    const messageCount = typeof candidate.messageCount === 'number' ? candidate.messageCount : 0;
+    if (messageCount === 0) continue;
+    metas.push({
+      id: candidate.id,
+      createdAt,
+      updatedAt,
+      preview: typeof candidate.preview === 'string' ? candidate.preview : '',
+      messageCount,
+    });
+  }
+  metas.sort((a, b) => b.updatedAt - a.updatedAt);
+  return metas;
+}
+
+export async function loadChat(id: string): Promise<PersistedChatState> {
+  await ensureLegacyMigration();
+  const stored = await idbGet<unknown>(STORE_CHATS, id);
+  if (!stored || typeof stored !== 'object') {
+    return { messages: [], pendingHumanEdits: [] };
+  }
+  const candidate = stored as Partial<StoredChat>;
+  return {
+    messages: normalizeMessages(candidate.messages),
+    pendingHumanEdits: normalizePendingHumanEdits(candidate.pendingHumanEdits),
+  };
+}
+
+export async function saveChat(id: string, state: PersistedChatState): Promise<void> {
+  await ensureLegacyMigration();
+  if (state.messages.length === 0 && state.pendingHumanEdits.length === 0) {
+    // Don't materialize an empty chat in the list. If a chat existed before
+    // and is now empty, leave its prior data alone (caller can deleteChat).
     return;
   }
-  try {
-    storage.removeItem(CHAT_COMPOSER_DRAFT_KEY);
-  } catch {
-    // Ignore storage errors.
+  const existing = (await idbGet<StoredChat>(STORE_CHATS, id)) as StoredChat | null;
+  const createdAt = existing?.createdAt ?? Date.now();
+  const stored: StoredChat = {
+    id,
+    createdAt,
+    messages: state.messages,
+    pendingHumanEdits: state.pendingHumanEdits,
+  };
+  await idbPut(STORE_CHATS, id, stored);
+  await idbPut(STORE_META, id, computeMeta(stored));
+  emitChatsChanged();
+}
+
+export async function deleteChat(id: string): Promise<void> {
+  await ensureLegacyMigration();
+  await Promise.all([
+    idbDelete(STORE_CHATS, id),
+    idbDelete(STORE_META, id),
+    idbDelete(STORE_DRAFTS, id),
+  ]);
+  emitChatsChanged();
+}
+
+export async function loadActiveChatId(): Promise<string | null> {
+  await ensureLegacyMigration();
+  const value = await idbGet<unknown>(STORE_SETTINGS, ACTIVE_CHAT_SETTING_KEY);
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export async function saveActiveChatId(id: string): Promise<void> {
+  await ensureLegacyMigration();
+  await idbPut(STORE_SETTINGS, ACTIVE_CHAT_SETTING_KEY, id);
+}
+
+export async function loadComposerDraft(chatId: string): Promise<string> {
+  await ensureLegacyMigration();
+  const value = await idbGet<unknown>(STORE_DRAFTS, chatId);
+  return typeof value === 'string' ? value : '';
+}
+
+export async function saveComposerDraft(chatId: string, draft: string): Promise<void> {
+  await ensureLegacyMigration();
+  if (draft.length === 0) {
+    await idbDelete(STORE_DRAFTS, chatId);
+    return;
   }
+  await idbPut(STORE_DRAFTS, chatId, draft);
+}
+
+export async function clearComposerDraft(chatId: string): Promise<void> {
+  await ensureLegacyMigration();
+  await idbDelete(STORE_DRAFTS, chatId);
 }
 
 function normalizeMessages(value: unknown): ChatMessage[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
+  if (!Array.isArray(value)) return [];
   const messages: ChatMessage[] = [];
   for (const item of value) {
     const normalized = normalizeMessage(item);
-    if (normalized) {
-      messages.push(normalized);
-    }
+    if (normalized) messages.push(normalized);
   }
   return messages;
 }
 
 function normalizeMessage(value: unknown): ChatMessage | null {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
+  if (!value || typeof value !== 'object') return null;
   const candidate = value as Record<string, unknown>;
   const role = normalizeRole(candidate.role);
   const id = typeof candidate.id === 'string' ? candidate.id : null;
@@ -132,17 +371,13 @@ function normalizeMessage(value: unknown): ChatMessage | null {
     ? candidate.createdAt
     : null;
   const parts = normalizeParts(candidate.parts);
-  if (!role || !id || createdAt === null || !parts) {
-    return null;
-  }
+  if (!role || !id || createdAt === null || !parts) return null;
   const message: ChatMessage = { id, role, createdAt, parts };
   if (typeof candidate.hiddenContext === 'string' && candidate.hiddenContext.length > 0) {
     message.hiddenContext = candidate.hiddenContext;
   }
   const usage = normalizeUsage(candidate.usage);
-  if (usage) {
-    message.usage = usage;
-  }
+  if (usage) message.usage = usage;
   return message;
 }
 
@@ -151,23 +386,17 @@ function normalizeRole(value: unknown): ChatRole | null {
 }
 
 function normalizeParts(value: unknown): ChatPart[] | null {
-  if (!Array.isArray(value)) {
-    return null;
-  }
+  if (!Array.isArray(value)) return null;
   const parts: ChatPart[] = [];
   for (const item of value) {
     const normalized = normalizePart(item);
-    if (normalized) {
-      parts.push(normalized);
-    }
+    if (normalized) parts.push(normalized);
   }
   return parts;
 }
 
 function normalizePart(value: unknown): ChatPart | null {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
+  if (!value || typeof value !== 'object') return null;
   const candidate = value as Record<string, unknown>;
   switch (candidate.type) {
     case 'text':
@@ -207,9 +436,7 @@ function normalizePart(value: unknown): ChatPart | null {
 }
 
 function normalizeUsage(value: unknown): ChatUsage | null {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
+  if (!value || typeof value !== 'object') return null;
   const candidate = value as Record<string, unknown>;
   return typeof candidate.inputTokens === 'number'
     && Number.isFinite(candidate.inputTokens)
@@ -223,8 +450,6 @@ function normalizeUsage(value: unknown): ChatUsage | null {
 }
 
 function normalizePendingHumanEdits(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
+  if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
 }

--- a/client/src/ai/useGodModeChat.ts
+++ b/client/src/ai/useGodModeChat.ts
@@ -7,11 +7,7 @@ import {
   type ChatImagePart,
   type ChatPart,
 } from './chatTypes';
-import {
-  clearPersistedChatState,
-  loadPersistedChatState,
-  savePersistedChatState,
-} from './chatStore';
+import { loadChat, saveChat } from './chatStore';
 import { createLanguageModel, getThinkingProviderOptions, type ProviderId } from './providers';
 import { SYSTEM_PROMPT } from './systemPrompt';
 import { createExecuteJsTool, createRollbackTool } from './worldTool';
@@ -20,6 +16,7 @@ import type { WorldAccessors } from './worldToolHelpers';
 export type ChatStatus = 'idle' | 'streaming' | 'error';
 
 export type GodModeChatOptions = {
+  chatId: string;
   accessors: WorldAccessors;
   provider: ProviderId;
   model: string;
@@ -36,20 +33,22 @@ export type GodModeChatHandle = {
   canSend: boolean;
   sendMessage(text: string, attachments?: ImageAttachment[]): Promise<void>;
   stop(): void;
-  clear(): void;
   pushHumanEdit(summary: string): void;
 };
 
 const MAX_TOOL_STEPS = 12;
 
 export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
-  const { accessors, provider, model, apiKey } = options;
-  const initialPersistedState = useMemo(() => loadPersistedChatState(), []);
+  const { chatId, accessors, provider, model, apiKey } = options;
 
-  const [messages, setMessages] = useState<ChatMessage[]>(() => initialPersistedState.messages);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [pendingHumanEdits, setPendingHumanEdits] = useState<string[]>([]);
   const [status, setStatus] = useState<ChatStatus>('idle');
   const [error, setError] = useState<Error | null>(null);
-  const [pendingHumanEdits, setPendingHumanEdits] = useState<string[]>(() => initialPersistedState.pendingHumanEdits);
+  // Chat is "loaded" when the persisted state for the active chatId has been
+  // hydrated into local state. We gate sends/saves on this so that switching
+  // chats doesn't briefly overwrite the destination chat with empty data.
+  const [loadedChatId, setLoadedChatId] = useState<string | null>(null);
 
   const accessorsRef = useRef(accessors);
   useEffect(() => {
@@ -77,20 +76,39 @@ export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
     setPendingHumanEdits((prev) => [...prev, summary]);
   }, []);
 
-  const clear = useCallback(() => {
-    stop();
-    setMessages([]);
-    setError(null);
-    setPendingHumanEdits([]);
-    setStatus('idle');
-    clearPersistedChatState();
-  }, [stop]);
-
+  // When chatId changes, abort any in-flight stream and (re)hydrate state
+  // from storage. Race-protected via a cancellation flag.
   useEffect(() => {
-    savePersistedChatState({ messages, pendingHumanEdits });
-  }, [messages, pendingHumanEdits]);
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    setStatus('idle');
+    setError(null);
+    setMessages([]);
+    setPendingHumanEdits([]);
+    setLoadedChatId(null);
+    let cancelled = false;
+    void loadChat(chatId).then((state) => {
+      if (cancelled) return;
+      setMessages(state.messages);
+      setPendingHumanEdits(state.pendingHumanEdits);
+      setLoadedChatId(chatId);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [chatId]);
 
-  const canSend = Boolean(apiKey) && status === 'idle';
+  // Persist whenever local state changes — but only after the chat has been
+  // loaded for the current chatId, to avoid clobbering it during the swap.
+  useEffect(() => {
+    if (loadedChatId !== chatId) return;
+    void saveChat(chatId, { messages, pendingHumanEdits });
+  }, [chatId, loadedChatId, messages, pendingHumanEdits]);
+
+  const isLoaded = loadedChatId === chatId;
+  const canSend = Boolean(apiKey) && status === 'idle' && isLoaded;
 
   const sendMessage = useCallback(
     async (text: string, attachments?: ImageAttachment[]) => {
@@ -102,6 +120,7 @@ export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
         return;
       }
       if (status === 'streaming') return;
+      if (!isLoaded) return;
 
       // Snapshot pending human edits and clear them up-front so concurrent
       // edits while we wait for the model start a fresh buffer.
@@ -318,7 +337,7 @@ export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
         }
       }
     },
-    [apiKey, messages, model, pendingHumanEdits, provider, status],
+    [apiKey, isLoaded, messages, model, pendingHumanEdits, provider, status],
   );
 
   return useMemo<GodModeChatHandle>(
@@ -330,10 +349,9 @@ export function useGodModeChat(options: GodModeChatOptions): GodModeChatHandle {
       canSend,
       sendMessage,
       stop,
-      clear,
       pushHumanEdit,
     }),
-    [canSend, clear, error, messages, pendingHumanEdits.length, pushHumanEdit, sendMessage, status, stop],
+    [canSend, error, messages, pendingHumanEdits.length, pushHumanEdit, sendMessage, status, stop],
   );
 }
 

--- a/client/src/pages/godmode/AiChatPanel.tsx
+++ b/client/src/pages/godmode/AiChatPanel.tsx
@@ -11,9 +11,11 @@ import {
   type FormEvent,
   type ClipboardEvent as ReactClipboardEvent,
   type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
 } from 'react';
 import { forwardRef } from 'react';
 import type { ChatImagePart, ChatMessage, ChatPart } from '../../ai/chatTypes';
+import { makeChatId } from '../../ai/chatTypes';
 import {
   MODELS,
   PROVIDER_LABELS,
@@ -22,9 +24,15 @@ import {
   type ProviderId,
 } from '../../ai/providers';
 import {
-  clearPersistedComposerDraft,
-  loadPersistedComposerDraft,
-  savePersistedComposerDraft,
+  clearComposerDraft,
+  deleteChat,
+  listChatMeta,
+  loadActiveChatId,
+  loadComposerDraft,
+  saveActiveChatId,
+  saveComposerDraft,
+  subscribeToChats,
+  type ChatMeta,
 } from '../../ai/chatStore';
 import {
   clearStoredApiKeys,
@@ -50,7 +58,14 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
   const [settings, setSettings] = useState<AiChatSettings>(() => loadSettings());
   const apiKey = settings.apiKeys[settings.provider];
 
+  // Active chat id. Seeded with a fresh id so the hook can mount synchronously
+  // while we asynchronously restore the previous active id from IndexedDB.
+  const [chatId, setChatId] = useState<string>(() => makeChatId());
+  const [chatList, setChatList] = useState<ChatMeta[]>([]);
+  const [restored, setRestored] = useState(false);
+
   const chat = useGodModeChat({
+    chatId,
     accessors,
     provider: settings.provider,
     model: settings.model,
@@ -65,6 +80,42 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
     }),
     [chat],
   );
+
+  // Restore the previous active chat id once on mount.
+  useEffect(() => {
+    let cancelled = false;
+    void loadActiveChatId().then((existing) => {
+      if (cancelled) return;
+      if (existing) setChatId(existing);
+      setRestored(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist active chat id whenever it changes (after initial restore).
+  useEffect(() => {
+    if (!restored) return;
+    void saveActiveChatId(chatId);
+  }, [chatId, restored]);
+
+  // Subscribe to the chat metadata list so the sidebar stays in sync.
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = () => {
+      void listChatMeta().then((items) => {
+        if (cancelled) return;
+        setChatList(items);
+      });
+    };
+    refresh();
+    const unsub = subscribeToChats(refresh);
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
 
   // Persist settings whenever they change.
   useEffect(() => {
@@ -102,12 +153,68 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
     setSettings((current) => ({ ...current, apiKeys: {} }));
   }, []);
 
-  const onClearChat = useCallback(() => {
+  const [draft, setDraft] = useState('');
+  const [settingsOpen, setSettingsOpen] = useState(!apiKey);
+  const [chatListOpen, setChatListOpen] = useState(true);
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Restore the composer draft for the active chat whenever it changes.
+  const draftChatIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    draftChatIdRef.current = null;
+    void loadComposerDraft(chatId).then((value) => {
+      if (cancelled) return;
+      setDraft(value);
+      draftChatIdRef.current = chatId;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [chatId]);
+
+  // Persist composer draft — gated on the draft belonging to the current chat
+  // to avoid overwriting it during a chat switch.
+  useEffect(() => {
+    if (draftChatIdRef.current !== chatId) return;
+    void saveComposerDraft(chatId, draft);
+  }, [chatId, draft]);
+
+  const onNewChat = useCallback(() => {
+    if (chat.status === 'streaming') chat.stop();
     setDraft('');
     setAttachments([]);
-    clearPersistedComposerDraft();
-    chat.clear();
+    const nextId = makeChatId();
+    setChatId(nextId);
   }, [chat]);
+
+  const onSelectChat = useCallback(
+    (id: string) => {
+      if (id === chatId) return;
+      if (chat.status === 'streaming') chat.stop();
+      setDraft('');
+      setAttachments([]);
+      setChatId(id);
+    },
+    [chat, chatId],
+  );
+
+  const onDeleteChat = useCallback(
+    (id: string, event: ReactMouseEvent) => {
+      event.stopPropagation();
+      void (async () => {
+        await deleteChat(id);
+        if (id === chatId) {
+          if (chat.status === 'streaming') chat.stop();
+          setDraft('');
+          setAttachments([]);
+          setChatId(makeChatId());
+        }
+      })();
+    },
+    [chat, chatId],
+  );
 
   const onPaste = useCallback((event: ReactClipboardEvent<HTMLTextAreaElement>) => {
     const items = Array.from(event.clipboardData.items);
@@ -143,15 +250,6 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
     }
   }, []);
 
-  const [draft, setDraft] = useState(() => loadPersistedComposerDraft());
-  const [settingsOpen, setSettingsOpen] = useState(!apiKey);
-  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    savePersistedComposerDraft(draft);
-  }, [draft]);
-
   const messageListRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = messageListRef.current;
@@ -160,18 +258,22 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
     }
   }, [chat.messages]);
 
+  const sendWithReset = useCallback(() => {
+    const text = draft;
+    const atts = attachments;
+    setDraft('');
+    void clearComposerDraft(chatId);
+    setAttachments([]);
+    void chat.sendMessage(text, atts.length > 0 ? atts : undefined);
+  }, [attachments, chat, chatId, draft]);
+
   const onSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       if (!chat.canSend) return;
-      const text = draft;
-      const atts = attachments;
-      setDraft('');
-      clearPersistedComposerDraft();
-      setAttachments([]);
-      void chat.sendMessage(text, atts.length > 0 ? atts : undefined);
+      sendWithReset();
     },
-    [attachments, chat, draft],
+    [chat.canSend, sendWithReset],
   );
 
   const onKeyDown = useCallback(
@@ -179,15 +281,10 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault();
         if (!chat.canSend) return;
-        const text = draft;
-        const atts = attachments;
-        setDraft('');
-        clearPersistedComposerDraft();
-        setAttachments([]);
-        void chat.sendMessage(text, atts.length > 0 ? atts : undefined);
+        sendWithReset();
       }
     },
-    [attachments, chat, draft],
+    [chat.canSend, sendWithReset],
   );
 
   const modelOptions = useMemo(() => MODELS[settings.provider], [settings.provider]);
@@ -199,11 +296,77 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
   return (
     <aside style={panelStyle}>
       <div style={headerStyle}>
-        <span style={eyebrowStyle}>AI Co-Editor</span>
-        <h2 style={titleStyle}>Chat</h2>
+        <div style={headerRowStyle}>
+          <div style={headerTitleGroupStyle}>
+            <span style={eyebrowStyle}>AI Co-Editor</span>
+            <h2 style={titleStyle}>Chat</h2>
+          </div>
+          <button type="button" onClick={onNewChat} style={newChatButtonStyle} title="Start a new chat">
+            + New chat
+          </button>
+        </div>
         <p style={mutedStyle}>
           Bring-your-own-key. Calls go straight to the provider from your browser — no proxy.
         </p>
+      </div>
+
+      <div style={sectionStyle}>
+        <div style={settingsHeaderStyle}>
+          <button
+            type="button"
+            onClick={() => setChatListOpen((v) => !v)}
+            style={ghostButtonStyle}
+          >
+            {chatListOpen ? '▾ History' : '▸ History'}
+          </button>
+          <span style={mutedStyle}>
+            {chatList.length === 0
+              ? 'No saved chats yet'
+              : `${chatList.length} chat${chatList.length === 1 ? '' : 's'}`}
+          </span>
+        </div>
+        {chatListOpen && (
+          <div style={chatListStyle}>
+            {chatList.length === 0 && (
+              <p style={mutedStyle}>Send a message to save this chat.</p>
+            )}
+            {chatList.map((meta) => {
+              const isActive = meta.id === chatId;
+              return (
+                <button
+                  key={meta.id}
+                  type="button"
+                  onClick={() => onSelectChat(meta.id)}
+                  style={isActive ? activeChatItemStyle : chatItemStyle}
+                  title={meta.preview || 'Empty chat'}
+                >
+                  <div style={chatItemHeaderStyle}>
+                    <span style={chatItemTimestampStyle}>{formatRelativeTime(meta.updatedAt)}</span>
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      aria-label="Delete chat"
+                      onClick={(e) => onDeleteChat(meta.id, e)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onDeleteChat(meta.id, e as unknown as ReactMouseEvent);
+                        }
+                      }}
+                      style={chatItemDeleteStyle}
+                      title="Delete chat"
+                    >
+                      ×
+                    </span>
+                  </div>
+                  <div style={chatItemPreviewStyle}>
+                    {meta.preview || <em style={chatItemEmptyStyle}>(no messages yet)</em>}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div style={sectionStyle}>
@@ -264,9 +427,6 @@ export const AiChatPanel = forwardRef(function AiChatPanel(
             <div style={buttonRowStyle}>
               <button type="button" onClick={onClearKeys} style={dangerButtonStyle}>
                 Clear all keys
-              </button>
-              <button type="button" onClick={onClearChat} style={secondaryButtonStyle}>
-                Clear chat
               </button>
             </div>
             <p style={mutedStyle}>
@@ -450,6 +610,21 @@ function jsonStringify(value: unknown): string {
   }
 }
 
+function formatRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  if (diff < 0) return 'just now';
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 45) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const date = new Date(timestamp);
+  return date.toLocaleDateString();
+}
+
 // ---------- styles (match GodMode.tsx palette) ----------
 
 const panelStyle: CSSProperties = {
@@ -468,6 +643,19 @@ const headerStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: 4,
+};
+
+const headerRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+  gap: 12,
+};
+
+const headerTitleGroupStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
 };
 
 const eyebrowStyle: CSSProperties = {
@@ -586,6 +774,81 @@ const disabledButtonStyle: CSSProperties = {
   background: 'rgba(20, 34, 48, 0.96)',
   color: 'rgba(238, 247, 255, 0.4)',
   cursor: 'not-allowed',
+};
+
+const newChatButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  background: '#86d6f5',
+  color: '#052233',
+  whiteSpace: 'nowrap',
+};
+
+const chatListStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  maxHeight: 220,
+  overflowY: 'auto',
+  paddingRight: 2,
+};
+
+const chatItemStyle: CSSProperties = {
+  textAlign: 'left',
+  background: 'rgba(8, 18, 28, 0.72)',
+  border: '1px solid rgba(141, 186, 221, 0.14)',
+  borderRadius: 10,
+  padding: '8px 10px',
+  color: '#eef7ff',
+  cursor: 'pointer',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  font: 'inherit',
+};
+
+const activeChatItemStyle: CSSProperties = {
+  ...chatItemStyle,
+  borderColor: 'rgba(116, 212, 255, 0.55)',
+  background: 'rgba(116, 212, 255, 0.12)',
+};
+
+const chatItemHeaderStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+};
+
+const chatItemTimestampStyle: CSSProperties = {
+  fontSize: 11,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: '#86d6f5',
+};
+
+const chatItemDeleteStyle: CSSProperties = {
+  fontSize: 14,
+  lineHeight: 1,
+  color: 'rgba(238, 247, 255, 0.5)',
+  cursor: 'pointer',
+  padding: '0 4px',
+  borderRadius: 4,
+  userSelect: 'none',
+};
+
+const chatItemPreviewStyle: CSSProperties = {
+  fontSize: 12,
+  lineHeight: 1.4,
+  color: 'rgba(238, 247, 255, 0.85)',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+  wordBreak: 'break-word',
+};
+
+const chatItemEmptyStyle: CSSProperties = {
+  color: 'rgba(238, 247, 255, 0.45)',
 };
 
 const messageListStyle: CSSProperties = {


### PR DESCRIPTION
## Summary

This PR migrates the chat storage system from localStorage to IndexedDB and adds support for managing multiple independent chats. Users can now create, switch between, and delete separate conversations, with each chat's state and composer draft persisted independently.

## Key Changes

- **Storage Migration**: Replaced localStorage-based persistence with IndexedDB for better capacity and structured data storage
  - Implements automatic migration of legacy localStorage data on first load
  - Creates four object stores: `chats`, `chatMeta`, `drafts`, and `settings`
  - Provides helper functions (`idbGet`, `idbPut`, `idbDelete`, `idbGetAll`) for safe IndexedDB operations

- **Multi-Chat Support**: 
  - Each chat now has a unique ID and can be independently created, loaded, and deleted
  - Added `listChatMeta()` to retrieve chat metadata (preview, timestamp, message count) for the sidebar
  - Implemented chat selection and switching with proper state cleanup
  - Added "New chat" button to start fresh conversations

- **Chat History UI**:
  - New collapsible "History" section in the sidebar showing all saved chats
  - Chat items display relative timestamps and message previews (truncated to 120 chars)
  - Delete button (×) on each chat item for removal
  - Active chat is visually highlighted
  - Empty state messaging when no chats exist

- **State Management**:
  - Active chat ID is persisted and restored on page reload
  - Composer drafts are now per-chat instead of global
  - Added `subscribeToChats()` listener pattern for reactive UI updates when chat list changes
  - Proper race condition handling during chat switches via cancellation flags

- **API Changes**:
  - Replaced `loadPersistedChatState()` / `savePersistedChatState()` with `loadChat(id)` / `saveChat(id, state)`
  - Replaced `loadPersistedComposerDraft()` / `savePersistedComposerDraft()` with per-chat versions: `loadComposerDraft(chatId)` / `saveComposerDraft(chatId, draft)`
  - Removed `clearPersistedChatState()` and `clearPersistedComposerDraft()` in favor of `deleteChat(id)` and `clearComposerDraft(chatId)`
  - Added `loadActiveChatId()` / `saveActiveChatId()` for persistence of the currently active chat

## Implementation Details

- **Legacy Migration**: On first load, any existing localStorage chat data is automatically migrated to IndexedDB under a new chat ID, preserving user data during the upgrade
- **Chat Metadata**: Computed on-the-fly from stored chat data (preview extracted from last non-empty message, updated timestamp from latest message)
- **Async Initialization**: Chat restoration and draft loading happen asynchronously after component mount to avoid blocking initial render
- **Error Resilience**: All IndexedDB operations gracefully degrade to null/empty values if the database is unavailable
- **Removed Functionality**: The "Clear chat" button has been removed in favor of the per-chat delete functionality in the history sidebar

https://claude.ai/code/session_01NGEAhouktDV6PqVHK4B57T