### PR TITLE
Add spacing tuning controls for practice bot crowd behavior

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,11 +40,13 @@ import {
   updateInputSettings,
 } from './input/inputSettingsStore';
 import {
+  DEFAULT_PRACTICE_BOT_SPACING_TUNING,
   MAX_PRACTICE_BOTS,
   PracticeBotRuntime,
   type PracticeBotBehaviorKind,
   type PracticeBotNavDebugConfig,
   type PracticeBotNavTuning,
+  type PracticeBotSpacingTuning,
   type PracticeBotStats,
 } from './bots';
 import { getSharedPlayerNavigationProfileAsync } from './wasm/sharedPhysics';
@@ -316,6 +318,13 @@ export function App({
     runtime.setUseVehicles(value);
     refreshPracticeBotStats();
   }, [refreshPracticeBotStats]);
+  const [practiceBotSpacingTuning, setPracticeBotSpacingTuning] = useState<PracticeBotSpacingTuning>(
+    DEFAULT_PRACTICE_BOT_SPACING_TUNING,
+  );
+  const handleSetSpacingTuning = useCallback((tuning: PracticeBotSpacingTuning) => {
+    setPracticeBotSpacingTuning(tuning);
+    practiceBotRuntimeRef.current?.setSpacingTuning(tuning);
+  }, []);
 
   useEffect(() => {
     if (!practiceMode) {
@@ -1026,6 +1035,7 @@ export function App({
         runtime={practiceBotRuntime}
         navConfig={practiceBotNavConfig}
         navTuning={practiceBotNavTuning}
+        spacingTuning={practiceBotSpacingTuning}
         debugOverlay={practiceBotDebugOverlay}
         debugLabels={practiceBotDebugLabels}
         onSetBotCount={handleSetBotCount}
@@ -1036,6 +1046,7 @@ export function App({
         onToggleDebugOverlay={handleToggleBotDebugOverlay}
         onToggleDebugLabels={handleToggleBotDebugLabels}
         onSetUseVehicles={handleSetBotUseVehicles}
+        onSetSpacingTuning={handleSetSpacingTuning}
       />
       <EnergyBar
         hp={displayStats.hp}

--- a/client/src/bots/agent/BotBrain.ts
+++ b/client/src/bots/agent/BotBrain.ts
@@ -11,6 +11,7 @@ export interface BotBrainOptions extends SteeringOptions {
   anchor?: Vec3Tuple;
   retargetDistanceSqM?: number;
   maxTicksBetweenReplans?: number;
+  botId?: number;
 }
 
 export class BotBrain {
@@ -19,6 +20,7 @@ export class BotBrain {
   private behavior: Behavior;
   private readonly steer: SteeringState;
   private readonly options: BotBrainOptions;
+  private readonly botId: number;
   private anchor: Vec3Tuple;
   private tick = 0;
   private lastTarget: Vec3Tuple | null = null;
@@ -36,6 +38,7 @@ export class BotBrain {
     this.handle = handle;
     this.behavior = behavior;
     this.options = options;
+    this.botId = options.botId ?? 0;
     this.steer = createSteeringState();
     const agent = crowd.getAgent(handle.id);
     this.anchor = options.anchor ?? (agent
@@ -66,6 +69,7 @@ export class BotBrain {
       remotePlayers,
       anchor: this.anchor,
       tick: this.tick,
+      botId: this.botId,
     };
     const decision = this.behavior(ctx);
     this.lastDecisionTarget = decision.target ? [...decision.target] : null;

--- a/client/src/bots/agent/behaviors.test.ts
+++ b/client/src/bots/agent/behaviors.test.ts
@@ -20,6 +20,7 @@ function makeContext(overrides: Partial<BotBehaviorContext> = {}): BotBehaviorCo
     }],
     anchor: [50, 1, -10],
     tick: 1,
+    botId: 0,
     ...overrides,
   };
 }
@@ -189,5 +190,71 @@ describe('harassNearest', () => {
     }));
     expect(decision.mode).toBe('hold_anchor');
     expect(decision.target).toEqual([50, 1, -10]);
+  });
+
+  describe('chase offset (chaseOffsetRadiusM)', () => {
+    it('bots with different ids choose different movement targets for the same player', () => {
+      const behavior1 = harassNearest({ acquireDistanceM: 40, chaseOffsetRadiusM: 1.25 });
+      const behavior2 = harassNearest({ acquireDistanceM: 40, chaseOffsetRadiusM: 1.25 });
+
+      const d1 = behavior1(makeContext({ botId: 1_000_001 }));
+      const d2 = behavior2(makeContext({ botId: 1_000_002 }));
+
+      expect(d1.mode).toBe('follow_target');
+      expect(d2.mode).toBe('follow_target');
+      // Targets differ because each bot gets a unique angle
+      expect(d1.target).not.toEqual(d2.target);
+    });
+
+    it('both targets remain within chaseOffsetRadiusM of the player center', () => {
+      const radius = 1.25;
+      const playerPos: [number, number, number] = [52, 1, -10];
+
+      for (const botId of [1_000_001, 1_000_002, 1_000_003]) {
+        const behavior = harassNearest({ acquireDistanceM: 40, chaseOffsetRadiusM: radius });
+        const d = behavior(makeContext({ botId }));
+        const dx = (d.target?.[0] ?? 0) - playerPos[0];
+        const dz = (d.target?.[2] ?? 0) - playerPos[2];
+        expect(Math.hypot(dx, dz)).toBeCloseTo(radius, 5);
+      }
+    });
+
+    it('fireAim always points at the real player position regardless of offset', () => {
+      const behavior = harassNearest({
+        acquireDistanceM: 40,
+        fireDistanceM: 18,
+        chaseOffsetRadiusM: 1.25,
+      });
+      const playerPos: [number, number, number] = [52, 1, -10];
+      const d = behavior(makeContext({ botId: 1_000_001 }));
+
+      expect(d.fireAim).toEqual(playerPos);
+      // movement target should differ from player center
+      expect(d.target).not.toEqual(playerPos);
+    });
+
+    it('falls back to the real player position inside melee range (no offset)', () => {
+      const behavior = harassNearest({
+        acquireDistanceM: 40,
+        meleeDistanceM: 2.0,
+        chaseOffsetRadiusM: 1.25,
+      });
+      const playerPos: [number, number, number] = [51.5, 1, -10];
+      const d = behavior(makeContext({
+        botId: 1_000_001,
+        self: { position: [50, 1, -10], velocity: [0, 0, 0], yaw: 0, pitch: 0, onGround: true, dead: false },
+        remotePlayers: [{ id: 7, position: playerPos, isDead: false }],
+      }));
+
+      expect(d.meleeAim).toEqual(playerPos);
+      expect(d.target).toEqual(playerPos);
+    });
+
+    it('zero chaseOffsetRadiusM targets the exact player center', () => {
+      const behavior = harassNearest({ acquireDistanceM: 40, chaseOffsetRadiusM: 0 });
+      const playerPos: [number, number, number] = [52, 1, -10];
+      const d = behavior(makeContext({ botId: 1_000_001 }));
+      expect(d.target).toEqual(playerPos);
+    });
   });
 });

--- a/client/src/bots/agent/behaviors.ts
+++ b/client/src/bots/agent/behaviors.ts
@@ -9,6 +9,7 @@ export interface BotBehaviorContext {
   remotePlayers: readonly ObservedPlayer[];
   anchor: Vec3Tuple;
   tick: number;
+  botId: number;
 }
 
 export interface BehaviorDecision {
@@ -63,6 +64,12 @@ export interface HarassNearestOptions {
   meleeDistanceM?: number;
   meleeAgainstVehicleDistanceM?: number;
   targetMemoryTicks?: number;
+  /**
+   * When > 0, the movement target is offset from the player center by this
+   * radius along a deterministic angle derived from (botId, targetPlayerId).
+   * fireAim / meleeAim always point at the real player position.
+   */
+  chaseOffsetRadiusM?: number;
 }
 
 export function harassNearest(options: HarassNearestOptions = {}): Behavior {
@@ -72,6 +79,7 @@ export function harassNearest(options: HarassNearestOptions = {}): Behavior {
   const meleeRange = options.meleeDistanceM ?? 2.0;
   const meleeVehicleRange = options.meleeAgainstVehicleDistanceM ?? 3.0;
   const targetMemoryTicks = options.targetMemoryTicks ?? 45;
+  const chaseOffsetRadiusM = options.chaseOffsetRadiusM ?? 0;
   const state = {
     lockedPlayerId: null as number | null,
     lastKnownTarget: null as Vec3Tuple | null,
@@ -107,12 +115,21 @@ export function harassNearest(options: HarassNearestOptions = {}): Behavior {
         nearest.player.position[2],
       ];
       state.lastSeenTick = ctx.tick;
+
+      // Offset the movement target so multiple bots don't all steer to the
+      // exact same player center. The angle is deterministic per (bot, target)
+      // pair so bots spread out predictably. Fire/melee aim always use the
+      // real position. Inside melee range no offset is applied so hits land.
+      let moveX = nearest.player.position[0];
+      let moveZ = nearest.player.position[2];
+      if (!inMelee && chaseOffsetRadiusM > 0) {
+        const angle = chaseAngle(ctx.botId, nearest.player.id);
+        moveX += Math.cos(angle) * chaseOffsetRadiusM;
+        moveZ += Math.sin(angle) * chaseOffsetRadiusM;
+      }
+
       return {
-        target: [
-          nearest.player.position[0],
-          nearest.player.position[1],
-          nearest.player.position[2],
-        ],
+        target: [moveX, nearest.player.position[1], moveZ],
         fireAim,
         meleeAim,
         targetPlayerId: nearest.player.id,
@@ -180,6 +197,12 @@ export function wander(options: WanderOptions = {}): Behavior {
       mode: 'hold_anchor',
     };
   };
+}
+
+/** Stable angle in [0, 2π) unique to each (botId, targetId) pair. */
+function chaseAngle(botId: number, targetId: number): number {
+  const hash = ((botId * 2654435761 + targetId * 1013904223) >>> 0);
+  return (hash / 4294967296) * Math.PI * 2;
 }
 
 function findNearest(

--- a/client/src/bots/crowd/BotCrowd.test.ts
+++ b/client/src/bots/crowd/BotCrowd.test.ts
@@ -127,4 +127,20 @@ describe('BotCrowd', () => {
     expect(handle.targetPosition?.[0] ?? 1).toBeLessThan(0);
     expect(handle.targetPosition?.[1] ?? 1).toBeLessThan(0.2);
   });
+
+  it('updateAgentSpacingParams patches separationWeight and collisionQueryRange on a live agent', () => {
+    const crowd = createBotCrowd(makeGapWorld(), {
+      navigationProfile: getSharedPlayerNavigationProfile(),
+      mode: 'solo',
+    });
+
+    const handle = crowd.addBot([-3, 0, 0]);
+    const agent = crowd.getAgent(handle.id);
+    expect(agent).toBeTruthy();
+
+    const ok = crowd.updateAgentSpacingParams(handle, 4.0, 7.5);
+    expect(ok).toBe(true);
+    expect(agent?.separationWeight).toBeCloseTo(4.0, 5);
+    expect(agent?.collisionQueryRange).toBeCloseTo(7.5, 5);
+  });
 });

--- a/client/src/bots/crowd/BotCrowd.ts
+++ b/client/src/bots/crowd/BotCrowd.ts
@@ -56,7 +56,7 @@ function defaultAgentParams(nav: BotNavMesh): Omit<AgentParams, 'queryFilter'> {
     maxAcceleration: 25.0,
     maxSpeed: 7.0,
     collisionQueryRange: 4,
-    separationWeight: 1.0,
+    separationWeight: 2.5,
     updateFlags:
       crowd.CrowdUpdateFlags.ANTICIPATE_TURNS
       | crowd.CrowdUpdateFlags.OBSTACLE_AVOIDANCE
@@ -277,6 +277,26 @@ export class BotCrowd {
     const result = findRandomPoint(this.nav.navMesh, DEFAULT_QUERY_FILTER, rand);
     if (!result.success) return null;
     return [result.position[0], result.position[1], result.position[2]];
+  }
+
+  /**
+   * Updates `separationWeight` and `collisionQueryRange` on a live crowd
+   * agent without removing and re-adding it. Safe to call every frame but
+   * intended for the runtime spacing-tuning setter.
+   *
+   * Returns false if the agent is unknown.
+   */
+  updateAgentSpacingParams(
+    agentOrHandleId: string | BotHandle,
+    separationWeight: number,
+    collisionQueryRange: number,
+  ): boolean {
+    const id = typeof agentOrHandleId === 'string' ? agentOrHandleId : agentOrHandleId.id;
+    const agent = this.crowd.agents[id];
+    if (!agent) return false;
+    agent.separationWeight = separationWeight;
+    agent.collisionQueryRange = collisionQueryRange;
+    return true;
   }
 
   /**

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -61,6 +61,7 @@ export {
   PRACTICE_BOT_SPRINT_SPEED,
   PRACTICE_BOT_SPRINT_DISTANCE_M,
   DEFAULT_VEHICLE_PROFILE,
+  DEFAULT_PRACTICE_BOT_SPACING_TUNING,
   type BotDebugInfo,
   type BotObstacleDebugInfo,
   type LocalSelfAccessor,
@@ -70,5 +71,6 @@ export {
   type PracticeBotNavTuning,
   type PracticeBotRuntimeOptions,
   type PracticeBotRuntimeSyncOptions,
+  type PracticeBotSpacingTuning,
   type PracticeBotStats,
 } from './practice/PracticeBotRuntime';

--- a/client/src/bots/practice/PracticeBotRuntime.test.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.test.ts
@@ -10,7 +10,7 @@ import {
   getSharedPlayerNavigationProfile,
   hydrateSharedPlayerNavigationProfileFromLoadedWasm,
 } from '../../wasm/sharedPhysics';
-import { PracticeBotRuntime } from './PracticeBotRuntime';
+import { DEFAULT_PRACTICE_BOT_SPACING_TUNING, PracticeBotRuntime } from './PracticeBotRuntime';
 import { initWasmForTests } from '../../wasm/testInit';
 import { identityQuaternion, type WorldDocument } from '../../world/worldDocument';
 
@@ -156,9 +156,14 @@ describe('PracticeBotRuntime.create', () => {
     expect(info?.mode).toBe('follow_target');
     expect(info?.targetPlayerId).toBe(host.playerId);
     expect(info?.lastMoveAccepted).toBe(true);
-    expect(info?.rawTarget?.[0]).toBeCloseTo(localPosition[0], 5);
-    expect(info?.rawTarget?.[2]).toBeCloseTo(localPosition[2], 5);
-    expect(info?.targetSnapDistanceM ?? Number.POSITIVE_INFINITY).toBeLessThan(2);
+    // rawTarget is the chase-offset movement target, which may be up to
+    // chaseOffsetRadiusM away from the real player position.
+    const offsetRadius = DEFAULT_PRACTICE_BOT_SPACING_TUNING.chaseOffsetRadiusM + 0.01;
+    expect(Math.hypot(
+      (info?.rawTarget?.[0] ?? Infinity) - localPosition[0],
+      (info?.rawTarget?.[2] ?? Infinity) - localPosition[2],
+    )).toBeLessThanOrEqual(offsetRadius);
+    expect(info?.targetSnapDistanceM ?? Number.POSITIVE_INFINITY).toBeLessThan(2 + offsetRadius);
     expect(host.sentInputCounts.get(botId) ?? 0).toBeGreaterThan(0);
 
     localPosition = [
@@ -170,8 +175,10 @@ describe('PracticeBotRuntime.create', () => {
 
     info = runtime.getBotDebugInfos()[0];
     expect(info?.mode).toBe('follow_target');
-    expect(info?.rawTarget?.[0]).toBeCloseTo(localPosition[0], 5);
-    expect(info?.rawTarget?.[2]).toBeCloseTo(localPosition[2], 5);
+    expect(Math.hypot(
+      (info?.rawTarget?.[0] ?? Infinity) - localPosition[0],
+      (info?.rawTarget?.[2] ?? Infinity) - localPosition[2],
+    )).toBeLessThanOrEqual(offsetRadius);
 
     runtime.clear();
     runtime.detach();
@@ -358,5 +365,91 @@ describe('PracticeBotRuntime.create', () => {
     rebuilt.clear();
     rebuilt.detach();
     expect(host.disconnectCalls).toBe(1);
+  });
+
+  describe('setSpacingTuning', () => {
+    it('two bots chasing the same player report distinct rawTargets after a tick', () => {
+      vi.useFakeTimers();
+
+      const runtime = PracticeBotRuntime.createSync(makeFlatPlatformWorld(), {
+        navigationProfile: getSharedPlayerNavigationProfile(),
+        maxAgentRadius: 0.6,
+      });
+
+      const bot1Id = runtime.spawnBot();
+      const bot2Id = runtime.spawnBot();
+
+      const host = new FakePracticeBotHost();
+      const centerY = playerCenterY(0);
+      host.spawnPositions.set(bot1Id, [0, centerY, 0]);
+      host.spawnPositions.set(bot2Id, [0.5, centerY, 0.5]);
+
+      const getSelf = () => ({
+        id: host.playerId,
+        position: [1, centerY, 1] as [number, number, number],
+        dead: false,
+      });
+
+      runtime.setSpacingTuning({
+        separationWeight: 2.5,
+        collisionQueryRange: 4,
+        chaseOffsetRadiusM: 1.25,
+      });
+
+      runtime.attach(host, getSelf);
+      vi.advanceTimersByTime(200);
+
+      const infos = runtime.getBotDebugInfos();
+      const info1 = infos.find((i) => i.id === bot1Id);
+      const info2 = infos.find((i) => i.id === bot2Id);
+
+      expect(info1?.mode).toBe('follow_target');
+      expect(info2?.mode).toBe('follow_target');
+      // Different bots should have different movement targets
+      expect(info1?.rawTarget).not.toEqual(info2?.rawTarget);
+
+      runtime.clear();
+      runtime.detach();
+    });
+
+    it('applying setSpacingTuning with zero chaseOffset makes bots target the exact player center', () => {
+      vi.useFakeTimers();
+
+      const runtime = PracticeBotRuntime.createSync(makeFlatPlatformWorld(), {
+        navigationProfile: getSharedPlayerNavigationProfile(),
+        maxAgentRadius: 0.6,
+      });
+
+      const botId = runtime.spawnBot();
+      const initialInfo = runtime.getBotDebugInfos()[0];
+
+      const host = new FakePracticeBotHost();
+      const centerY = playerCenterY(initialInfo?.position[1] ?? 0);
+      host.spawnPositions.set(botId, [
+        initialInfo?.position[0] ?? 0,
+        centerY,
+        initialInfo?.position[2] ?? 0,
+      ]);
+
+      const playerPos: [number, number, number] = [
+        (initialInfo?.position[0] ?? 0) + 1,
+        centerY,
+        (initialInfo?.position[2] ?? 0) + 1,
+      ];
+      const getSelf = () => ({ id: host.playerId, position: playerPos, dead: false });
+
+      // Disable chase offset so rawTarget must match the exact player position
+      runtime.setSpacingTuning({ ...DEFAULT_PRACTICE_BOT_SPACING_TUNING, chaseOffsetRadiusM: 0 });
+      runtime.attach(host, getSelf);
+      vi.advanceTimersByTime(100);
+
+      const info = runtime.getBotDebugInfos()[0];
+      expect(info?.mode).toBe('follow_target');
+      expect(info?.rawTarget?.[0]).toBeCloseTo(playerPos[0], 5);
+      expect(info?.rawTarget?.[2]).toBeCloseTo(playerPos[2], 5);
+
+      runtime.clear();
+      runtime.detach();
+    });
   });
 });

--- a/client/src/bots/practice/PracticeBotRuntime.ts
+++ b/client/src/bots/practice/PracticeBotRuntime.ts
@@ -48,6 +48,18 @@ export const PRACTICE_BOT_SPRINT_DISTANCE_M = 10.0;
 
 export type PracticeBotBehaviorKind = 'harass' | 'wander' | 'hold';
 
+export interface PracticeBotSpacingTuning {
+  separationWeight: number;
+  collisionQueryRange: number;
+  chaseOffsetRadiusM: number;
+}
+
+export const DEFAULT_PRACTICE_BOT_SPACING_TUNING: PracticeBotSpacingTuning = Object.freeze({
+  separationWeight: 2.5,
+  collisionQueryRange: 4,
+  chaseOffsetRadiusM: 1.25,
+});
+
 export interface PracticeBotRuntimeOptions {
   maxAgentRadius?: number;
   snapHalfExtents?: Vec3Tuple;
@@ -63,6 +75,8 @@ export interface PracticeBotRuntimeOptions {
   useVehicles?: boolean;
   /** Override the default vehicle profile used by the walk-vs-drive planner. */
   vehicleProfile?: VehicleProfile;
+  /** Initial crowd-separation and chase-offset tuning. Defaults to DEFAULT_PRACTICE_BOT_SPACING_TUNING. */
+  spacingTuning?: PracticeBotSpacingTuning;
 }
 
 export interface PracticeBotRuntimeSyncOptions extends PracticeBotRuntimeOptions {
@@ -220,6 +234,8 @@ export class PracticeBotRuntime {
   private useVehicles: boolean;
   /** Static physical profile of the vehicle the bots would drive. */
   private readonly vehicleProfile: VehicleProfile;
+  /** Live crowd-separation and chase-offset tuning applied to all bots. */
+  private spacingTuning: PracticeBotSpacingTuning;
   /**
    * Lazy second crowd built on the first call to `setUseVehicles(true)`.
    * The underlying navmesh has a larger walkable radius so narrow
@@ -279,6 +295,7 @@ export class PracticeBotRuntime {
     this.tickHz = options.tickHz ?? DEFAULT_TICK_HZ;
     this.useVehicles = options.useVehicles ?? false;
     this.vehicleProfile = options.vehicleProfile ?? DEFAULT_VEHICLE_PROFILE;
+    this.spacingTuning = options.spacingTuning ?? DEFAULT_PRACTICE_BOT_SPACING_TUNING;
   }
 
   attach(host: PracticeBotHost, getSelf: LocalSelfAccessor): void {
@@ -382,7 +399,7 @@ export class PracticeBotRuntime {
     if (kind === this.behaviorKind) return;
     this.behaviorKind = kind;
     for (const bot of this.bots.values()) {
-      bot.brain.setBehavior(makeBehavior(kind));
+      bot.brain.setBehavior(makeBehavior(kind, this.spacingTuning));
       bot.behaviorKind = kind;
     }
   }
@@ -394,6 +411,27 @@ export class PracticeBotRuntime {
       const agent = this.crowd.getAgent(bot.handle.id);
       if (agent) agent.maxSpeed = PRACTICE_BOT_SPRINT_SPEED;
       this.host?.setBotMaxSpeed(bot.id, null);
+    }
+  }
+
+  /**
+   * Updates crowd-separation and chase-offset tuning for all live bots
+   * without requiring a navmesh rebuild or bot respawn.
+   *
+   * - `separationWeight` / `collisionQueryRange` are patched directly on each
+   *   existing crowd agent so navcat picks them up next `crowd.step()`.
+   * - `chaseOffsetRadiusM` takes effect immediately because each bot's
+   *   behavior closure is rebuilt with the new value.
+   */
+  setSpacingTuning(tuning: PracticeBotSpacingTuning): void {
+    this.spacingTuning = { ...tuning };
+    for (const bot of this.bots.values()) {
+      this.crowd.updateAgentSpacingParams(
+        bot.handle,
+        tuning.separationWeight,
+        tuning.collisionQueryRange,
+      );
+      bot.brain.setBehavior(makeBehavior(bot.behaviorKind, tuning));
     }
   }
 
@@ -412,13 +450,17 @@ export class PracticeBotRuntime {
 
   spawnBot(snapshot?: Partial<PracticeBotSnapshot>): number {
     const spawn = snapshot?.position ?? this.crowd.findRandomWalkable() ?? [0, 2, 0];
-    const handle = this.crowd.addBot(spawn);
+    const handle = this.crowd.addBot(spawn, {
+      separationWeight: this.spacingTuning.separationWeight,
+      collisionQueryRange: this.spacingTuning.collisionQueryRange,
+    });
     const agent = this.crowd.getAgent(handle.id);
     if (agent) agent.maxSpeed = PRACTICE_BOT_SPRINT_SPEED;
     const id = snapshot?.id ?? this.nextId;
     this.nextId = Math.max(this.nextId, id + 1);
-    const brain = new BotBrain(this.crowd, handle, makeBehavior(this.behaviorKind), {
+    const brain = new BotBrain(this.crowd, handle, makeBehavior(this.behaviorKind, this.spacingTuning), {
       anchor: snapshot?.anchor ?? spawn,
+      botId: id,
     });
     this.bots.set(id, {
       id,
@@ -1124,7 +1166,7 @@ function makeIdleIntent(): BotIntent {
   };
 }
 
-function makeBehavior(kind: PracticeBotBehaviorKind): Behavior {
+function makeBehavior(kind: PracticeBotBehaviorKind, spacing: PracticeBotSpacingTuning): Behavior {
   switch (kind) {
     case 'wander':
       return wander({ radiusM: 18 });
@@ -1136,6 +1178,7 @@ function makeBehavior(kind: PracticeBotBehaviorKind): Behavior {
         acquireDistanceM: 80,
         releaseDistanceM: 120,
         fireDistanceM: 0,
+        chaseOffsetRadiusM: spacing.chaseOffsetRadiusM,
       });
   }
 }

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
+  DEFAULT_PRACTICE_BOT_SPACING_TUNING,
   MAX_PRACTICE_BOTS,
   PRACTICE_BOT_SPRINT_DISTANCE_M,
   PRACTICE_BOT_SPRINT_SPEED,
@@ -9,6 +10,7 @@ import {
   type PracticeBotNavDebugConfig,
   type PracticeBotNavTuning,
   type PracticeBotRuntime,
+  type PracticeBotSpacingTuning,
   type PracticeBotStats,
 } from '../bots';
 
@@ -19,6 +21,7 @@ interface PracticeBotsPanelProps {
   runtime: PracticeBotRuntime | null;
   navConfig: PracticeBotNavDebugConfig | null;
   navTuning: PracticeBotNavTuning | null;
+  spacingTuning: PracticeBotSpacingTuning;
   debugOverlay: boolean;
   debugLabels: boolean;
   onSetBotCount: (count: number) => void;
@@ -29,6 +32,7 @@ interface PracticeBotsPanelProps {
   onToggleDebugOverlay: (value: boolean) => void;
   onToggleDebugLabels: (value: boolean) => void;
   onSetUseVehicles: (value: boolean) => void;
+  onSetSpacingTuning: (tuning: PracticeBotSpacingTuning) => void;
 }
 
 interface NavTuningDraft {
@@ -58,6 +62,7 @@ export function PracticeBotsPanel({
   runtime,
   navConfig,
   navTuning,
+  spacingTuning,
   debugOverlay,
   debugLabels,
   onSetBotCount,
@@ -68,6 +73,7 @@ export function PracticeBotsPanel({
   onToggleDebugOverlay,
   onToggleDebugLabels,
   onSetUseVehicles,
+  onSetSpacingTuning,
 }: PracticeBotsPanelProps) {
   const [open, setOpen] = useState(false);
   const [botInfos, setBotInfos] = useState<BotDebugInfo[]>([]);
@@ -215,6 +221,41 @@ export function PracticeBotsPanel({
               />
               <span>bots can drive vehicles to reach targets</span>
             </label>
+          </div>
+          <div className="flex items-start gap-2 text-xs">
+            {panelLabel('Spacing')}
+            <div className="flex flex-1 flex-col gap-2">
+              <SpacingSlider
+                label="Separation"
+                value={spacingTuning.separationWeight}
+                min={0}
+                max={6}
+                step={0.1}
+                format={(v) => v.toFixed(1)}
+                defaultValue={DEFAULT_PRACTICE_BOT_SPACING_TUNING.separationWeight}
+                onChange={(v) => onSetSpacingTuning({ ...spacingTuning, separationWeight: v })}
+              />
+              <SpacingSlider
+                label="Coll range"
+                value={spacingTuning.collisionQueryRange}
+                min={1}
+                max={12}
+                step={0.5}
+                format={(v) => `${v.toFixed(1)} m`}
+                defaultValue={DEFAULT_PRACTICE_BOT_SPACING_TUNING.collisionQueryRange}
+                onChange={(v) => onSetSpacingTuning({ ...spacingTuning, collisionQueryRange: v })}
+              />
+              <SpacingSlider
+                label="Chase offset"
+                value={spacingTuning.chaseOffsetRadiusM}
+                min={0}
+                max={4}
+                step={0.25}
+                format={(v) => `${v.toFixed(2)} m`}
+                defaultValue={DEFAULT_PRACTICE_BOT_SPACING_TUNING.chaseOffsetRadiusM}
+                onChange={(v) => onSetSpacingTuning({ ...spacingTuning, chaseOffsetRadiusM: v })}
+              />
+            </div>
           </div>
           <div className="flex items-center gap-2 text-xs">
             {panelLabel('Debug')}
@@ -458,6 +499,45 @@ function isValidNavDraft(draft: NavTuningDraft | null): boolean {
     && slope > 0
     && slope < 90
     && cellHeight > 0;
+}
+
+function SpacingSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  format,
+  defaultValue,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  format: (v: number) => string;
+  defaultValue: number;
+  onChange: (v: number) => void;
+}) {
+  const isDefault = Math.abs(value - defaultValue) < step * 0.01;
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-20 shrink-0 text-[10px] uppercase tracking-[0.1em] text-white/55">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        className="h-1.5 flex-1 cursor-pointer accent-emerald-300"
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+      <span className={['w-14 text-right text-[11px] font-mono', isDefault ? 'text-white/50' : 'text-emerald-200'].join(' ')}>
+        {format(value)}
+      </span>
+    </div>
+  );
 }
 
 function BotDebugCard({ info }: { info: BotDebugInfo }) {


### PR DESCRIPTION
## Summary
This PR adds configurable spacing tuning parameters for practice bots, allowing users to adjust crowd separation behavior and chase offset targeting through a new UI panel. Bots can now spread out around a target player instead of all converging on the exact same position.

## Key Changes

- **New `PracticeBotSpacingTuning` interface** with three parameters:
  - `separationWeight`: Controls how strongly bots avoid each other (default 2.5)
  - `collisionQueryRange`: Detection range for nearby agents in meters (default 4)
  - `chaseOffsetRadiusM`: Radius around target player for offset positioning (default 1.25)

- **Chase offset targeting**: When `chaseOffsetRadiusM > 0`, each bot's movement target is offset from the player center by a deterministic angle derived from the bot and target IDs. This prevents all bots from steering to the exact same point while keeping fire/melee aim pointed at the real player position.

- **Runtime spacing tuning**: Added `setSpacingTuning()` method to `PracticeBotRuntime` that updates all live bots without requiring respawn or navmesh rebuild. Separation parameters are patched directly on crowd agents, while chase offset takes effect via behavior closure rebuild.

- **UI controls**: New "Spacing" section in `PracticeBotsPanel` with three range sliders for real-time tuning of all three parameters, with visual feedback showing default values.

- **Crowd agent updates**: Modified `BotCrowd.addBot()` to accept spacing parameters and added `updateAgentSpacingParams()` method for live patching of agent properties.

- **Test coverage**: Added comprehensive tests for chase offset behavior including multi-bot spreading, zero-offset targeting, and melee range fallback behavior.

## Implementation Details

- Chase offset angle is computed via a stable hash function: `((botId * 2654435761 + targetId * 1013904223) >>> 0) / 4294967296 * 2π`
- Inside melee range, offset is disabled so attacks land on the real player position
- Default `separationWeight` increased from 1.0 to 2.5 to improve baseline bot spreading
- All spacing parameters are passed through the behavior creation pipeline so they're available to the `harassNearest` behavior

https://claude.ai/code/session_01LVDcJ5jiZnqzGMd8Y2H85T