### PR TITLE
Practice: faster world serialization, leaner bot navmesh, local shared-world dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ WT_HOST=127.0.0.1
 # Vite dev server
 ALLOWED_HOSTS=localhost
 CLIENT_PORT=5555
+# Shared practice: append ?local=1 to /practice/shared/<uuid> to load
+# worlds/<uuid>.world.json from the repo root (see client/vite.config.ts).
+# Example: curl -fsSL 'https://vibe-land-worlds.glavin.ca/published/<uuid>.world.json' \\
+#   -o worlds/<uuid>.world.json
 
 # World publishing + /gallery storage (optional — enables the "Publish to
 # Cloud" button in the world builder and populates /gallery). Pick ONE of

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ blob-report/
 logs/
 .vercel
 .env*.local
+
+# Large published worlds for local /practice/shared?local=1 testing (download separately)
+worlds/*.world.json

--- a/client/src/bots/index.ts
+++ b/client/src/bots/index.ts
@@ -4,7 +4,12 @@
  * First-class bot automation framework built on top of navcat.
  */
 
-export { buildWorldGeometry, type BotWorldGeometry } from './world/worldGeometry';
+export {
+  buildWorldGeometry,
+  buildWorldGeometryFullResolution,
+  type BotWorldGeometry,
+  type BuildWorldGeometryOptions,
+} from './world/worldGeometry';
 export {
   buildBotNavMesh,
   buildBotNavMeshFromSharedProfile,

--- a/client/src/bots/world/worldGeometry.ts
+++ b/client/src/bots/world/worldGeometry.ts
@@ -22,11 +22,40 @@ export interface BotWorldGeometry {
   vertexCount: number;
 }
 
-export function buildWorldGeometry(world: WorldDocument): BotWorldGeometry {
+/**
+ * Full-resolution terrain + props (e.g. debug visualization). For navmesh
+ * generation use {@link buildWorldGeometry} which decimates terrain.
+ */
+export function buildWorldGeometryFullResolution(world: WorldDocument): BotWorldGeometry {
+  return buildWorldGeometryInner(world, 1);
+}
+
+/**
+ * Terrain decimation step along each axis (1 = full resolution). Values > 1
+ * shrink navmesh input dramatically on large heightmaps (e.g. 129² → 65²
+ * verts per tile when step is 2) while keeping tile edge vertices aligned.
+ */
+export type BuildWorldGeometryOptions = {
+  terrainVertexStep?: number;
+};
+
+export function buildWorldGeometry(
+  world: WorldDocument,
+  options?: BuildWorldGeometryOptions,
+): BotWorldGeometry {
+  const step = options?.terrainVertexStep ?? 2;
+  const terrainVertexStep = Math.max(1, Math.floor(step));
+  return buildWorldGeometryInner(world, terrainVertexStep);
+}
+
+function buildWorldGeometryInner(world: WorldDocument, terrainVertexStep: number): BotWorldGeometry {
   const tiles = sortTerrainTiles(world.terrain.tiles);
   const tileGridSize = world.terrain.tileGridSize;
-  const vertsPerTile = tileGridSize * tileGridSize;
-  const trisPerTile = Math.max(0, (tileGridSize - 1) * (tileGridSize - 1) * 2);
+  const decimatedGridSize = terrainVertexStep === 1
+    ? tileGridSize
+    : computeDecimatedAxisLength(tileGridSize, terrainVertexStep);
+  const vertsPerTile = decimatedGridSize * decimatedGridSize;
+  const trisPerTile = Math.max(0, (decimatedGridSize - 1) * (decimatedGridSize - 1) * 2);
 
   const terrainVerts = tiles.length * vertsPerTile;
   const terrainTris = tiles.length * trisPerTile;
@@ -53,7 +82,18 @@ export function buildWorldGeometry(world: WorldDocument): BotWorldGeometry {
 
   for (const tile of tiles) {
     const tileBaseVertex = vertexCursor;
-    writeTerrainTileVertices(world, tile, positions, vertexCursor);
+    if (terrainVertexStep <= 1) {
+      writeTerrainTileVertices(world, tile, positions, vertexCursor);
+    } else {
+      writeDecimatedTerrainTileVertices(
+        world,
+        tile,
+        terrainVertexStep,
+        decimatedGridSize,
+        positions,
+        vertexCursor,
+      );
+    }
 
     for (let i = 0; i < vertsPerTile; i += 1) {
       const px = positions[(tileBaseVertex + i) * 3];
@@ -67,12 +107,13 @@ export function buildWorldGeometry(world: WorldDocument): BotWorldGeometry {
       if (pz > maxZ) maxZ = pz;
     }
 
-    for (let row = 0; row < tileGridSize - 1; row += 1) {
-      for (let col = 0; col < tileGridSize - 1; col += 1) {
-        const a = tileBaseVertex + row * tileGridSize + col;
-        const b = tileBaseVertex + row * tileGridSize + col + 1;
-        const c = tileBaseVertex + (row + 1) * tileGridSize + col;
-        const d = tileBaseVertex + (row + 1) * tileGridSize + col + 1;
+    const rowStride = decimatedGridSize;
+    for (let row = 0; row < decimatedGridSize - 1; row += 1) {
+      for (let col = 0; col < decimatedGridSize - 1; col += 1) {
+        const a = tileBaseVertex + row * rowStride + col;
+        const b = tileBaseVertex + row * rowStride + col + 1;
+        const c = tileBaseVertex + (row + 1) * rowStride + col;
+        const d = tileBaseVertex + (row + 1) * rowStride + col + 1;
 
         indices[indexCursor + 0] = a;
         indices[indexCursor + 1] = c;
@@ -126,6 +167,21 @@ export function buildWorldGeometry(world: WorldDocument): BotWorldGeometry {
   };
 }
 
+function computeDecimatedAxisLength(tileGridSize: number, step: number): number {
+  if (tileGridSize < 2 || step <= 1) {
+    return tileGridSize;
+  }
+  const last = tileGridSize - 1;
+  let count = 0;
+  for (let i = 0; i < last; i += step) {
+    count += 1;
+  }
+  if ((count - 1) * step < last) {
+    count += 1;
+  }
+  return count;
+}
+
 function writeTerrainTileVertices(
   world: WorldDocument,
   tile: WorldTerrainTile,
@@ -143,6 +199,42 @@ function writeTerrainTileVertices(
       out[offset + 1] = height;
       out[offset + 2] = wz;
     }
+  }
+}
+
+function writeDecimatedTerrainTileVertices(
+  world: WorldDocument,
+  tile: WorldTerrainTile,
+  step: number,
+  decimatedGridSize: number,
+  out: Float32Array,
+  baseVertex: number,
+): void {
+  const tileGridSize = world.terrain.tileGridSize;
+  const last = tileGridSize - 1;
+  const rows: number[] = [];
+  for (let r = 0; r < last; r += step) {
+    rows.push(r);
+  }
+  if (rows.length === 0 || rows[rows.length - 1] !== last) {
+    rows.push(last);
+  }
+  const cols = rows;
+  let v = 0;
+  for (const row of rows) {
+    for (const col of cols) {
+      const vi = row * tileGridSize + col;
+      const [wx, wz] = getTerrainTileWorldPosition(world, tile, row, col);
+      const height = tile.heights[vi] ?? 0;
+      const offset = (baseVertex + v) * 3;
+      out[offset + 0] = wx;
+      out[offset + 1] = height;
+      out[offset + 2] = wz;
+      v += 1;
+    }
+  }
+  if (v !== decimatedGridSize * decimatedGridSize) {
+    throw new Error('Decimated terrain vertex count mismatch.');
   }
 }
 

--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -514,7 +514,7 @@ export function GodModePage({ publishedId }: GodModePageProps = {}) {
   }, [mode]);
 
   const handleExport = useCallback(() => {
-    const blob = new Blob([serializeWorldDocument(world)], { type: 'application/json' });
+    const blob = new Blob([serializeWorldDocument(world, { pretty: true })], { type: 'application/json' });
     const href = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = href;

--- a/client/src/pages/SharedPractice.tsx
+++ b/client/src/pages/SharedPractice.tsx
@@ -3,6 +3,22 @@ import { App } from '../App';
 import { parseWorldDocument, type WorldDocument } from '../world/worldDocument';
 import { fetchCloudConfig, fetchPublishedWorld } from '../world/worldsCloud';
 
+async function loadPublishedWorldForRoute(id: string): Promise<unknown> {
+  const params = new URLSearchParams(window.location.search);
+  const useLocalPublished = import.meta.env.DEV && params.get('local') === '1';
+  if (useLocalPublished) {
+    const response = await fetch(`/published/${encodeURIComponent(id)}.world.json`);
+    if (!response.ok) {
+      throw new Error(
+        `Local world file missing (HTTP ${response.status}). Place worlds/${id}.world.json at the repo root or drop ?local=1.`,
+      );
+    }
+    return response.json();
+  }
+  const config = await fetchCloudConfig();
+  return fetchPublishedWorld(id, config.publicUrl);
+}
+
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'error'; message: string }
@@ -14,15 +30,13 @@ type SharedPracticePageProps = {
 
 export function SharedPracticePage({ id }: SharedPracticePageProps) {
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const loadFromLocalDevFile = import.meta.env.DEV
+    && new URLSearchParams(window.location.search).get('local') === '1';
 
   useEffect(() => {
     let cancelled = false;
     setState({ kind: 'loading' });
-    fetchCloudConfig()
-      .then((config) => {
-        if (cancelled) return;
-        return fetchPublishedWorld(id, config.publicUrl);
-      })
+    loadPublishedWorldForRoute(id)
       .then((raw) => {
         if (cancelled || !raw) return;
         const world = parseWorldDocument(raw);
@@ -50,7 +64,16 @@ export function SharedPracticePage({ id }: SharedPracticePageProps) {
           </div>
           <h1 className="text-3xl font-bold m-0 mb-2 text-white/90">Loading world…</h1>
           <p className="text-white/45 m-0 text-sm leading-relaxed">
-            Fetching <code className="font-mono text-white/60">{id}</code> from the cloud.
+            {loadFromLocalDevFile ? (
+              <>
+                Loading <code className="font-mono text-white/60">{id}</code> from{' '}
+                <code className="font-mono text-white/60">worlds/{id}.world.json</code> (dev).
+              </>
+            ) : (
+              <>
+                Fetching <code className="font-mono text-white/60">{id}</code> from the cloud.
+              </>
+            )}
           </p>
         </div>
       </div>

--- a/client/src/ui/PracticeBotsPanel.tsx
+++ b/client/src/ui/PracticeBotsPanel.tsx
@@ -89,7 +89,7 @@ export function PracticeBotsPanel({
   const useVehicles = stats?.useVehicles ?? false;
 
   useEffect(() => {
-    if (!visible || !open || !runtime) {
+    if (!visible || !open || !runtime || !debugOverlay) {
       setBotInfos([]);
       return;
     }
@@ -101,9 +101,9 @@ export function PracticeBotsPanel({
       setBotInfos(next);
     };
     sync();
-    const interval = setInterval(sync, 100);
+    const interval = setInterval(sync, 250);
     return () => clearInterval(interval);
-  }, [open, runtime, visible]);
+  }, [debugOverlay, open, runtime, visible]);
 
   useEffect(() => {
     setCountDraft(String(desiredCount));

--- a/client/src/world/worldDocument.ts
+++ b/client/src/world/worldDocument.ts
@@ -206,33 +206,48 @@ function parseSpawnArea(raw: unknown): SpawnArea {
   };
 }
 
-export function serializeWorldDocument(world: WorldDocument): string {
-  return JSON.stringify(
-    {
-      ...world,
-      version: WORLD_DOCUMENT_VERSION,
-      terrain: {
-        tileGridSize: world.terrain.tileGridSize,
-        tileHalfExtentM: world.terrain.tileHalfExtentM,
-        tiles: sortTerrainTiles(world.terrain.tiles).map((tile) => {
-          const entry: Record<string, unknown> = {
-            tileX: tile.tileX,
-            tileZ: tile.tileZ,
-            heights: [...tile.heights],
-          };
-          if (tile.materials && tile.materials.length > 0) {
-            entry.materials = tile.materials;
-          }
-          if (tile.materialWeights && tile.materialWeights.length > 0) {
-            entry.materialWeights = [...tile.materialWeights];
-          }
-          return entry;
-        }),
-      },
+export type SerializeWorldDocumentOptions = {
+  /** Pretty-print JSON (larger; use for downloads / human inspection only). */
+  pretty?: boolean;
+};
+
+/**
+ * Serializes a world for storage or WASM `loadWorldDocument`. Defaults to a
+ * compact single-line JSON string to avoid multi-megabyte pretty prints and
+ * extra allocation from spreading large height arrays.
+ */
+export function serializeWorldDocument(
+  world: WorldDocument,
+  options?: SerializeWorldDocumentOptions,
+): string {
+  const pretty = options?.pretty === true;
+  const tiles = sortTerrainTiles(world.terrain.tiles).map((tile) => {
+    const entry: Record<string, unknown> = {
+      tileX: tile.tileX,
+      tileZ: tile.tileZ,
+      heights: tile.heights,
+    };
+    if (tile.materials && tile.materials.length > 0) {
+      entry.materials = tile.materials;
+    }
+    if (tile.materialWeights && tile.materialWeights.length > 0) {
+      entry.materialWeights = tile.materialWeights;
+    }
+    return entry;
+  });
+  const payload = {
+    version: WORLD_DOCUMENT_VERSION,
+    meta: world.meta,
+    terrain: {
+      tileGridSize: world.terrain.tileGridSize,
+      tileHalfExtentM: world.terrain.tileHalfExtentM,
+      tiles,
     },
-    null,
-    2,
-  );
+    staticProps: world.staticProps,
+    dynamicEntities: world.dynamicEntities,
+    spawnAreas: world.spawnAreas,
+  };
+  return pretty ? JSON.stringify(payload, null, 2) : JSON.stringify(payload);
 }
 
 export function cloneWorldDocument(world: WorldDocument): WorldDocument {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,7 +1,38 @@
 import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type { Connect } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+
+function localPublishedWorldsMiddleware(repoRoot: string): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    const url = req.url;
+    if (!url?.startsWith('/published/') || !url.endsWith('.world.json')) {
+      next();
+      return;
+    }
+    const name = path.basename(url, '.world.json');
+    if (!/^[0-9a-f-]+$/i.test(name)) {
+      next();
+      return;
+    }
+    const filePath = path.join(repoRoot, 'worlds', `${name}.world.json`);
+    if (!fs.existsSync(filePath)) {
+      next();
+      return;
+    }
+    try {
+      const body = fs.readFileSync(filePath);
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-store');
+      res.end(body);
+    } catch {
+      next();
+    }
+  };
+}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, '../', '');
@@ -16,8 +47,19 @@ export default defineConfig(({ mode }) => {
     ? { cert: fs.readFileSync(certPath), key: fs.readFileSync(keyPath) }
     : undefined;
 
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
   return {
-    plugins: [tailwindcss(), react()],
+    plugins: [
+      tailwindcss(),
+      react(),
+      {
+        name: 'local-published-worlds',
+        configureServer(server) {
+          server.middlewares.use(localPublishedWorldsMiddleware(repoRoot));
+        },
+      },
+    ],
     envDir: '../',
     server: {
       port: Number(env.CLIENT_PORT) || 3001,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Optimizes practice/shared-world load and runtime when many bots are present, and adds a dev-only path to load published world JSON from the repo without hitting `/api/worlds`.

## Changes

- **Compact `serializeWorldDocument`**: default is single-line JSON (no 2-space pretty print). Builder export still uses `{ pretty: true }`.
- **Bot navmesh input**: terrain is decimated by default (step 2) for `buildWorldGeometry`, cutting triangle count roughly 4× on large tiles while keeping tile-edge vertices aligned. Full resolution remains available via `buildWorldGeometryFullResolution`.
- **Local dev**: Vite serves `worlds/<uuid>.world.json` at `/published/<uuid>.world.json`. Use `/practice/shared/<uuid>?local=1` to load from disk and skip `fetchCloudConfig`. Documented in `.env.example` with a curl example.
- **Bots panel**: expensive `getBotDebugInfos()` polling only runs when the Bots panel is open **and** debug overlay is enabled; interval 250ms.

## Verification

- `npm run lint` (client) passes.
- `npm run test:world-docs` passes.
- Browser: `http://127.0.0.1:5555/practice/shared/e4361ac9-3482-42ed-bd3c-51181e99aed1?local=1` with `worlds/<uuid>.world.json` present loads successfully.

## Note

Large world JSON files are gitignored under `worlds/*.world.json`; download from the CDN as in `.env.example` for local testing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b06418e9-f7dc-4c42-9201-b3693e46dfb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b06418e9-f7dc-4c42-9201-b3693e46dfb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

