### PR TITLE
Add low energy warning UI component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,6 +19,7 @@ import { ControlHintsOverlay } from './ui/ControlHintsOverlay';
 import { ControlsSettingsPanel } from './ui/ControlsSettingsPanel';
 import { debugStatsToMarkdown, DebugOverlay, type DebugStats } from './ui/DebugOverlay';
 import { EnergyBar } from './ui/EnergyBar';
+import { LowEnergyWarning } from './ui/LowEnergyWarning';
 import { MeleeHUD } from './ui/MeleeHUD';
 import { MobileHUD } from './ui/MobileHUD';
 import { SpawnProtectionHUD } from './ui/SpawnProtectionHUD';
@@ -1052,6 +1053,10 @@ export function App({
       />
       <EnergyBar
         hp={displayStats.hp}
+        energy={displayStats.energy}
+        visible={connected}
+      />
+      <LowEnergyWarning
         energy={displayStats.energy}
         visible={connected}
       />

--- a/client/src/ui/LowEnergyWarning.tsx
+++ b/client/src/ui/LowEnergyWarning.tsx
@@ -1,0 +1,63 @@
+import { type CSSProperties } from 'react';
+
+const LOW_ENERGY_THRESHOLD = 250;
+
+type Props = {
+  energy: number;
+  visible: boolean;
+};
+
+export function LowEnergyWarning({ energy, visible }: Props) {
+  if (!visible || energy <= 0 || energy >= LOW_ENERGY_THRESHOLD) return null;
+
+  return (
+    <>
+      <style>{`
+        @keyframes energy-warn-pulse {
+          0%, 100% { opacity: 0.9; }
+          50% { opacity: 1; box-shadow: 0 0 18px 4px rgba(243,192,66,0.45); }
+        }
+      `}</style>
+      <div style={containerStyle}>
+        <span style={titleStyle}>ENERGY RUNNING LOW</span>
+        <span style={bodyStyle}>
+          Collect the glowing yellow batteries on the ground to recharge
+        </span>
+      </div>
+    </>
+  );
+}
+
+const containerStyle: CSSProperties = {
+  position: 'absolute',
+  bottom: 72,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 4,
+  padding: '10px 18px',
+  background: 'rgba(20, 14, 0, 0.82)',
+  border: '1px solid rgba(243,192,66,0.6)',
+  borderRadius: 8,
+  color: '#f3c042',
+  font: '13px/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, monospace',
+  pointerEvents: 'none',
+  userSelect: 'none',
+  zIndex: 20,
+  whiteSpace: 'nowrap',
+  animation: 'energy-warn-pulse 1.4s ease-in-out infinite',
+};
+
+const titleStyle: CSSProperties = {
+  fontWeight: 700,
+  fontSize: 13,
+  letterSpacing: 1.5,
+};
+
+const bodyStyle: CSSProperties = {
+  fontWeight: 400,
+  fontSize: 12,
+  opacity: 0.85,
+};


### PR DESCRIPTION
## Summary
Added a new `LowEnergyWarning` component that displays a pulsing warning message when the player's energy drops below a threshold, guiding them to collect batteries for recharge.

## Changes
- **New component**: Created `LowEnergyWarning.tsx` with:
  - Energy threshold set to 250
  - Pulsing animation with golden glow effect
  - Centered positioning above the energy bar
  - Instructional text directing players to collect yellow batteries
  - Monospace font styling matching the game's UI aesthetic
  
- **Integration**: Added `LowEnergyWarning` component to `App.tsx` to render alongside other HUD elements, passing energy and visibility state

## Implementation Details
- Component only renders when energy is between 0 and 250 (exclusive)
- Uses CSS keyframe animation for continuous pulse effect with box-shadow glow
- Styled with dark semi-transparent background and golden border/text color
- Non-interactive (`pointerEvents: 'none'`) to avoid blocking user input
- Positioned absolutely at `bottom: 72px` to sit above the energy bar

https://claude.ai/code/session_01Ua3MkcQB7uxFMRzEVzKZAb