### PR TITLE
Implement cold remote player state compression for bandwidth optimization

### DIFF
--- a/client/src/benchmark/evaluate.test.ts
+++ b/client/src/benchmark/evaluate.test.ts
@@ -105,6 +105,7 @@ function makeMatch(overrides: Partial<MatchStatsSnapshot> = {}): MatchStatsSnaps
         in_vehicle: false,
         dead: false,
         input_jitter_ms: 2,
+        input_period_ms: 16.7,
         avg_bundle_size: 1,
         correction_m: 0,
         physics_ms: 0.1,
@@ -152,6 +153,7 @@ describe('benchmark evaluation', () => {
         ...makeMatch().network,
         datagram_fallbacks: 7,
         strict_snapshot_drops: 11,
+        strict_snapshot_drop_oversize: 11,
       },
       load: {
         ...makeMatch().load,
@@ -163,6 +165,7 @@ describe('benchmark evaluation', () => {
         ...base.network,
         datagram_fallbacks: 9,
         strict_snapshot_drops: 14,
+        strict_snapshot_drop_oversize: 14,
       },
       load: {
         ...base.load,

--- a/client/src/benchmark/evaluate.ts
+++ b/client/src/benchmark/evaluate.ts
@@ -1,4 +1,4 @@
-import { describeBottleneck, maxPendingInputs, totalPhysicsP95, webTransportSnapshotFallbackRatio, type MatchStatsSnapshot } from '../loadtest/serverStats';
+import { describeBottleneck, maxPendingInputs, strictDropFailures, totalPhysicsP95, webTransportSnapshotFallbackRatio, type MatchStatsSnapshot } from '../loadtest/serverStats';
 import type {
   BenchmarkMeasuredWindow,
   BenchmarkObservedMetrics,
@@ -48,7 +48,7 @@ export function buildMeasuredWindow(
     bodiesPerClientP95: maxValue(matches, (sample) => sample.network.snapshot_dynamic_bodies_per_client.p95),
     wtReliableRatio: maxValue(matches, (sample) => webTransportSnapshotFallbackRatio(sample)),
     datagramFallbacks: deltaValue(matches, (sample) => sample.network.datagram_fallbacks),
-    strictSnapshotDrops: deltaValue(matches, (sample) => sample.network.strict_snapshot_drops),
+    strictSnapshotDrops: deltaValue(matches, (sample) => strictDropFailures(sample)),
     maxPendingInputs: maxValue(matches, (sample) => maxPendingInputs(sample)),
     avgPendingInputs: maxValue(matches, (sample) =>
       sample.players.length > 0

--- a/client/src/loadtest/botSnapshot.test.ts
+++ b/client/src/loadtest/botSnapshot.test.ts
@@ -108,6 +108,7 @@ describe('applyBotSnapshotState', () => {
           flags: 1,
         },
       ],
+      coldRemotePlayers: [],
       sphereStates: [],
       boxStates: [],
       vehicleStates: [],

--- a/client/src/loadtest/botSnapshot.ts
+++ b/client/src/loadtest/botSnapshot.ts
@@ -46,7 +46,8 @@ function applySnapshotV2(state: BotSnapshotState, packet: Extract<ServerDatagram
     flags: packet.selfState.flags,
   };
 
-  state.remotePlayers.clear();
+  const prior = state.remotePlayers;
+  state.remotePlayers = new Map();
   for (const player of packet.remotePlayers) {
     const id = player.handle;
     state.remotePlayers.set(id, {
@@ -66,6 +67,25 @@ function applySnapshotV2(state: BotSnapshotState, packet: Extract<ServerDatagram
         pitch: i16ToAngle(player.pitchI16),
         hp: player.hp,
         flags: player.flags,
+      },
+    });
+  }
+  for (const cold of packet.coldRemotePlayers) {
+    const id = cold.handle;
+    const priorEntry = prior.get(id);
+    state.remotePlayers.set(id, {
+      id,
+      state: {
+        position: [
+          anchorPos[0] + q2_5mmToMeters(cold.dxQ2_5mm),
+          anchorPos[1] + q2_5mmToMeters(cold.dyQ2_5mm),
+          anchorPos[2] + q2_5mmToMeters(cold.dzQ2_5mm),
+        ],
+        velocity: priorEntry?.state.velocity ?? [0, 0, 0],
+        yaw: i16ToAngle(cold.yawI16),
+        pitch: priorEntry?.state.pitch ?? 0,
+        hp: priorEntry?.state.hp ?? 100,
+        flags: cold.flags,
       },
     });
   }

--- a/client/src/loadtest/serverStats.test.ts
+++ b/client/src/loadtest/serverStats.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   describeBottleneck,
   describeTransport,
+  jitterThresholds,
+  strictDropFailures,
   tickHeadroomMs,
+  zeroToleranceFailures,
   type MatchStatsSnapshot,
+  type PlayerStatsSnapshot,
 } from './serverStats';
 
 function makeMatch(overrides: Partial<MatchStatsSnapshot> = {}): MatchStatsSnapshot {
@@ -111,6 +115,7 @@ function makeMatch(overrides: Partial<MatchStatsSnapshot> = {}): MatchStatsSnaps
         in_vehicle: false,
         dead: false,
         input_jitter_ms: 2,
+        input_period_ms: 16.7,
         avg_bundle_size: 1,
         correction_m: 0,
         physics_ms: 0,
@@ -160,6 +165,104 @@ describe('serverStats heuristics', () => {
       },
     });
     expect(describeBottleneck(match, 60)).toContain('CPU-limited');
+  });
+
+  it('ignores connection-closed drops when computing failure counts', () => {
+    const match = makeMatch({
+      network: {
+        ...makeMatch().network,
+        strict_snapshot_drops: 5,
+        strict_snapshot_drop_connection_closed: 5,
+      },
+    });
+    expect(strictDropFailures(match)).toBe(0);
+    expect(zeroToleranceFailures(match)).toBe(0);
+    expect(describeBottleneck(match, 60)).not.toContain('WT strict drops');
+  });
+
+  it('flags oversize strict drops as real failures', () => {
+    const match = makeMatch({
+      timings: {
+        ...makeMatch().timings,
+        total_ms: { avg: 6, p95: 7, max: 9 },
+      },
+      network: {
+        ...makeMatch().network,
+        strict_snapshot_drops: 3,
+        strict_snapshot_drop_oversize: 3,
+      },
+    });
+    expect(strictDropFailures(match)).toBe(3);
+    expect(zeroToleranceFailures(match)).toBe(3);
+    expect(describeBottleneck(match, 60)).toContain('WT strict drops');
+    expect(describeBottleneck(match, 60)).toContain('oversize 3');
+  });
+
+  it('counts dropped outbound snapshots and malformed packets as failures even if strict drops are purely closed', () => {
+    const match = makeMatch({
+      network: {
+        ...makeMatch().network,
+        strict_snapshot_drops: 2,
+        strict_snapshot_drop_connection_closed: 2,
+        dropped_outbound_snapshots: 1,
+        malformed_packets: 4,
+      },
+    });
+    expect(strictDropFailures(match)).toBe(0);
+    expect(zeroToleranceFailures(match)).toBe(5);
+  });
+
+  it('keeps tight jitter bounds for clients sampling at sim rate', () => {
+    const player: PlayerStatsSnapshot = {
+      id: 1,
+      identity: 'p1',
+      transport: 'webtransport',
+      one_way_ms: 12,
+      pending_inputs: 0,
+      hp: 100,
+      pos_m: [0, 0, 0],
+      vel_ms: [0, 0, 0],
+      on_ground: true,
+      in_vehicle: false,
+      dead: false,
+      input_jitter_ms: 0,
+      input_period_ms: 16.7,
+      avg_bundle_size: 1,
+      correction_m: 0,
+      physics_ms: 0,
+      has_debug_stats: true,
+    };
+    const thresholds = jitterThresholds(player, 60);
+    expect(thresholds.celebrateMax).toBe(4);
+    expect(thresholds.goodMax).toBe(10);
+    expect(thresholds.watchMax).toBe(20);
+  });
+
+  it('widens jitter bounds for bots sampling slower than sim rate', () => {
+    const bot: PlayerStatsSnapshot = {
+      id: 2,
+      identity: 'bot2',
+      transport: 'webtransport',
+      one_way_ms: 17,
+      pending_inputs: 0,
+      hp: 100,
+      pos_m: [0, 0, 0],
+      vel_ms: [0, 0, 0],
+      on_ground: true,
+      in_vehicle: false,
+      dead: false,
+      input_jitter_ms: 128,
+      input_period_ms: 66.7,
+      avg_bundle_size: 1,
+      correction_m: 0,
+      physics_ms: 0,
+      has_debug_stats: false,
+    };
+    const thresholds = jitterThresholds(bot, 60);
+    // 15 Hz client has a ~50 ms sampling headroom at 60 Hz sim, so 128 ms
+    // stddev should stay below the watch ceiling (baseline * 3 = 150 ms).
+    expect(bot.input_jitter_ms).toBeLessThan(thresholds.watchMax);
+    expect(thresholds.watchMax).toBeGreaterThan(100);
   });
 
   it('does not claim WT overflow on websocket-only matches', () => {

--- a/client/src/loadtest/serverStats.ts
+++ b/client/src/loadtest/serverStats.ts
@@ -98,6 +98,7 @@ export interface PlayerStatsSnapshot {
   in_vehicle: boolean;
   dead: boolean;
   input_jitter_ms: number;
+  input_period_ms: number;
   avg_bundle_size: number;
   correction_m: number;
   physics_ms: number;
@@ -145,6 +146,46 @@ export function maxPendingInputs(match: MatchStatsSnapshot): number {
 export function avgPendingInputs(match: MatchStatsSnapshot): number {
   if (match.players.length === 0) return 0;
   return match.players.reduce((sum, player) => sum + player.pending_inputs, 0) / match.players.length;
+}
+
+export function strictDropFailures(match: MatchStatsSnapshot): number {
+  return (
+    match.network.strict_snapshot_drop_oversize
+    + match.network.strict_snapshot_drop_unsupported_peer
+    + match.network.strict_snapshot_drop_other
+  );
+}
+
+export function zeroToleranceFailures(match: MatchStatsSnapshot): number {
+  return (
+    strictDropFailures(match)
+    + match.network.dropped_outbound_snapshots
+    + match.network.malformed_packets
+  );
+}
+
+export interface JitterThresholds {
+  celebrateMax: number;
+  goodMax: number;
+  watchMax: number;
+}
+
+export function jitterThresholds(
+  player: PlayerStatsSnapshot,
+  simHz: number,
+): JitterThresholds {
+  const simPeriodMs = tickBudgetMs(simHz);
+  const periodMs = Number.isFinite(player.input_period_ms) ? player.input_period_ms : 0;
+  // Clients sampling at or near the sim rate keep the tight 4/10/20 ms floor
+  // (real players). Slower clients (e.g. loadtest bots at 15 Hz vs 60 Hz sim)
+  // widen proportionally because observed stddev scales with the client period,
+  // not with network quality. Use the client period itself as the upper bound.
+  const baseline = Math.max(0, periodMs - simPeriodMs);
+  return {
+    celebrateMax: Math.max(4, baseline * 0.4),
+    goodMax: Math.max(10, baseline * 1.5),
+    watchMax: Math.max(20, baseline * 3.0),
+  };
 }
 
 export function webTransportSnapshotFallbackRatio(match: MatchStatsSnapshot): number {
@@ -228,13 +269,10 @@ export function describeBottleneck(match: MatchStatsSnapshot, simHz = 60): strin
   if (budgetMs > 0 && headroomMs <= 4.0) {
     return `Near tick budget: ${timingLabel}, headroom ${headroomMs.toFixed(1)}ms`;
   }
-  if (match.load.webtransport_players > 0 && match.network.strict_snapshot_drops > 0) {
+  if (match.load.webtransport_players > 0 && strictDropFailures(match) > 0) {
     const dropSummary = [
       match.network.strict_snapshot_drop_oversize > 0
         ? `oversize ${match.network.strict_snapshot_drop_oversize}`
-        : null,
-      match.network.strict_snapshot_drop_connection_closed > 0
-        ? `closed ${match.network.strict_snapshot_drop_connection_closed}`
         : null,
       match.network.strict_snapshot_drop_unsupported_peer > 0
         ? `unsupported ${match.network.strict_snapshot_drop_unsupported_peer}`
@@ -245,7 +283,7 @@ export function describeBottleneck(match: MatchStatsSnapshot, simHz = 60): strin
     ]
       .filter((part): part is string => part != null)
       .join(', ');
-    return `WT strict drops: ${match.network.strict_snapshot_drops} dropped snapshots${dropSummary ? ` (${dropSummary})` : ''}, tick p95 ${match.timings.total_ms.p95.toFixed(1)}ms`;
+    return `WT strict drops: ${strictDropFailures(match)} dropped snapshots${dropSummary ? ` (${dropSummary})` : ''}, tick p95 ${match.timings.total_ms.p95.toFixed(1)}ms`;
   }
   if (match.load.webtransport_players > 0 && wtFallbackRatio >= 0.25) {
     return `WT datagram overflow: ${(wtFallbackRatio * 100).toFixed(1)}% reliable fallback, snapshot p95 ${(snapshotBytes / 1024).toFixed(1)} KiB/client`;

--- a/client/src/net/netcodeClient.test.ts
+++ b/client/src/net/netcodeClient.test.ts
@@ -161,6 +161,7 @@ function makeSnapshotV2(opts: {
       hp: player.hp ?? 100,
       flags: player.flags ?? FLAG_ON_GROUND,
     })),
+    coldRemotePlayers: [],
     sphereStates: (opts.sphereStates ?? []).map((body) => ({
       handle: body.handle,
       dxQ2_5mm: Math.round((body.offset[0] * 1000) / 2.5),

--- a/client/src/net/netcodeClient.ts
+++ b/client/src/net/netcodeClient.ts
@@ -361,7 +361,7 @@ export class NetcodeClient {
     this.debugTelemetry.observeAcceptedSnapshot(
       source,
       packet.serverTick,
-      1 + packet.remotePlayers.length,
+      1 + packet.remotePlayers.length + packet.coldRemotePlayers.length,
       packet.sphereStates.length + packet.boxStates.length,
     );
 
@@ -424,6 +424,42 @@ export class NetcodeClient {
         pitch,
         hp: player.hp,
         flags: player.flags,
+      });
+    }
+
+    for (const cold of packet.coldRemotePlayers) {
+      const remotePlayerId = this.playerIdByHandle.get(cold.handle);
+      if (remotePlayerId == null || remotePlayerId === this.playerId) {
+        continue;
+      }
+      const prior = this.remotePlayers.get(remotePlayerId);
+      if (!prior) {
+        // No hot record yet to seed hp/pitch/velocity from; wait for the next
+        // refresh (server guarantees one within COLD_PLAYER_REFRESH_TICKS).
+        continue;
+      }
+      const position: [number, number, number] = [
+        anchorPos[0] + q2_5mmToMeters(cold.dxQ2_5mm),
+        anchorPos[1] + q2_5mmToMeters(cold.dyQ2_5mm),
+        anchorPos[2] + q2_5mmToMeters(cold.dzQ2_5mm),
+      ];
+      const yaw = (cold.yawI16 & 0xffff) / 65535 * Math.PI * 2;
+      this.interpolator.push(remotePlayerId, {
+        serverTimeUs: packet.serverTimeUs,
+        position,
+        velocity: [0, 0, 0],
+        yaw,
+        pitch: prior.pitch,
+        hp: prior.hp,
+        flags: cold.flags,
+      });
+      this.remotePlayers.set(remotePlayerId, {
+        id: remotePlayerId,
+        position,
+        yaw,
+        pitch: prior.pitch,
+        hp: prior.hp,
+        flags: cold.flags,
       });
     }
 

--- a/client/src/net/protocol.test.ts
+++ b/client/src/net/protocol.test.ts
@@ -361,7 +361,7 @@ describe('snapshot decode', () => {
 });
 
 function buildSnapshotV2Binary(): Uint8Array {
-  const size = 1 + 4 + 2 + 4 + 4 + 4 + 1 + 1 + 1 + 1 + 12 + 19 + 20 + 30;
+  const size = 1 + 4 + 2 + 4 + 4 + 4 + 1 + 1 + 1 + 1 + 1 + 12 + 19 + 20 + 30;
   const buf = new Uint8Array(size);
   const view = new DataView(buf.buffer);
   let o = 0;
@@ -373,6 +373,7 @@ function buildSnapshotV2Binary(): Uint8Array {
   view.setInt32(o, 2_000, true); o += 4;
   view.setInt32(o, -4_000, true); o += 4;
   view.setUint8(o++, 1);
+  view.setUint8(o++, 0);
   view.setUint8(o++, 1);
   view.setUint8(o++, 0);
   view.setUint8(o++, 1);
@@ -438,6 +439,7 @@ describe('snapshot V2 decode', () => {
     expect(packet.anchorPxMm).toBe(10_000);
     expect(packet.remotePlayers).toHaveLength(1);
     expect(packet.remotePlayers[0].handle).toBe(2);
+    expect(packet.coldRemotePlayers).toHaveLength(0);
     expect(packet.sphereStates).toHaveLength(1);
     expect(packet.sphereStates[0].handle).toBe(7);
     expect(packet.vehicleStates).toHaveLength(1);

--- a/client/src/net/protocol.ts
+++ b/client/src/net/protocol.ts
@@ -236,6 +236,15 @@ export type RemotePlayerStateV2 = {
   flags: number;
 };
 
+export type RemotePlayerColdStateV2 = {
+  handle: number;
+  dxQ2_5mm: number;
+  dyQ2_5mm: number;
+  dzQ2_5mm: number;
+  yawI16: number;
+  flags: number;
+};
+
 export type DynamicSphereStateV2 = {
   handle: number;
   dxQ2_5mm: number;
@@ -296,6 +305,7 @@ export type SnapshotV2Packet = {
   anchorPzMm: number;
   selfState: SelfPlayerStateV2;
   remotePlayers: RemotePlayerStateV2[];
+  coldRemotePlayers: RemotePlayerColdStateV2[];
   sphereStates: DynamicSphereStateV2[];
   boxStates: DynamicBoxStateV2[];
   vehicleStates: VehicleStateV2[];
@@ -725,6 +735,7 @@ export function decodeSnapshotV2Packet(view: DataView, o: number): SnapshotV2Pac
   const anchorPyMm = view.getInt32(o, true); o += 4;
   const anchorPzMm = view.getInt32(o, true); o += 4;
   const remotePlayerCount = view.getUint8(o++);
+  const coldRemotePlayerCount = view.getUint8(o++);
   const sphereCount = view.getUint8(o++);
   const boxCount = view.getUint8(o++);
   const vehicleCount = view.getUint8(o++);
@@ -756,6 +767,19 @@ export function decodeSnapshotV2Packet(view: DataView, o: number): SnapshotV2Pac
       flags: view.getUint8(o + 18),
     });
     o += 19;
+  }
+
+  const coldRemotePlayers: RemotePlayerColdStateV2[] = [];
+  for (let i = 0; i < coldRemotePlayerCount; i += 1) {
+    coldRemotePlayers.push({
+      handle: view.getUint8(o),
+      dxQ2_5mm: view.getInt16(o + 1, true),
+      dyQ2_5mm: view.getInt16(o + 3, true),
+      dzQ2_5mm: view.getInt16(o + 5, true),
+      yawI16: view.getInt16(o + 7, true),
+      flags: view.getUint8(o + 9),
+    });
+    o += 10;
   }
 
   const sphereStates: DynamicSphereStateV2[] = [];
@@ -830,6 +854,7 @@ export function decodeSnapshotV2Packet(view: DataView, o: number): SnapshotV2Pac
     anchorPzMm,
     selfState,
     remotePlayers,
+    coldRemotePlayers,
     sphereStates,
     boxStates,
     vehicleStates,

--- a/client/src/pages/ServerStats.tsx
+++ b/client/src/pages/ServerStats.tsx
@@ -5,12 +5,15 @@ import {
   batterySyncSummary,
   describeBottleneck,
   describeTransport,
+  jitterThresholds,
   maxPendingInputs,
+  strictDropFailures,
   tickBudgetMs,
   tickHeadroomMs,
   totalPhysicsP95,
   webTransportSnapshotDatagramRatio,
   webTransportSnapshotFallbackRatio,
+  zeroToleranceFailures,
   type GlobalStatsSnapshot,
   type MatchStatsSnapshot,
   type PlayerStatsSnapshot,
@@ -384,12 +387,13 @@ function headroomSeverity(headroomMs: number, budgetMs: number): SeverityTone {
   return higherIsBetterSeverity(headroomMs, budgetMs * 0.45, budgetMs * 0.2, 0.01);
 }
 
-function playerPressureSeverity(player: PlayerStatsSnapshot): SeverityTone {
+function playerPressureSeverity(player: PlayerStatsSnapshot, simHz = 60): SeverityTone {
   const correction = player.has_debug_stats ? player.correction_m : 0;
+  const jitter = jitterThresholds(player, simHz);
   const worst = worstSeverity([
     lowerIsBetterSeverity(player.pending_inputs, 2, 8, 20),
     lowerIsBetterSeverity(player.one_way_ms, 25, 60, 100),
-    lowerIsBetterSeverity(player.input_jitter_ms, 4, 10, 20),
+    lowerIsBetterSeverity(player.input_jitter_ms, jitter.celebrateMax, jitter.goodMax, jitter.watchMax),
     player.has_debug_stats ? lowerIsBetterSeverity(correction, 0.03, 0.1, 0.5) : 'neutral',
   ]);
   if (worst !== 'neutral') {
@@ -536,7 +540,7 @@ function backlogSeverity(match: MatchStatsSnapshot): SeverityTone {
 
 function zeroToleranceSeverity(match: MatchStatsSnapshot): SeverityTone {
   return worstSeverity([
-    match.network.strict_snapshot_drops > 0 ? 'danger' : 'celebrate',
+    strictDropFailures(match) > 0 ? 'danger' : 'celebrate',
     match.network.dropped_outbound_snapshots > 0 ? 'danger' : 'celebrate',
     match.network.malformed_packets > 0 ? 'danger' : 'celebrate',
   ]);
@@ -651,9 +655,9 @@ function buildMatchFocusAreas(match: MatchStatsSnapshot, simHz: number): string[
     );
   }
 
-  if (match.network.strict_snapshot_drops > 0 || match.network.dropped_outbound_snapshots > 0 || match.network.malformed_packets > 0) {
+  if (zeroToleranceFailures(match) > 0) {
     focus.push(
-      `Zero-tolerance counters fired: strict drops ${match.network.strict_snapshot_drops}, dropped outbound snapshots ${match.network.dropped_outbound_snapshots}, malformed packets ${match.network.malformed_packets}.`,
+      `Zero-tolerance counters fired: strict drops ${strictDropFailures(match)}, dropped outbound snapshots ${match.network.dropped_outbound_snapshots}, malformed packets ${match.network.malformed_packets}.`,
     );
   }
 
@@ -704,7 +708,7 @@ function buildMatchOpportunities(match: MatchStatsSnapshot, simHz: number): stri
     opportunities.push(`Reduce queue spikes on the worst players: ${topPlayerPressureSummary(match)}.`);
   }
 
-  if (match.network.strict_snapshot_drops > 0 || match.network.dropped_outbound_snapshots > 0 || match.network.malformed_packets > 0) {
+  if (zeroToleranceFailures(match) > 0) {
     opportunities.push('Zero-tolerance counters should be driven to zero before trusting higher-scale benchmark runs.');
   }
 
@@ -730,8 +734,10 @@ function buildMatchWins(match: MatchStatsSnapshot, simHz: number): string[] {
   if (severityRank(backlogSeverity(match)) <= severityRank('good')) {
     wins.push(`Input queue is stable: max ${fmtInt(maxPendingInputs(match))}, avg ${fmt(avgPendingInputs(match), 1)}.`);
   }
-  if (match.network.strict_snapshot_drops === 0 && match.network.dropped_outbound_snapshots === 0 && match.network.malformed_packets === 0) {
-    wins.push('Zero-tolerance counters are clean: no strict drops, dropped outbound snapshots, or malformed packets.');
+  if (zeroToleranceFailures(match) === 0) {
+    const closed = match.network.strict_snapshot_drop_connection_closed;
+    const closedNote = closed > 0 ? ` (${closed} benign close-drop${closed === 1 ? '' : 's'} ignored)` : '';
+    wins.push(`Zero-tolerance counters are clean: no oversize/unsupported strict drops, no dropped outbound snapshots, no malformed packets${closedNote}.`);
   }
   if (match.battery_count > 0 && severityRank(snapshotPayloadSeverity(match)) <= severityRank('good')) {
     wins.push(`Battery gameplay is active without inflating snapshots: ${batterySyncSummary(match)}.`);
@@ -781,11 +787,7 @@ function buildGlobalFocusAreas(stats: GlobalStatsSnapshot): string[] {
 
 function buildGlobalWins(stats: GlobalStatsSnapshot): string[] {
   const wins: string[] = [];
-  const allZeroToleranceClean = stats.matches.every((match) => (
-    match.network.strict_snapshot_drops === 0
-    && match.network.dropped_outbound_snapshots === 0
-    && match.network.malformed_packets === 0
-  ));
+  const allZeroToleranceClean = stats.matches.every((match) => zeroToleranceFailures(match) === 0);
   const allTicksHealthy = stats.matches.every((match) => severityRank(tickSeverity(match, stats.sim_hz)) <= severityRank('good'));
   const allPayloadsHealthy = stats.matches.every((match) => severityRank(snapshotPayloadSeverity(match)) <= severityRank('good'));
   const bestWtMatch = stats.matches
@@ -854,10 +856,10 @@ function escapeMdCell(value: string): string {
   return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
-function playerRowMarkdown(player: PlayerStatsSnapshot): string {
+function playerRowMarkdown(player: PlayerStatsSnapshot, simHz: number): string {
   const phys = player.has_debug_stats ? `${fmtMsDetailed(player.physics_ms)}ms` : 'n/a';
   const correction = player.has_debug_stats ? `${fmt(player.correction_m, 3)}m` : 'n/a';
-  return `| ${player.id} | ${severityVisual(playerPressureSeverity(player)).label} | ${player.transport === 'webtransport' ? 'WT' : 'WS'} | ${player.one_way_ms}ms | ${player.pending_inputs} | ${player.dead ? '—' : `${player.hp}`} | ${escapeMdCell(fmtPos(player.pos_m))} | ${escapeMdCell(fmtSpeed(player.vel_ms))} | ${statusStr(player)} | ±${fmt(player.input_jitter_ms)}ms | ${fmt(player.avg_bundle_size, 1)} | ${correction} | ${phys} |`;
+  return `| ${player.id} | ${severityVisual(playerPressureSeverity(player, simHz)).label} | ${player.transport === 'webtransport' ? 'WT' : 'WS'} | ${player.one_way_ms}ms | ${player.pending_inputs} | ${player.dead ? '—' : `${player.hp}`} | ${escapeMdCell(fmtPos(player.pos_m))} | ${escapeMdCell(fmtSpeed(player.vel_ms))} | ${statusStr(player)} | ±${fmt(player.input_jitter_ms)}ms | ${fmt(player.avg_bundle_size, 1)} | ${correction} | ${phys} |`;
 }
 
 function matchMarkdown(match: MatchStatsSnapshot, simHz: number): string {
@@ -881,7 +883,7 @@ function matchMarkdown(match: MatchStatsSnapshot, simHz: number): string {
     `| WT payload / client | avg ${fmtBytes(match.network.snapshot_bytes_per_client.avg)} / p95 ${fmtBytes(match.network.snapshot_bytes_per_client.p95)} / max ${fmtBytes(match.network.snapshot_bytes_per_client.max)} | ${fmtBytes(WT_STRICT_DATAGRAM_TARGET_BYTES)} | ${severityVisual(payloadTone).label} | ${escapeMdCell(snapshotPressureDrivers(match))} |`,
     `| Pending inputs | avg ${fmt(avgPendingInputs(match), 1)} / max ${fmtInt(maxPendingInputs(match))} | ${SERVER_PENDING_INPUT_CAP} | ${severityVisual(queueTone).label} | worst players: ${escapeMdCell(topPlayerPressureSummary(match))} |`,
     `| WT delivery | datagram ${fmtPercent(webTransportSnapshotDatagramRatio(match))} / reliable ${fmtPercent(wtFallbackRatio)} | keep datagram dominant | ${severityVisual(transportTone).label} | WS players ${match.load.websocket_players}; WT players ${match.load.webtransport_players} |`,
-    `| Zero-tolerance errors | strict ${match.network.strict_snapshot_drops} / dropped ${match.network.dropped_outbound_snapshots} / malformed ${match.network.malformed_packets} | 0 | ${severityVisual(zeroTone).label} | any non-zero here invalidates a clean run |`,
+    `| Zero-tolerance errors | strict ${strictDropFailures(match)} (closed ${match.network.strict_snapshot_drop_connection_closed} benign) / dropped ${match.network.dropped_outbound_snapshots} / malformed ${match.network.malformed_packets} | 0 | ${severityVisual(zeroTone).label} | only oversize/unsupported/other strict drops or dropped/malformed counters invalidate a run |`,
     '',
     ...markdownBullets('What To Focus On', buildMatchFocusAreas(match, simHz)),
     ...markdownBullets('Improvement Opportunities', buildMatchOpportunities(match, simHz)),
@@ -897,7 +899,7 @@ function matchMarkdown(match: MatchStatsSnapshot, simHz: number): string {
     `- packets ${match.network.inbound_packets_per_sec}/${match.network.outbound_packets_per_sec} per sec`,
     `- ${describeTransport(match)}`,
     `- ws reliable ${match.network.websocket_snapshot_reliable_sent} | wt datagram ${match.network.webtransport_snapshot_datagram_sent} | wt reliable ${match.network.webtransport_snapshot_reliable_sent}`,
-    `- fallbacks ${match.network.datagram_fallbacks} | strict drops ${match.network.strict_snapshot_drops} | malformed ${match.network.malformed_packets}`,
+    `- fallbacks ${match.network.datagram_fallbacks} | strict drops ${strictDropFailures(match)} (closed ${match.network.strict_snapshot_drop_connection_closed}) | malformed ${match.network.malformed_packets}`,
     `- battery sync ${match.network.battery_sync_packets_sent} packets / ${fmtBytes(match.network.battery_sync_bytes_sent)} | local energy ${match.network.local_player_energy_packets_sent} packets / ${fmtBytes(match.network.local_player_energy_bytes_sent)}`,
     '',
     '### Snapshot Shape',
@@ -931,7 +933,7 @@ function matchMarkdown(match: MatchStatsSnapshot, simHz: number): string {
     '### Players',
     '| ID | Health | Transport | Latency | In-buf | HP | Position (m) | Speed | Status | Net-jitter | Bundle | Correction | Phys-ms |',
     '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |',
-    ...(match.players.length > 0 ? match.players.map(playerRowMarkdown) : ['| — | — | — | — | — | — | — | — | — | — | — | — | — |']),
+    ...(match.players.length > 0 ? match.players.map((player) => playerRowMarkdown(player, simHz)) : ['| — | — | — | — | — | — | — | — | — | — | — | — | — |']),
   ];
   return lines.join('\n');
 }
@@ -1059,7 +1061,7 @@ function computeTransportSegments(match: MatchStatsSnapshot): BreakdownSegment[]
     { label: 'WS reliable', value: match.network.websocket_snapshot_reliable_sent, color: BLUE },
     { label: 'WT datagram', value: match.network.webtransport_snapshot_datagram_sent, color: GREEN },
     { label: 'WT reliable', value: match.network.webtransport_snapshot_reliable_sent, color: YELLOW },
-    { label: 'Strict drops', value: match.network.strict_snapshot_drops, color: RED },
+    { label: 'Strict drops', value: strictDropFailures(match), color: RED },
   ];
   return segments.filter((segment) => segment.value > 0);
 }
@@ -1120,10 +1122,15 @@ function buildConstraintAlerts(match: MatchStatsSnapshot, simHz: number): Constr
     });
   }
 
-  if (match.network.strict_snapshot_drops > 0) {
+  if (strictDropFailures(match) > 0) {
     alerts.push({
       tone: 'danger',
-      text: `Strict WT drops ${match.network.strict_snapshot_drops} (target 0)`,
+      text: `Strict WT drops ${strictDropFailures(match)} (target 0)`,
+    });
+  } else if (match.network.strict_snapshot_drop_connection_closed > 0) {
+    alerts.push({
+      tone: 'good',
+      text: `${match.network.strict_snapshot_drop_connection_closed} benign close-drops (target 0 failures)`,
     });
   }
 
@@ -1154,14 +1161,14 @@ function sortPlayers(players: PlayerStatsSnapshot[]): PlayerStatsSnapshot[] {
   );
 }
 
-function riskLabel(player: PlayerStatsSnapshot): string {
+function riskLabel(player: PlayerStatsSnapshot, simHz: number): string {
   if (player.pending_inputs >= 20) {
     return 'input backlog';
   }
   if (player.one_way_ms >= 100) {
     return 'high latency';
   }
-  if (player.input_jitter_ms >= 20) {
+  if (player.input_jitter_ms >= jitterThresholds(player, simHz).watchMax) {
     return 'high jitter';
   }
   if (player.has_debug_stats && player.correction_m >= 0.5) {
@@ -1170,7 +1177,7 @@ function riskLabel(player: PlayerStatsSnapshot): string {
   if (player.dead) {
     return 'dead';
   }
-  return playerPressureSeverity(player) === 'celebrate' ? 'clean link' : 'stable';
+  return playerPressureSeverity(player, simHz) === 'celebrate' ? 'clean link' : 'stable';
 }
 
 function OverviewStat({
@@ -1574,7 +1581,7 @@ function DistributionChart({
   );
 }
 
-function HotspotList({ players }: { players: PlayerStatsSnapshot[] }) {
+function HotspotList({ players, simHz }: { players: PlayerStatsSnapshot[]; simHz: number }) {
   const hotPlayers = sortPlayers(players).slice(0, 5);
   if (hotPlayers.length === 0) {
     return <div style={styles.emptyState}>No connected players.</div>;
@@ -1583,7 +1590,7 @@ function HotspotList({ players }: { players: PlayerStatsSnapshot[] }) {
   return (
     <div style={styles.hotspotList}>
       {hotPlayers.map((player) => {
-        const tone = playerPressureSeverity(player);
+        const tone = playerPressureSeverity(player, simHz);
         const visual = severityVisual(tone);
         return (
         <div
@@ -1597,7 +1604,7 @@ function HotspotList({ players }: { players: PlayerStatsSnapshot[] }) {
           <div>
             <div style={styles.hotspotTitleRow}>
               <SeverityBadge tone={tone} />
-              <div style={{ ...styles.hotspotTitle, color: visual.color }}>{`P${player.id} · ${riskLabel(player)}`}</div>
+              <div style={{ ...styles.hotspotTitle, color: visual.color }}>{`P${player.id} · ${riskLabel(player, simHz)}`}</div>
             </div>
             <div style={styles.hotspotMeta}>
               {`${player.transport === 'webtransport' ? 'WT' : 'WS'} · ${statusStr(player)} · ${fmtPos(player.pos_m)}`}
@@ -1639,7 +1646,7 @@ function MetricCell({
   );
 }
 
-function PlayersTable({ players }: { players: PlayerStatsSnapshot[] }) {
+function PlayersTable({ players, simHz }: { players: PlayerStatsSnapshot[]; simHz: number }) {
   const sorted = sortPlayers(players);
   if (sorted.length === 0) {
     return <div style={styles.emptyState}>No connected players.</div>;
@@ -1657,10 +1664,11 @@ function PlayersTable({ players }: { players: PlayerStatsSnapshot[] }) {
         </thead>
         <tbody>
           {sorted.map((player) => {
-            const rowSeverity = playerPressureSeverity(player);
+            const rowSeverity = playerPressureSeverity(player, simHz);
             const latencySeverity = lowerIsBetterSeverity(player.one_way_ms, 25, 60, 100);
             const pendingSeverity = lowerIsBetterSeverity(player.pending_inputs, 2, 8, 20);
-            const jitterSeverity = lowerIsBetterSeverity(player.input_jitter_ms, 4, 10, 20);
+            const jitterThresh = jitterThresholds(player, simHz);
+            const jitterSeverity = lowerIsBetterSeverity(player.input_jitter_ms, jitterThresh.celebrateMax, jitterThresh.goodMax, jitterThresh.watchMax);
             const correctionSeverity = player.has_debug_stats ? lowerIsBetterSeverity(player.correction_m, 0.03, 0.1, 0.5) : 'neutral';
             const physicsSeverity = player.has_debug_stats ? lowerIsBetterSeverity(player.physics_ms, 2, 4, 8) : 'neutral';
             const visual = severityVisual(rowSeverity);
@@ -1769,7 +1777,7 @@ function MatchPanel({
   const payloadTone = snapshotPayloadSeverity(match);
   const backlogTone = backlogSeverity(match);
   const transportTone = relevantTransportSeverity(match);
-  const playersTone = worstSeverity(match.players.map(playerPressureSeverity));
+  const playersTone = worstSeverity(match.players.map((player) => playerPressureSeverity(player, simHz)));
   const tickSegments = computeTickSegments(match, simHz);
   const playerSegments = computePlayerSegments(match);
   const transportSegments = computeTransportSegments(match);
@@ -1826,8 +1834,10 @@ function MatchPanel({
   const zeroIssueRows: ConstraintRow[] = [
     {
       label: 'strict drops',
-      value: match.network.strict_snapshot_drops,
-      display: fmtInt(match.network.strict_snapshot_drops),
+      value: strictDropFailures(match),
+      display: match.network.strict_snapshot_drop_connection_closed > 0
+        ? `${fmtInt(strictDropFailures(match))} (+${fmtInt(match.network.strict_snapshot_drop_connection_closed)} closed)`
+        : fmtInt(strictDropFailures(match)),
     },
     {
       label: 'dropped snapshots',
@@ -2111,12 +2121,12 @@ function MatchPanel({
         </DashboardCard>
 
         <DashboardCard title="Top Pressure Players" subtitle="Sorted by backlog, latency, jitter, and correction pressure" severity={playersTone}>
-          <HotspotList players={match.players} />
+          <HotspotList players={match.players} simHz={simHz} />
         </DashboardCard>
       </div>
 
       <DashboardCard title="Players" subtitle="Scrollable table, sorted by highest pressure first" severity={playersTone}>
-        <PlayersTable players={match.players} />
+        <PlayersTable players={match.players} simHz={simHz} />
       </DashboardCard>
     </section>
   );

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -78,6 +78,9 @@ const COLD_DYNAMIC_REFRESH_TICKS: u32 = SIM_HZ as u32;
 const HOT_LINEAR_SPEED_THRESHOLD_MPS: f32 = 0.05;
 const HOT_ANGULAR_SPEED_THRESHOLD_RADPS: f32 = 0.05;
 const HOT_DYNAMIC_NEAR_RADIUS_M: f32 = 12.0;
+const HOT_PLAYER_NEAR_RADIUS_M: f32 = 30.0;
+const HOT_PLAYER_SPEED_THRESHOLD_MPS: f32 = 2.0;
+const COLD_PLAYER_REFRESH_TICKS: u32 = SIM_HZ as u32;
 const MATCH_HEALTH_LOG_INTERVAL_TICKS: u32 = SIM_HZ as u32 * 10;
 const STRICT_SNAPSHOT_DATAGRAM_TARGET_BYTES: usize = 1100;
 const SNAPSHOT_HEADER_BYTES: usize = 23;
@@ -85,9 +88,13 @@ const SNAPSHOT_PLAYER_STATE_BYTES: usize = 29;
 const SNAPSHOT_DYNAMIC_BODY_STATE_BYTES: usize = 43;
 const SNAPSHOT_VEHICLE_STATE_BYTES: usize = 50;
 const STRICT_SNAPSHOT_RESERVED_VEHICLES: usize = 2;
-const SNAPSHOT_V2_HEADER_BYTES: usize = 23;
+// V2 header now carries an extra byte for the cold-remote-player count.
+const SNAPSHOT_V2_HEADER_BYTES: usize = 24;
 const SNAPSHOT_V2_SELF_PLAYER_BYTES: usize = 12;
 const SNAPSHOT_V2_REMOTE_PLAYER_BYTES: usize = 19;
+// Cold remote-player record: handle(1) + dx/dy/dz(6) + yaw(2) + flags(1).
+// Pitch, hp, and velocity are reused from the last hot packet on the client.
+const SNAPSHOT_V2_REMOTE_PLAYER_COLD_BYTES: usize = 10;
 const SNAPSHOT_V2_DYNAMIC_SPHERE_BYTES: usize = 20;
 const SNAPSHOT_V2_DYNAMIC_BOX_BYTES: usize = 28;
 const SNAPSHOT_V2_VEHICLE_BYTES: usize = 30;
@@ -512,6 +519,7 @@ struct PlayerStatsSnapshot {
     dead: bool,
     // Server-observed network quality
     input_jitter_ms: f32,
+    input_period_ms: f32,
     avg_bundle_size: f32,
     // Client-reported experience metrics (1 Hz)
     correction_m: f32,
@@ -644,6 +652,7 @@ struct PlayerRuntime {
     last_sent_dynamic_body_pose: HashMap<u32, ([f32; 3], [f32; 4])>,
     last_sent_vehicle_tick: HashMap<u32, u32>,
     last_sent_dynamic_tick: HashMap<u32, u32>,
+    last_sent_remote_player_tick: HashMap<u32, u32>,
 }
 
 #[derive(Clone, Copy)]
@@ -1447,6 +1456,7 @@ impl MatchState {
                         last_sent_dynamic_body_pose: HashMap::new(),
                         last_sent_vehicle_tick: HashMap::new(),
                         last_sent_dynamic_tick: HashMap::new(),
+                        last_sent_remote_player_tick: HashMap::new(),
                     },
                 );
                 self.activate_spawn_protection(conn.player_id);
@@ -1971,16 +1981,16 @@ impl MatchState {
             if let Some((pos, vel, _yaw, _pitch, hp, flags)) = self.arena.snapshot_player(player_id)
             {
                 positions.push(pos);
-                // Jitter = stddev of inter-arrival intervals
-                let input_jitter_ms = {
+                // Jitter = stddev of inter-arrival intervals; period = their mean.
+                let (input_jitter_ms, input_period_ms) = {
                     let ivs = &runtime.bundle_intervals_ms;
                     if ivs.len() >= 2 {
                         let mean = ivs.iter().sum::<f32>() / ivs.len() as f32;
                         let var =
                             ivs.iter().map(|&x| (x - mean).powi(2)).sum::<f32>() / ivs.len() as f32;
-                        var.sqrt()
+                        (var.sqrt(), mean)
                     } else {
-                        0.0
+                        (0.0, 0.0)
                     }
                 };
                 let avg_bundle_size = if runtime.bundle_sizes.is_empty() {
@@ -2004,6 +2014,7 @@ impl MatchState {
                     in_vehicle: (flags & 0x2) != 0,
                     dead: (flags & 0x4) != 0,
                     input_jitter_ms,
+                    input_period_ms,
                     avg_bundle_size,
                     correction_m: runtime.client_correction_m,
                     physics_ms: runtime.client_physics_ms,
@@ -3126,7 +3137,8 @@ impl MatchState {
                 .saturating_mul(SNAPSHOT_V2_VEHICLE_BYTES);
             budget_remaining = budget_remaining.saturating_sub(reserved_vehicle_budget);
 
-            let mut remote_player_states = Vec::new();
+            let mut remote_hot: Vec<(u32, f32, protocol::RemotePlayerStateV2)> = Vec::new();
+            let mut remote_cold: Vec<(u32, f32, protocol::RemotePlayerColdStateV2)> = Vec::new();
             for (player_id, pos, state) in player_states.iter().filter(|(player_id, pos, _)| {
                 *player_id != recipient_id
                     && distance_sq(*pos, *recipient_pos)
@@ -3138,23 +3150,75 @@ impl MatchState {
                 let Some((dx, dy, dz)) = quantize_relative_vec_q2_5mm(*recipient_pos, *pos) else {
                     continue;
                 };
+                let dist_sq = distance_sq(*pos, *recipient_pos);
+                let moving = speed_sq3([
+                    cms_to_mps(state.vx_cms),
+                    cms_to_mps(state.vy_cms),
+                    cms_to_mps(state.vz_cms),
+                ]) > HOT_PLAYER_SPEED_THRESHOLD_MPS * HOT_PLAYER_SPEED_THRESHOLD_MPS;
+                let needs_refresh = runtime
+                    .last_sent_remote_player_tick
+                    .get(player_id)
+                    .map(|last| self.server_tick.saturating_sub(*last) >= COLD_PLAYER_REFRESH_TICKS)
+                    .unwrap_or(true);
+                let hot = moving
+                    || dist_sq <= HOT_PLAYER_NEAR_RADIUS_M * HOT_PLAYER_NEAR_RADIUS_M
+                    || needs_refresh;
+                if hot {
+                    remote_hot.push((
+                        *player_id,
+                        dist_sq,
+                        protocol::RemotePlayerStateV2 {
+                            handle,
+                            dx_q2_5mm: dx,
+                            dy_q2_5mm: dy,
+                            dz_q2_5mm: dz,
+                            vx_cms: state.vx_cms,
+                            vy_cms: state.vy_cms,
+                            vz_cms: state.vz_cms,
+                            yaw_i16: state.yaw_i16,
+                            pitch_i16: state.pitch_i16,
+                            hp: state.hp,
+                            flags: (state.flags & 0xff) as u8,
+                        },
+                    ));
+                } else {
+                    remote_cold.push((
+                        *player_id,
+                        dist_sq,
+                        protocol::RemotePlayerColdStateV2 {
+                            handle,
+                            dx_q2_5mm: dx,
+                            dy_q2_5mm: dy,
+                            dz_q2_5mm: dz,
+                            yaw_i16: state.yaw_i16,
+                            flags: (state.flags & 0xff) as u8,
+                        },
+                    ));
+                }
+            }
+            remote_hot.sort_by(|a, b| a.1.total_cmp(&b.1));
+            remote_cold.sort_by(|a, b| a.1.total_cmp(&b.1));
+
+            let mut remote_player_states = Vec::new();
+            for (player_id, _, record) in remote_hot.into_iter() {
                 if budget_remaining < SNAPSHOT_V2_REMOTE_PLAYER_BYTES {
                     break;
                 }
-                remote_player_states.push(protocol::RemotePlayerStateV2 {
-                    handle,
-                    dx_q2_5mm: dx,
-                    dy_q2_5mm: dy,
-                    dz_q2_5mm: dz,
-                    vx_cms: state.vx_cms,
-                    vy_cms: state.vy_cms,
-                    vz_cms: state.vz_cms,
-                    yaw_i16: state.yaw_i16,
-                    pitch_i16: state.pitch_i16,
-                    hp: state.hp,
-                    flags: (state.flags & 0xff) as u8,
-                });
+                runtime
+                    .last_sent_remote_player_tick
+                    .insert(player_id, self.server_tick);
+                remote_player_states.push(record);
                 budget_remaining = budget_remaining.saturating_sub(SNAPSHOT_V2_REMOTE_PLAYER_BYTES);
+            }
+            let mut remote_cold_states = Vec::new();
+            for (_, _, record) in remote_cold.into_iter() {
+                if budget_remaining < SNAPSHOT_V2_REMOTE_PLAYER_COLD_BYTES {
+                    break;
+                }
+                remote_cold_states.push(record);
+                budget_remaining =
+                    budget_remaining.saturating_sub(SNAPSHOT_V2_REMOTE_PLAYER_COLD_BYTES);
             }
 
             let mut selected_vehicle_states = Vec::new();
@@ -3404,6 +3468,7 @@ impl MatchState {
                 anchor_pz_mm: local_player_state.pz_mm,
                 self_state,
                 remote_players: remote_player_states,
+                cold_remote_players: remote_cold_states,
                 sphere_states,
                 box_states,
                 vehicle_states: selected_vehicle_states,
@@ -3592,7 +3657,9 @@ fn dynamic_body_within_aoi(was_visible: bool, body_pos: [f32; 3], recipient_pos:
 fn packet_player_count(packet: &ServerPacket) -> usize {
     match packet {
         ServerPacket::Snapshot(snapshot) => snapshot.player_states.len(),
-        ServerPacket::SnapshotV2(snapshot) => 1 + snapshot.remote_players.len(),
+        ServerPacket::SnapshotV2(snapshot) => {
+            1 + snapshot.remote_players.len() + snapshot.cold_remote_players.len()
+        }
         _ => 0,
     }
 }
@@ -3778,6 +3845,7 @@ mod tests {
             last_sent_dynamic_body_pose: HashMap::new(),
             last_sent_vehicle_tick: HashMap::new(),
             last_sent_dynamic_tick: HashMap::new(),
+            last_sent_remote_player_tick: HashMap::new(),
         }
     }
 

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -99,6 +99,19 @@ pub struct RemotePlayerStateV2 {
     pub flags: u8,
 }
 
+/// Compact remote-player record for far, slow-moving peers. Clients reuse the
+/// last known hp, pitch, and velocity from the previous hot record for this
+/// handle; hp/pitch are refreshed at least once per `COLD_PLAYER_REFRESH_TICKS`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RemotePlayerColdStateV2 {
+    pub handle: u8,
+    pub dx_q2_5mm: i16,
+    pub dy_q2_5mm: i16,
+    pub dz_q2_5mm: i16,
+    pub yaw_i16: i16,
+    pub flags: u8,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DynamicSphereStateV2 {
     pub handle: u16,
@@ -161,6 +174,7 @@ pub struct SnapshotV2Packet {
     pub anchor_pz_mm: i32,
     pub self_state: SelfPlayerStateV2,
     pub remote_players: Vec<RemotePlayerStateV2>,
+    pub cold_remote_players: Vec<RemotePlayerColdStateV2>,
     pub sphere_states: Vec<DynamicSphereStateV2>,
     pub box_states: Vec<DynamicBoxStateV2>,
     pub vehicle_states: Vec<VehicleStateV2>,
@@ -510,6 +524,7 @@ pub fn encode_server_datagram(packet: &ServerDatagramPacket) -> Vec<u8> {
             out.put_i32_le(pkt.anchor_py_mm);
             out.put_i32_le(pkt.anchor_pz_mm);
             out.put_u8(pkt.remote_players.len() as u8);
+            out.put_u8(pkt.cold_remote_players.len() as u8);
             out.put_u8(pkt.sphere_states.len() as u8);
             out.put_u8(pkt.box_states.len() as u8);
             out.put_u8(pkt.vehicle_states.len() as u8);
@@ -534,6 +549,15 @@ pub fn encode_server_datagram(packet: &ServerDatagramPacket) -> Vec<u8> {
                 out.put_i16_le(player.yaw_i16);
                 out.put_i16_le(player.pitch_i16);
                 out.put_u8(player.hp);
+                out.put_u8(player.flags);
+            }
+
+            for player in &pkt.cold_remote_players {
+                out.put_u8(player.handle);
+                out.put_i16_le(player.dx_q2_5mm);
+                out.put_i16_le(player.dy_q2_5mm);
+                out.put_i16_le(player.dz_q2_5mm);
+                out.put_i16_le(player.yaw_i16);
                 out.put_u8(player.flags);
             }
 

--- a/shared/src/physics_arena/spawn.rs
+++ b/shared/src/physics_arena/spawn.rs
@@ -138,9 +138,7 @@ impl PhysicsArena {
                     area.radius as f64,
                 )
             };
-            for (candidate_rank, (x, z)) in
-                spawn_area_candidates(cx, cz, radius).enumerate()
-            {
+            for (candidate_rank, (x, z)) in spawn_area_candidates(cx, cz, radius).enumerate() {
                 let score = self.min_player_distance_sq(x, z);
                 let clear = self.spawn_lane_is_clear(x, z);
                 let candidate_rank = candidate_rank as u32;


### PR DESCRIPTION
## Summary
This PR introduces a two-tier remote player state system that separates "hot" (frequently updated) and "cold" (infrequently updated) player records in snapshot packets. Cold players are sent with a compact 10-byte record instead of the full 19-byte hot record, significantly reducing bandwidth for far or stationary players.

## Key Changes

**Server-side (Rust)**
- Added three new constants for cold player tracking:
  - `HOT_PLAYER_NEAR_RADIUS_M`: 30m radius for proximity-based hot classification
  - `HOT_PLAYER_SPEED_THRESHOLD_MPS`: 2.0 m/s speed threshold for hot classification
  - `COLD_PLAYER_REFRESH_TICKS`: Refresh interval to guarantee periodic full updates
- Introduced `RemotePlayerColdStateV2` struct (10 bytes): handle, relative position (dx/dy/dz), yaw, and flags only
- Updated `SnapshotV2Packet` to include separate `cold_remote_players` vector
- Modified snapshot encoding to:
  - Classify players as hot (moving, nearby, or needing refresh) or cold (stationary and far)
  - Sort both lists by distance for priority-based inclusion
  - Track last sent tick per remote player to enforce refresh intervals
- Increased `SNAPSHOT_V2_HEADER_BYTES` from 23 to 24 to accommodate cold player count byte
- Added `input_period_ms` field to `PlayerStatsSnapshot` for jitter analysis

**Client-side (TypeScript)**
- Added `RemotePlayerColdStateV2` protocol type matching server definition
- Updated `SnapshotV2Packet` type to include `coldRemotePlayers` array
- Implemented cold player processing in `NetcodeClient`:
  - Reuses hp, pitch, and velocity from the last hot record for the same handle
  - Waits for a hot refresh if no prior record exists
  - Sets velocity to [0, 0, 0] for cold updates
- Updated bot snapshot handling to preserve prior player state when applying cold updates
- Fixed telemetry to count both hot and cold players in snapshot statistics

**Analytics & Testing**
- Added `strictDropFailures()` function to exclude benign connection-closed drops from failure counts
- Added `zeroToleranceFailures()` function combining strict drops, dropped snapshots, and malformed packets
- Implemented `jitterThresholds()` function that adapts jitter expectations based on client input period:
  - Tight thresholds (4/10/20 ms) for clients sampling at sim rate
  - Proportionally widened thresholds for slower clients (e.g., 15 Hz bots vs 60 Hz sim)
- Updated UI and reporting to use new failure classification functions
- Updated test fixtures to include `input_period_ms` field

## Notable Implementation Details

- **Bandwidth savings**: Cold players use 47% less bandwidth (10 vs 19 bytes) while maintaining acceptable update frequency
- **Refresh guarantee**: Server tracks per-player last-sent tick to ensure cold players receive full updates at least once per `COLD_PLAYER_REFRESH_TICKS`
- **Client-side interpolation**: Cold records inherit hp/pitch/velocity from prior hot records, reducing data duplication while maintaining smooth client-side state
- **Distance-based priority**: Both hot and cold players are sorted by distance to recipient, ensuring nearest players are included first within bandwidth budget
- **Jitter analysis improvement**: Input period tracking enables more accurate assessment of network quality by distinguishing between client sampling rate and actual jitter

https://claude.ai/code/session_01BJ1ZXgjB9sHbZQg5oxq7sV