### PR TITLE
Add authored destructible structures with chunk-based composition

### DIFF
--- a/client/src/ai/systemPrompt.ts
+++ b/client/src/ai/systemPrompt.ts
@@ -30,6 +30,28 @@ type WorldDocument = {
     radius?: number;              // ball only
     vehicleType?: number;         // vehicle only
   }>;
+  destructibles: Array<
+    | { id: number; kind: 'wall' | 'tower'; position: [x,y,z]; rotation: [x,y,z,w] }
+    | {
+        id: number;
+        kind: 'structure';
+        position: [x, y, z];
+        rotation: [x, y, z, w];
+        density?: number;              // kg/m³, default 2400
+        solverMaterialScale?: number;  // Blast stiffness multiplier, default 1
+        chunks: Array<{
+          shape: 'box' | 'sphere' | 'capsule';
+          position: [x, y, z];           // in structure-local frame
+          rotation: [x, y, z, w];
+          halfExtents?: [hx, hy, hz];    // box only
+          radius?: number;               // sphere + capsule
+          height?: number;               // capsule cylinder segment (caps excluded)
+          mass?: number;                 // overrides density-derived mass
+          material?: string;
+          anchor?: boolean;              // static support; replaces implicit y==0 rule
+        }>;
+      }
+  >;
 };
 \`\`\`
 
@@ -123,6 +145,98 @@ Terrain write helpers also return when changed: \`samplesAffected, deltaMin, del
 - \`ctx.deformTerrainAlongSpline({ splineId, profile, mode?, applyMode?, strength?, falloff?, sampleSpacing? })\` — powerful profile-based terrain deformation along a spline (see Splines section below).
 - \`ctx.applyTerrainRamp(stencil)\` — see TerrainRampStencil below.
 - \`ctx.addTerrainTile(tileX, tileZ)\` / \`ctx.removeTerrainTile(tileX, tileZ)\`
+
+## Destructible structures
+
+Destructibles are authored assemblies of chunks that fracture under impact. Single-player runs them through NVIDIA Blast's stress solver (chunks stay bonded until the solver tears bonds apart). Multiplayer falls back to independent dynamic rigid bodies — one per chunk — so in MP a structure just collapses into loose pieces.
+
+**Read:**
+- \`ctx.listDestructibles()\` → full array of destructibles (factory + structures with chunks).
+- \`ctx.getDestructible(id)\` → one destructible or null.
+
+**Create / remove:**
+- \`ctx.addDestructibleStructure({ position, rotation?, density?, solverMaterialScale?, chunks })\` → \`{ changed, id?, reason? }\`. \`chunks\` must be a non-empty array (≤ 4096).
+- \`ctx.removeDestructible(id)\` → \`{ changed, reason? }\`.
+
+**Edit structure / factory pose:**
+- \`ctx.updateDestructible(id, { position?, rotation?, density?, solverMaterialScale? })\` → \`{ changed, reason? }\`. \`density\`/\`solverMaterialScale\` only valid for \`structure\` kind.
+
+**Chunk-level CRUD (structure kind only):**
+- \`ctx.addChunk(structureId, chunk)\` → \`{ changed, chunkIndex?, reason? }\`.
+- \`ctx.updateChunk(structureId, chunkIndex, patch)\` → \`{ changed, reason? }\`. Patch is a partial Chunk; shape-specific fields are re-validated against the merged result.
+- \`ctx.removeChunk(structureId, chunkIndex)\` → \`{ changed, reason? }\`. Refuses to remove the last chunk (use \`removeDestructible\` instead).
+- \`ctx.duplicateChunk(structureId, chunkIndex, offset?)\` → \`{ changed, chunkIndex?, reason? }\`. \`offset\` is an optional \`[dx, dy, dz]\` in structure-local space.
+
+**Convert a factory (wall / tower) to a structure you can edit:**
+- \`ctx.convertFactoryToStructure(id)\` → \`{ changed, reason? }\`. Expands the factory into its equivalent box chunks so \`addChunk\`/\`updateChunk\`/\`removeChunk\` can then operate on it. Calling any chunk-level helper on a factory destructible without converting first returns \`{ changed: false, reason: 'factory destructibles are immutable; convert to structure first' }\`.
+
+**Auto-bonding:** Blast wires bonds between any two chunks whose surfaces are in contact (within ~1 cm). **Leave no gaps** — a chunk floating 2 cm above its neighbor will not bond and will fall immediately. Overlap is fine (bonds still form); gaps are not.
+
+**Anchors:** \`anchor: true\` pins a chunk as a static support — it never moves. Anchors replace the old implicit \`y == 0\` rule, so mark the bottom row of any stacked structure as anchors, or the whole thing collapses on spawn. On the native server, non-box anchors fall back to tight-fit AABB cuboids.
+
+**Multiplayer reality:** in MP there is no stress solver — every non-anchor chunk is an independent dynamic body. Design structures so that removing bonds yields sensible physics: an arch in MP will collapse immediately unless both pillars are fully anchored. Anchors stay put in both single-player and multiplayer.
+
+**Authoring tips:**
+- Chunk positions are in the **structure's local frame**. The structure's own \`position\`/\`rotation\` applies on top.
+- Box chunks only pay for collider: \`halfExtents\` is required. Spheres need \`radius\`. Capsules need \`radius\` + \`height\` (cylinder segment; caps are added on top).
+- Mass defaults to \`volume × structure.density\`. Override with \`mass\` only when you need a specific value.
+- Max 4096 chunks per structure. Stay well under this for performance.
+
+**Worked example — build a 3-chunk arch:**
+\`\`\`js
+const halfSide = 0.25;      // each chunk is 0.5 m on a side
+const step = 2 * halfSide;   // 0.5 m
+const pillarHeight = 5;      // 5 chunks per pillar
+const span = 3 * step;       // lintel spans 3 chunks → 1.5 m outer-to-outer
+const pillarX = span * 0.5 - halfSide;
+const chunks = [];
+// Two pillars, bottom-anchored.
+for (const sign of [-1, 1]) {
+  for (let i = 0; i < pillarHeight; i++) {
+    chunks.push({
+      shape: 'box',
+      position: [sign * pillarX, halfSide + i * step, 0],
+      rotation: ctx.identityQuaternion(),
+      halfExtents: [halfSide, halfSide, halfSide],
+      anchor: i === 0,
+    });
+  }
+}
+// Lintel: 3 chunks resting on the pillar tops, no gap.
+const lintelY = halfSide + pillarHeight * step + halfSide;  // sits exactly on the pillars
+for (let i = -1; i <= 1; i++) {
+  chunks.push({
+    shape: 'box',
+    position: [i * step, lintelY, 0],
+    rotation: ctx.identityQuaternion(),
+    halfExtents: [halfSide, halfSide, halfSide],
+  });
+}
+const baseY = ctx.sampleTerrainHeight(0, 0);
+const { id, reason } = ctx.addDestructibleStructure({
+  position: [0, baseY, 0],
+  chunks,
+});
+return { id, chunkCount: chunks.length, reason };
+\`\`\`
+
+**Worked example — retune one chunk's mass and demolish a corner:**
+\`\`\`js
+const target = ctx.listDestructibles().find((d) => d.kind === 'structure');
+if (!target) return { changed: false, reason: 'no structure in world' };
+// Make the top chunk heavier so it drops faster when bonds break.
+const topIdx = target.chunks.reduce(
+  (best, c, i, arr) => (c.position[1] > arr[best].position[1] ? i : best),
+  0,
+);
+const massResult = ctx.updateChunk(target.id, topIdx, { mass: 80 });
+// Knock out a corner chunk entirely.
+const cornerIdx = target.chunks.findIndex((c) => !c.anchor);
+const removeResult = cornerIdx >= 0
+  ? ctx.removeChunk(target.id, cornerIdx)
+  : { changed: false, reason: 'no dynamic chunk to remove' };
+return { massResult, removeResult };
+\`\`\`
 
 ## Spline helpers
 

--- a/client/src/ai/systemPrompt.ts
+++ b/client/src/ai/systemPrompt.ts
@@ -39,6 +39,7 @@ type WorldDocument = {
         rotation: [x, y, z, w];
         density?: number;              // kg/m³, default 2400
         solverMaterialScale?: number;  // Blast stiffness multiplier, default 1
+        fractured?: boolean;           // runtime: split each chunk into ~0.25m bricks, auto-bond
         chunks: Array<{
           shape: 'box' | 'sphere' | 'capsule';
           position: [x, y, z];           // in structure-local frame
@@ -155,11 +156,11 @@ Destructibles are authored assemblies of chunks that fracture under impact. Sing
 - \`ctx.getDestructible(id)\` → one destructible or null.
 
 **Create / remove:**
-- \`ctx.addDestructibleStructure({ position, rotation?, density?, solverMaterialScale?, chunks })\` → \`{ changed, id?, reason? }\`. \`chunks\` must be a non-empty array (≤ 4096).
+- \`ctx.addDestructibleStructure({ position, rotation?, density?, solverMaterialScale?, fractured?, chunks })\` → \`{ changed, id?, reason? }\`. \`chunks\` must be a non-empty array (≤ 4096).
 - \`ctx.removeDestructible(id)\` → \`{ changed, reason? }\`.
 
 **Edit structure / factory pose:**
-- \`ctx.updateDestructible(id, { position?, rotation?, density?, solverMaterialScale? })\` → \`{ changed, reason? }\`. \`density\`/\`solverMaterialScale\` only valid for \`structure\` kind.
+- \`ctx.updateDestructible(id, { position?, rotation?, density?, solverMaterialScale?, fractured? })\` → \`{ changed, reason? }\`. \`density\`/\`solverMaterialScale\`/\`fractured\` only valid for \`structure\` kind.
 
 **Chunk-level CRUD (structure kind only):**
 - \`ctx.addChunk(structureId, chunk)\` → \`{ changed, chunkIndex?, reason? }\`.
@@ -175,6 +176,8 @@ Destructibles are authored assemblies of chunks that fracture under impact. Sing
 **Anchors:** \`anchor: true\` pins a chunk as a static support — it never moves. Anchors replace the old implicit \`y == 0\` rule, so mark the bottom row of any stacked structure as anchors, or the whole thing collapses on spawn. On the native server, non-box anchors fall back to tight-fit AABB cuboids.
 
 **Multiplayer reality:** in MP there is no stress solver — every non-anchor chunk is an independent dynamic body. Design structures so that removing bonds yields sensible physics: an arch in MP will collapse immediately unless both pillars are fully anchored. Anchors stay put in both single-player and multiplayer.
+
+**Fractured structures (opt-in, default off):** set \`fractured: true\` on a structure and every **box** chunk is subdivided into brick-sized sub-chunks (~0.25 m edge) at spawn time; the Blast auto-bonder wires them into a rich network so impact damage fractures locally instead of destroying the whole chunk. Sphere / capsule chunks pass through unchanged for now. Sub-bricks inherit the parent chunk's \`anchor\` and \`material\`; explicit \`mass\` overrides are divided across them so total mass is preserved. Keep authored chunk counts reasonable — the post-fracture total must stay under 4096 per structure.
 
 **Authoring tips:**
 - Chunk positions are in the **structure's local frame**. The structure's own \`position\`/\`rotation\` applies on top.

--- a/client/src/ai/worldToolHelpers.ts
+++ b/client/src/ai/worldToolHelpers.ts
@@ -14,14 +14,18 @@ import {
   getTerrainTileCenter,
   getTerrainWorldBounds,
   identityQuaternion,
+  MAX_CHUNKS_PER_STRUCTURE,
   quaternionFromYaw,
   removeTerrainTile,
   sampleTerrainHeightAtWorldPosition,
   sampleTerrainHeightGrid,
   smoothTerrainBrush,
+  type Chunk,
+  type Destructible,
   type DynamicEntity,
   type Quaternion,
   type StaticProp,
+  type StructureDestructible,
   type TerrainRampStencil,
   type Vec3,
   type WorldDocument,
@@ -151,6 +155,46 @@ export type WorldCtx = {
       radius: number;
     }>,
   ): { changed: boolean; reason?: string };
+
+  // ---- DESTRUCTIBLES ----
+  listDestructibles(): Destructible[];
+  getDestructible(id: number): Destructible | null;
+  addDestructibleStructure(spec: {
+    position: Vec3;
+    rotation?: Quaternion;
+    density?: number;
+    solverMaterialScale?: number;
+    chunks: Chunk[];
+  }): { changed: boolean; id?: number; reason?: string };
+  removeDestructible(id: number): { changed: boolean; reason?: string };
+  updateDestructible(
+    id: number,
+    patch: Partial<{
+      position: Vec3;
+      rotation: Quaternion;
+      density: number;
+      solverMaterialScale: number;
+    }>,
+  ): { changed: boolean; reason?: string };
+  addChunk(
+    structureId: number,
+    chunk: Chunk,
+  ): { changed: boolean; chunkIndex?: number; reason?: string };
+  updateChunk(
+    structureId: number,
+    chunkIndex: number,
+    patch: Partial<Chunk>,
+  ): { changed: boolean; reason?: string };
+  removeChunk(
+    structureId: number,
+    chunkIndex: number,
+  ): { changed: boolean; reason?: string };
+  duplicateChunk(
+    structureId: number,
+    chunkIndex: number,
+    offset?: Vec3,
+  ): { changed: boolean; chunkIndex?: number; reason?: string };
+  convertFactoryToStructure(id: number): { changed: boolean; reason?: string };
 
   applyTerrainBrush(spec: {
     centerX: number;
@@ -476,6 +520,304 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
       return { changed };
     },
 
+    // ---- DESTRUCTIBLES ----
+    listDestructibles() {
+      return cloneArray(accessors.getWorld().destructibles);
+    },
+
+    getDestructible(id) {
+      const found = accessors.getWorld().destructibles.find((d) => d.id === id);
+      return found ? cloneJson(found) : null;
+    },
+
+    addDestructibleStructure(spec) {
+      if (!spec || typeof spec !== 'object') {
+        return { changed: false, reason: 'spec must be an object' };
+      }
+      const positionErr = validateVec3('position', spec.position);
+      if (positionErr) return { changed: false, reason: positionErr };
+      if (!Array.isArray(spec.chunks) || spec.chunks.length === 0) {
+        return { changed: false, reason: 'chunks must be a non-empty array' };
+      }
+      if (spec.chunks.length > MAX_CHUNKS_PER_STRUCTURE) {
+        return {
+          changed: false,
+          reason: `chunks length ${spec.chunks.length} exceeds max ${MAX_CHUNKS_PER_STRUCTURE}`,
+        };
+      }
+      const validatedChunks: Chunk[] = [];
+      for (let i = 0; i < spec.chunks.length; i += 1) {
+        const result = validateChunkInput(spec.chunks[i]);
+        if (!result.ok) return { changed: false, reason: `chunks[${i}]: ${result.reason}` };
+        validatedChunks.push(result.chunk);
+      }
+      let assignedId = 0;
+      const changed = aiEdit((current) => {
+        const id = getNextWorldEntityId(current);
+        assignedId = id;
+        const next: StructureDestructible = {
+          id,
+          kind: 'structure',
+          position: [...spec.position] as Vec3,
+          rotation: spec.rotation ? ([...spec.rotation] as Quaternion) : identityQuaternion(),
+          ...(typeof spec.density === 'number' ? { density: spec.density } : {}),
+          ...(typeof spec.solverMaterialScale === 'number'
+            ? { solverMaterialScale: spec.solverMaterialScale }
+            : {}),
+          chunks: validatedChunks,
+        };
+        return { ...current, destructibles: [...current.destructibles, next] };
+      });
+      return changed ? { changed, id: assignedId } : { changed };
+    },
+
+    removeDestructible(id) {
+      const world = accessors.getWorld();
+      if (!world.destructibles.some((d) => d.id === id)) {
+        return { changed: false, reason: `no destructible with id ${id}` };
+      }
+      const changed = aiEdit((current) => ({
+        ...current,
+        destructibles: current.destructibles.filter((d) => d.id !== id),
+      }));
+      return { changed };
+    },
+
+    updateDestructible(id, patch) {
+      if (!patch || typeof patch !== 'object') {
+        return { changed: false, reason: 'patch must be an object' };
+      }
+      if (patch.position) {
+        const err = validateVec3('position', patch.position);
+        if (err) return { changed: false, reason: err };
+      }
+      const found = accessors.getWorld().destructibles.find((d) => d.id === id);
+      if (!found) return { changed: false, reason: `no destructible with id ${id}` };
+      const isFactory = found.kind === 'wall' || found.kind === 'tower';
+      if (
+        isFactory
+        && (typeof patch.density === 'number' || typeof patch.solverMaterialScale === 'number')
+      ) {
+        return {
+          changed: false,
+          reason: 'density / solverMaterialScale only apply to structure destructibles',
+        };
+      }
+      const changed = aiEdit((current) => {
+        const idx = current.destructibles.findIndex((d) => d.id === id);
+        if (idx === -1) return current;
+        const target = current.destructibles[idx];
+        const nextList = [...current.destructibles];
+        if (target.kind === 'structure') {
+          nextList[idx] = {
+            ...target,
+            ...(patch.position ? { position: [...patch.position] as Vec3 } : {}),
+            ...(patch.rotation ? { rotation: [...patch.rotation] as Quaternion } : {}),
+            ...(typeof patch.density === 'number' ? { density: patch.density } : {}),
+            ...(typeof patch.solverMaterialScale === 'number'
+              ? { solverMaterialScale: patch.solverMaterialScale }
+              : {}),
+          };
+        } else {
+          nextList[idx] = {
+            ...target,
+            ...(patch.position ? { position: [...patch.position] as Vec3 } : {}),
+            ...(patch.rotation ? { rotation: [...patch.rotation] as Quaternion } : {}),
+          };
+        }
+        return { ...current, destructibles: nextList };
+      });
+      return { changed };
+    },
+
+    addChunk(structureId, chunk) {
+      const found = accessors.getWorld().destructibles.find((d) => d.id === structureId);
+      if (!found) return { changed: false, reason: `no destructible with id ${structureId}` };
+      if (found.kind !== 'structure') {
+        return {
+          changed: false,
+          reason: 'factory destructibles are immutable; convert to structure first',
+        };
+      }
+      if (found.chunks.length >= MAX_CHUNKS_PER_STRUCTURE) {
+        return {
+          changed: false,
+          reason: `structure ${structureId} is at max chunks (${MAX_CHUNKS_PER_STRUCTURE})`,
+        };
+      }
+      const result = validateChunkInput(chunk);
+      if (!result.ok) return { changed: false, reason: result.reason };
+      let assignedIndex = -1;
+      const changed = aiEdit((current) => {
+        const idx = current.destructibles.findIndex((d) => d.id === structureId);
+        if (idx === -1) return current;
+        const target = current.destructibles[idx];
+        if (target.kind !== 'structure') return current;
+        assignedIndex = target.chunks.length;
+        const updated: StructureDestructible = {
+          ...target,
+          chunks: [...target.chunks, result.chunk],
+        };
+        const nextList = [...current.destructibles];
+        nextList[idx] = updated;
+        return { ...current, destructibles: nextList };
+      });
+      return changed ? { changed, chunkIndex: assignedIndex } : { changed };
+    },
+
+    updateChunk(structureId, chunkIndex, patch) {
+      if (!patch || typeof patch !== 'object') {
+        return { changed: false, reason: 'patch must be an object' };
+      }
+      const found = accessors.getWorld().destructibles.find((d) => d.id === structureId);
+      if (!found) return { changed: false, reason: `no destructible with id ${structureId}` };
+      if (found.kind !== 'structure') {
+        return {
+          changed: false,
+          reason: 'factory destructibles are immutable; convert to structure first',
+        };
+      }
+      if (chunkIndex < 0 || chunkIndex >= found.chunks.length) {
+        return {
+          changed: false,
+          reason: `chunk index ${chunkIndex} out of range [0, ${found.chunks.length})`,
+        };
+      }
+      const merged: Chunk = { ...found.chunks[chunkIndex], ...patch };
+      const result = validateChunkInput(merged);
+      if (!result.ok) return { changed: false, reason: result.reason };
+      const changed = aiEdit((current) => {
+        const idx = current.destructibles.findIndex((d) => d.id === structureId);
+        if (idx === -1) return current;
+        const target = current.destructibles[idx];
+        if (target.kind !== 'structure') return current;
+        if (chunkIndex >= target.chunks.length) return current;
+        const nextChunks = [...target.chunks];
+        nextChunks[chunkIndex] = result.chunk;
+        const updated: StructureDestructible = { ...target, chunks: nextChunks };
+        const nextList = [...current.destructibles];
+        nextList[idx] = updated;
+        return { ...current, destructibles: nextList };
+      });
+      return { changed };
+    },
+
+    removeChunk(structureId, chunkIndex) {
+      const found = accessors.getWorld().destructibles.find((d) => d.id === structureId);
+      if (!found) return { changed: false, reason: `no destructible with id ${structureId}` };
+      if (found.kind !== 'structure') {
+        return {
+          changed: false,
+          reason: 'factory destructibles are immutable; convert to structure first',
+        };
+      }
+      if (chunkIndex < 0 || chunkIndex >= found.chunks.length) {
+        return {
+          changed: false,
+          reason: `chunk index ${chunkIndex} out of range [0, ${found.chunks.length})`,
+        };
+      }
+      if (found.chunks.length === 1) {
+        return {
+          changed: false,
+          reason: 'cannot remove last chunk; use removeDestructible to remove the whole structure',
+        };
+      }
+      const changed = aiEdit((current) => {
+        const idx = current.destructibles.findIndex((d) => d.id === structureId);
+        if (idx === -1) return current;
+        const target = current.destructibles[idx];
+        if (target.kind !== 'structure') return current;
+        const nextChunks = target.chunks.filter((_, i) => i !== chunkIndex);
+        const updated: StructureDestructible = { ...target, chunks: nextChunks };
+        const nextList = [...current.destructibles];
+        nextList[idx] = updated;
+        return { ...current, destructibles: nextList };
+      });
+      return { changed };
+    },
+
+    duplicateChunk(structureId, chunkIndex, offset) {
+      const found = accessors.getWorld().destructibles.find((d) => d.id === structureId);
+      if (!found) return { changed: false, reason: `no destructible with id ${structureId}` };
+      if (found.kind !== 'structure') {
+        return {
+          changed: false,
+          reason: 'factory destructibles are immutable; convert to structure first',
+        };
+      }
+      if (chunkIndex < 0 || chunkIndex >= found.chunks.length) {
+        return {
+          changed: false,
+          reason: `chunk index ${chunkIndex} out of range [0, ${found.chunks.length})`,
+        };
+      }
+      if (found.chunks.length >= MAX_CHUNKS_PER_STRUCTURE) {
+        return {
+          changed: false,
+          reason: `structure ${structureId} is at max chunks (${MAX_CHUNKS_PER_STRUCTURE})`,
+        };
+      }
+      if (offset !== undefined) {
+        const err = validateVec3('offset', offset);
+        if (err) return { changed: false, reason: err };
+      }
+      const offsetVec: Vec3 = offset ? ([...offset] as Vec3) : [0, 0, 0];
+      let assignedIndex = -1;
+      const changed = aiEdit((current) => {
+        const idx = current.destructibles.findIndex((d) => d.id === structureId);
+        if (idx === -1) return current;
+        const target = current.destructibles[idx];
+        if (target.kind !== 'structure') return current;
+        const source = target.chunks[chunkIndex];
+        const cloned: Chunk = {
+          ...source,
+          position: [
+            source.position[0] + offsetVec[0],
+            source.position[1] + offsetVec[1],
+            source.position[2] + offsetVec[2],
+          ],
+          rotation: [...source.rotation] as Quaternion,
+          ...(source.halfExtents ? { halfExtents: [...source.halfExtents] as Vec3 } : {}),
+        };
+        assignedIndex = target.chunks.length;
+        const updated: StructureDestructible = {
+          ...target,
+          chunks: [...target.chunks, cloned],
+        };
+        const nextList = [...current.destructibles];
+        nextList[idx] = updated;
+        return { ...current, destructibles: nextList };
+      });
+      return changed ? { changed, chunkIndex: assignedIndex } : { changed };
+    },
+
+    convertFactoryToStructure(id) {
+      const found = accessors.getWorld().destructibles.find((d) => d.id === id);
+      if (!found) return { changed: false, reason: `no destructible with id ${id}` };
+      if (found.kind === 'structure') {
+        return { changed: false, reason: `destructible ${id} is already a structure` };
+      }
+      const chunks = expandFactoryKindToChunks(found.kind);
+      const changed = aiEdit((current) => {
+        const idx = current.destructibles.findIndex((d) => d.id === id);
+        if (idx === -1) return current;
+        const target = current.destructibles[idx];
+        if (target.kind === 'structure') return current;
+        const structure: StructureDestructible = {
+          id: target.id,
+          kind: 'structure',
+          position: [...target.position] as Vec3,
+          rotation: [...target.rotation] as Quaternion,
+          chunks,
+        };
+        const nextList = [...current.destructibles];
+        nextList[idx] = structure;
+        return { ...current, destructibles: nextList };
+      });
+      return { changed };
+    },
+
     applyTerrainBrush(spec) {
       if (typeof spec?.centerX !== 'number' || typeof spec?.centerZ !== 'number') {
         return { changed: false };
@@ -751,6 +1093,152 @@ function computeTerrainMutationStats(before: WorldDocument, after: WorldDocument
     return { samplesAffected: 0, deltaMin: 0, deltaMax: 0, heightMin: 0, heightMax: 0 };
   }
   return { samplesAffected, deltaMin, deltaMax, heightMin, heightMax };
+}
+
+type ValidatedChunk = { ok: true; chunk: Chunk } | { ok: false; reason: string };
+
+function validateChunkInput(raw: unknown): ValidatedChunk {
+  if (!raw || typeof raw !== 'object') {
+    return { ok: false, reason: 'chunk must be an object' };
+  }
+  const c = raw as Partial<Chunk> & { shape?: string };
+  if (c.shape !== 'box' && c.shape !== 'sphere' && c.shape !== 'capsule') {
+    return { ok: false, reason: `unknown shape ${String(c.shape)}; must be box | sphere | capsule` };
+  }
+  const position = c.position ?? [0, 0, 0];
+  const posErr = validateVec3('position', position);
+  if (posErr) return { ok: false, reason: posErr };
+  if (c.rotation !== undefined) {
+    if (
+      !Array.isArray(c.rotation)
+      || c.rotation.length !== 4
+      || c.rotation.some((v) => typeof v !== 'number' || !Number.isFinite(v))
+    ) {
+      return { ok: false, reason: 'rotation must be a [x, y, z, w] tuple of finite numbers' };
+    }
+  }
+  if (c.shape === 'box') {
+    if (
+      !Array.isArray(c.halfExtents)
+      || c.halfExtents.length !== 3
+      || c.halfExtents.some((v) => typeof v !== 'number' || !(v > 0))
+    ) {
+      return { ok: false, reason: 'box chunk requires halfExtents: [x, y, z] with positive numbers' };
+    }
+  } else if (c.shape === 'sphere') {
+    if (typeof c.radius !== 'number' || !(c.radius > 0)) {
+      return { ok: false, reason: 'sphere chunk requires positive radius' };
+    }
+  } else {
+    if (typeof c.radius !== 'number' || !(c.radius > 0)) {
+      return { ok: false, reason: 'capsule chunk requires positive radius' };
+    }
+    if (typeof c.height !== 'number' || !(c.height >= 0)) {
+      return { ok: false, reason: 'capsule chunk requires non-negative height' };
+    }
+  }
+  if (c.mass !== undefined && (typeof c.mass !== 'number' || !(c.mass >= 0))) {
+    return { ok: false, reason: 'mass must be a non-negative number when provided' };
+  }
+  const chunk: Chunk = {
+    shape: c.shape,
+    position: [...(position as Vec3)] as Vec3,
+    rotation: c.rotation ? ([...c.rotation] as Quaternion) : identityQuaternion(),
+  };
+  if (c.shape === 'box' && Array.isArray(c.halfExtents)) {
+    chunk.halfExtents = [...c.halfExtents] as Vec3;
+  }
+  if ((c.shape === 'sphere' || c.shape === 'capsule') && typeof c.radius === 'number') {
+    chunk.radius = c.radius;
+  }
+  if (c.shape === 'capsule' && typeof c.height === 'number') {
+    chunk.height = c.height;
+  }
+  if (typeof c.mass === 'number') chunk.mass = c.mass;
+  if (typeof c.material === 'string') chunk.material = c.material;
+  if (c.anchor === true) chunk.anchor = true;
+  return { ok: true, chunk };
+}
+
+// Mirror of `WallOptions::default()` / `TowerOptions::default()` layouts
+// used by the Rust factory expansion. Keep in sync with
+// `shared/src/destructibles_native_fallback.rs`.
+const WALL_SPAN_M = 6.0;
+const WALL_HEIGHT_M = 3.0;
+const WALL_THICKNESS_M = 0.32;
+const WALL_SPAN_SEGMENTS = 12;
+const WALL_HEIGHT_SEGMENTS = 6;
+const WALL_LAYERS = 1;
+
+const TOWER_SIDE = 4;
+const TOWER_STORIES = 7;
+const TOWER_SPACING_X = 0.5;
+const TOWER_SPACING_Y = 0.5;
+const TOWER_SPACING_Z = 0.5;
+
+function expandFactoryKindToChunks(kind: 'wall' | 'tower'): Chunk[] {
+  return kind === 'wall' ? buildWallChunks() : buildTowerChunks();
+}
+
+function buildWallChunks(): Chunk[] {
+  const cellX = WALL_SPAN_M / WALL_SPAN_SEGMENTS;
+  const cellY = WALL_HEIGHT_M / WALL_HEIGHT_SEGMENTS;
+  const cellZ = WALL_THICKNESS_M / WALL_LAYERS;
+  const originX = -WALL_SPAN_M * 0.5 + cellX * 0.5;
+  const originY = cellY * 0.5;
+  const halfExtents: Vec3 = [cellX * 0.5, cellY * 0.5, cellZ * 0.5];
+  const out: Chunk[] = [];
+  for (let ix = 0; ix < WALL_SPAN_SEGMENTS; ix += 1) {
+    for (let iy = 0; iy < WALL_HEIGHT_SEGMENTS; iy += 1) {
+      for (let iz = 0; iz < WALL_LAYERS; iz += 1) {
+        const position: Vec3 = [
+          originX + ix * cellX,
+          originY + iy * cellY,
+          (iz - (WALL_LAYERS - 1) * 0.5) * cellZ,
+        ];
+        const chunk: Chunk = {
+          shape: 'box',
+          position,
+          rotation: identityQuaternion(),
+          halfExtents: [...halfExtents] as Vec3,
+        };
+        if (iy === 0) chunk.anchor = true;
+        out.push(chunk);
+      }
+    }
+  }
+  return out;
+}
+
+function buildTowerChunks(): Chunk[] {
+  const totalRows = TOWER_STORIES + 1;
+  const halfExtents: Vec3 = [
+    TOWER_SPACING_X * 0.5,
+    TOWER_SPACING_Y * 0.5,
+    TOWER_SPACING_Z * 0.5,
+  ];
+  const sideCenter = (TOWER_SIDE - 1) * 0.5;
+  const out: Chunk[] = [];
+  for (let iz = 0; iz < TOWER_SIDE; iz += 1) {
+    for (let iy = 0; iy < totalRows; iy += 1) {
+      for (let ix = 0; ix < TOWER_SIDE; ix += 1) {
+        const position: Vec3 = [
+          (ix - sideCenter) * TOWER_SPACING_X,
+          (iy - 1) * TOWER_SPACING_Y,
+          (iz - sideCenter) * TOWER_SPACING_Z,
+        ];
+        const chunk: Chunk = {
+          shape: 'box',
+          position,
+          rotation: identityQuaternion(),
+          halfExtents: [...halfExtents] as Vec3,
+        };
+        if (iy === 0) chunk.anchor = true;
+        out.push(chunk);
+      }
+    }
+  }
+  return out;
 }
 
 function validateVec3(name: string, value: unknown): string | null {

--- a/client/src/ai/worldToolHelpers.ts
+++ b/client/src/ai/worldToolHelpers.ts
@@ -30,6 +30,7 @@ import {
   type Vec3,
   type WorldDocument,
 } from '../world/worldDocument';
+import { expandFactoryKindToChunks } from '../world/destructibleFactory';
 import { applyCustomStencilToWorld, type CustomStencilDefinition } from './customStencil';
 import { getStencil, registerStencil } from './customStencilStore';
 
@@ -1158,87 +1159,6 @@ function validateChunkInput(raw: unknown): ValidatedChunk {
   if (typeof c.material === 'string') chunk.material = c.material;
   if (c.anchor === true) chunk.anchor = true;
   return { ok: true, chunk };
-}
-
-// Mirror of `WallOptions::default()` / `TowerOptions::default()` layouts
-// used by the Rust factory expansion. Keep in sync with
-// `shared/src/destructibles_native_fallback.rs`.
-const WALL_SPAN_M = 6.0;
-const WALL_HEIGHT_M = 3.0;
-const WALL_THICKNESS_M = 0.32;
-const WALL_SPAN_SEGMENTS = 12;
-const WALL_HEIGHT_SEGMENTS = 6;
-const WALL_LAYERS = 1;
-
-const TOWER_SIDE = 4;
-const TOWER_STORIES = 7;
-const TOWER_SPACING_X = 0.5;
-const TOWER_SPACING_Y = 0.5;
-const TOWER_SPACING_Z = 0.5;
-
-function expandFactoryKindToChunks(kind: 'wall' | 'tower'): Chunk[] {
-  return kind === 'wall' ? buildWallChunks() : buildTowerChunks();
-}
-
-function buildWallChunks(): Chunk[] {
-  const cellX = WALL_SPAN_M / WALL_SPAN_SEGMENTS;
-  const cellY = WALL_HEIGHT_M / WALL_HEIGHT_SEGMENTS;
-  const cellZ = WALL_THICKNESS_M / WALL_LAYERS;
-  const originX = -WALL_SPAN_M * 0.5 + cellX * 0.5;
-  const originY = cellY * 0.5;
-  const halfExtents: Vec3 = [cellX * 0.5, cellY * 0.5, cellZ * 0.5];
-  const out: Chunk[] = [];
-  for (let ix = 0; ix < WALL_SPAN_SEGMENTS; ix += 1) {
-    for (let iy = 0; iy < WALL_HEIGHT_SEGMENTS; iy += 1) {
-      for (let iz = 0; iz < WALL_LAYERS; iz += 1) {
-        const position: Vec3 = [
-          originX + ix * cellX,
-          originY + iy * cellY,
-          (iz - (WALL_LAYERS - 1) * 0.5) * cellZ,
-        ];
-        const chunk: Chunk = {
-          shape: 'box',
-          position,
-          rotation: identityQuaternion(),
-          halfExtents: [...halfExtents] as Vec3,
-        };
-        if (iy === 0) chunk.anchor = true;
-        out.push(chunk);
-      }
-    }
-  }
-  return out;
-}
-
-function buildTowerChunks(): Chunk[] {
-  const totalRows = TOWER_STORIES + 1;
-  const halfExtents: Vec3 = [
-    TOWER_SPACING_X * 0.5,
-    TOWER_SPACING_Y * 0.5,
-    TOWER_SPACING_Z * 0.5,
-  ];
-  const sideCenter = (TOWER_SIDE - 1) * 0.5;
-  const out: Chunk[] = [];
-  for (let iz = 0; iz < TOWER_SIDE; iz += 1) {
-    for (let iy = 0; iy < totalRows; iy += 1) {
-      for (let ix = 0; ix < TOWER_SIDE; ix += 1) {
-        const position: Vec3 = [
-          (ix - sideCenter) * TOWER_SPACING_X,
-          (iy - 1) * TOWER_SPACING_Y,
-          (iz - sideCenter) * TOWER_SPACING_Z,
-        ];
-        const chunk: Chunk = {
-          shape: 'box',
-          position,
-          rotation: identityQuaternion(),
-          halfExtents: [...halfExtents] as Vec3,
-        };
-        if (iy === 0) chunk.anchor = true;
-        out.push(chunk);
-      }
-    }
-  }
-  return out;
 }
 
 function validateVec3(name: string, value: unknown): string | null {

--- a/client/src/ai/worldToolHelpers.ts
+++ b/client/src/ai/worldToolHelpers.ts
@@ -165,6 +165,7 @@ export type WorldCtx = {
     rotation?: Quaternion;
     density?: number;
     solverMaterialScale?: number;
+    fractured?: boolean;
     chunks: Chunk[];
   }): { changed: boolean; id?: number; reason?: string };
   removeDestructible(id: number): { changed: boolean; reason?: string };
@@ -175,6 +176,7 @@ export type WorldCtx = {
       rotation: Quaternion;
       density: number;
       solverMaterialScale: number;
+      fractured: boolean;
     }>,
   ): { changed: boolean; reason?: string };
   addChunk(
@@ -565,6 +567,7 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
           ...(typeof spec.solverMaterialScale === 'number'
             ? { solverMaterialScale: spec.solverMaterialScale }
             : {}),
+          ...(spec.fractured === true ? { fractured: true } : {}),
           chunks: validatedChunks,
         };
         return { ...current, destructibles: [...current.destructibles, next] };
@@ -597,11 +600,13 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
       const isFactory = found.kind === 'wall' || found.kind === 'tower';
       if (
         isFactory
-        && (typeof patch.density === 'number' || typeof patch.solverMaterialScale === 'number')
+        && (typeof patch.density === 'number'
+          || typeof patch.solverMaterialScale === 'number'
+          || typeof patch.fractured === 'boolean')
       ) {
         return {
           changed: false,
-          reason: 'density / solverMaterialScale only apply to structure destructibles',
+          reason: 'density / solverMaterialScale / fractured only apply to structure destructibles',
         };
       }
       const changed = aiEdit((current) => {
@@ -610,7 +615,7 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
         const target = current.destructibles[idx];
         const nextList = [...current.destructibles];
         if (target.kind === 'structure') {
-          nextList[idx] = {
+          const merged: StructureDestructible = {
             ...target,
             ...(patch.position ? { position: [...patch.position] as Vec3 } : {}),
             ...(patch.rotation ? { rotation: [...patch.rotation] as Quaternion } : {}),
@@ -619,6 +624,14 @@ export function buildWorldCtx(accessors: WorldAccessors): WorldCtx {
               ? { solverMaterialScale: patch.solverMaterialScale }
               : {}),
           };
+          if (typeof patch.fractured === 'boolean') {
+            if (patch.fractured) {
+              merged.fractured = true;
+            } else {
+              delete merged.fractured;
+            }
+          }
+          nextList[idx] = merged;
         } else {
           nextList[idx] = {
             ...target,

--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -4,6 +4,7 @@ import { Canvas, useThree, type ThreeEvent } from '@react-three/fiber';
 import * as THREE from 'three';
 import { App } from '../App';
 import { WorldTerrain } from '../scene/WorldTerrain';
+import { DestructibleAuthoringPreview } from '../scene/DestructibleAuthoringPreview';
 import {
   DEFAULT_WORLD_DOCUMENT,
   DEFAULT_TERRAIN_MATERIALS,
@@ -2016,6 +2017,12 @@ function GodModeEditorScene({
           centerZ={terrainPointerPoint[2]}
         />
       )}
+      <DestructibleAuthoringPreview
+        world={world}
+        selected={selected}
+        onSelect={onSelect}
+        registerSelectableObject={registerSelectableObject}
+      />
       <group>
         {world.staticProps.map((entity) => (
           <mesh

--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -814,6 +814,23 @@ export function GodModePage({ publishedId }: GodModePageProps = {}) {
     applyPreviewWorldEdit((current) => updateSelectedTargetRotation(current, selected, nextRotation));
   }, [applyPreviewWorldEdit, selected]);
 
+  const updateSelectedDestructibleFractured = useCallback((nextFractured: boolean) => {
+    if (selected?.kind !== 'destructible') return;
+    const targetId = selected.id;
+    applyCommittedWorldEdit((current) => ({
+      ...current,
+      destructibles: current.destructibles.map((entry) => {
+        if (entry.id !== targetId || entry.kind !== 'structure') return entry;
+        if ((entry.fractured ?? false) === nextFractured) return entry;
+        if (!nextFractured) {
+          const { fractured: _drop, ...rest } = entry;
+          return rest;
+        }
+        return { ...entry, fractured: true };
+      }),
+    }));
+  }, [applyCommittedWorldEdit, selected]);
+
   const canUndo = editHistory.undoStack.length > 0;
   const canRedo = editHistory.redoStack.length > 0;
 
@@ -1413,6 +1430,15 @@ export function GodModePage({ publishedId }: GodModePageProps = {}) {
                       {selectedDestructible.chunks.length} chunk{selectedDestructible.chunks.length === 1 ? '' : 's'}
                       {' · '}density {selectedDestructible.density ?? 2400} kg/m³
                       {' · '}solver scale {selectedDestructible.solverMaterialScale ?? 1}
+                      <br />
+                      <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, marginTop: 6 }}>
+                        <input
+                          type="checkbox"
+                          checked={selectedDestructible.fractured === true}
+                          onChange={(event) => updateSelectedDestructibleFractured(event.target.checked)}
+                        />
+                        Fractured (split each chunk into brick-sized sub-chunks at runtime and auto-bond)
+                      </label>
                       <br />
                       Use the AI chat to add / remove / tune individual chunks.
                     </div>

--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -68,9 +68,11 @@ import {
   type WorldEditHistory,
 } from './godModeHistory';
 import {
+  addDestructibleStructureToWorld,
   addDynamicEntityToWorld,
   addStaticCuboidToWorld,
   clonePlayWorldSnapshot,
+  getSelectedDestructible,
   getSelectedDynamic,
   getSelectedStatic,
   removeSelectedTargetFromWorld,
@@ -426,6 +428,7 @@ export function GodModePage({ publishedId }: GodModePageProps = {}) {
 
   const selectedStatic = useMemo(() => getSelectedStatic(world, selected), [selected, world]);
   const selectedDynamic = useMemo(() => getSelectedDynamic(world, selected), [selected, world]);
+  const selectedDestructible = useMemo(() => getSelectedDestructible(world, selected), [selected, world]);
   const selectedTransformEntity = useMemo<SelectedTransformEntity | null>(() => {
     return resolveSelectedTransformEntity(world, selected);
   }, [selected, world]);
@@ -717,6 +720,18 @@ export function GodModePage({ publishedId }: GodModePageProps = {}) {
     let nextSelected: SelectedTarget = null;
     const changed = applyCommittedWorldEdit((current) => {
       const result = addDynamicEntityToWorld(current, kind);
+      nextSelected = result.selected;
+      return result.world;
+    });
+    if (changed && nextSelected) {
+      setSelected(nextSelected);
+    }
+  }, [applyCommittedWorldEdit]);
+
+  const addDestructibleStructure = useCallback(() => {
+    let nextSelected: SelectedTarget = null;
+    const changed = applyCommittedWorldEdit((current) => {
+      const result = addDestructibleStructureToWorld(current);
       nextSelected = result.selected;
       return result.world;
     });
@@ -1304,6 +1319,7 @@ export function GodModePage({ publishedId }: GodModePageProps = {}) {
                 <button type="button" onClick={() => addDynamicEntity('box')} style={secondaryButtonStyle}>Dynamic Box</button>
                 <button type="button" onClick={() => addDynamicEntity('ball')} style={secondaryButtonStyle}>Ball</button>
                 <button type="button" onClick={() => addDynamicEntity('vehicle')} style={secondaryButtonStyle}>Vehicle</button>
+                <button type="button" onClick={addDestructibleStructure} style={secondaryButtonStyle}>Destructible</button>
               </div>
             </div>
 
@@ -1381,6 +1397,31 @@ export function GodModePage({ publishedId }: GodModePageProps = {}) {
                   onYawChange={updateSelectedYaw}
                   onDelete={removeSelected}
                 />
+              )}
+              {selectedDestructible && (
+                <EditorFields
+                  title={`destructible ${selectedDestructible.kind} ${selectedDestructible.id}`}
+                  position={selectedDestructible.position}
+                  onPositionChange={updateSelectedPosition}
+                  yawDegrees={(yawFromQuaternion(selectedDestructible.rotation) * 180) / Math.PI}
+                  onYawChange={updateSelectedYaw}
+                  onDelete={removeSelected}
+                >
+                  {selectedDestructible.kind === 'structure' ? (
+                    <div style={mutedTextStyle}>
+                      {selectedDestructible.chunks.length} chunk{selectedDestructible.chunks.length === 1 ? '' : 's'}
+                      {' · '}density {selectedDestructible.density ?? 2400} kg/m³
+                      {' · '}solver scale {selectedDestructible.solverMaterialScale ?? 1}
+                      <br />
+                      Use the AI chat to add / remove / tune individual chunks.
+                    </div>
+                  ) : (
+                    <div style={mutedTextStyle}>
+                      Factory {selectedDestructible.kind} — immutable preset. Ask the AI to convert it to a
+                      structure if you want to edit individual chunks.
+                    </div>
+                  )}
+                </EditorFields>
               )}
             </div>
           </>
@@ -2375,6 +2416,7 @@ function EditorFields({
   yawDegrees,
   onYawChange,
   onDelete,
+  children,
 }: {
   title: string;
   position: [number, number, number];
@@ -2389,6 +2431,7 @@ function EditorFields({
   yawDegrees?: number;
   onYawChange?: (value: number) => void;
   onDelete: () => void;
+  children?: React.ReactNode;
 }) {
   return (
     <div style={fieldStackStyle}>
@@ -2433,6 +2476,7 @@ function EditorFields({
           <input type="number" step="1" value={yawDegrees} onChange={(event) => onYawChange(Number(event.target.value))} />
         </label>
       )}
+      {children}
       <button type="button" onClick={onDelete} style={dangerButtonStyle}>Delete</button>
     </div>
   );

--- a/client/src/pages/godModeEditorDocument.ts
+++ b/client/src/pages/godModeEditorDocument.ts
@@ -1,12 +1,16 @@
 import {
   cloneWorldDocument,
+  DEFAULT_STRUCTURE_DENSITY_KG_M3,
+  DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE,
   getMinimumDynamicEntityY,
   getNextWorldEntityId,
   identityQuaternion,
   sampleTerrainHeightAtWorldPosition,
+  type Destructible,
   type DynamicEntity,
   type Quaternion,
   type StaticProp,
+  type StructureDestructible,
   type Vec3,
   type WorldDocument,
 } from '../world/worldDocument';
@@ -17,10 +21,11 @@ const DEFAULT_EDITOR_VEHICLE_TYPE = getSharedVehicleTypeByKey('cybertruck') ?? 0
 export type SelectedTarget =
   | { kind: 'static'; id: number }
   | { kind: 'dynamic'; id: number }
+  | { kind: 'destructible'; id: number }
   | null;
 
 export type SelectedTransformEntity = {
-  kind: 'static' | 'dynamic';
+  kind: 'static' | 'dynamic' | 'destructible';
   id: number;
   position: Vec3;
   rotation: Quaternion;
@@ -34,9 +39,23 @@ export function selectionExists(world: WorldDocument, selected: SelectedTarget):
   if (!selected) {
     return false;
   }
-  return selected.kind === 'static'
-    ? world.staticProps.some((entity) => entity.id === selected.id)
-    : world.dynamicEntities.some((entity) => entity.id === selected.id);
+  if (selected.kind === 'static') {
+    return world.staticProps.some((entity) => entity.id === selected.id);
+  }
+  if (selected.kind === 'dynamic') {
+    return world.dynamicEntities.some((entity) => entity.id === selected.id);
+  }
+  return world.destructibles.some((entity) => entity.id === selected.id);
+}
+
+export function getSelectedDestructible(
+  world: WorldDocument,
+  selected: SelectedTarget,
+): Destructible | null {
+  if (selected?.kind !== 'destructible') {
+    return null;
+  }
+  return world.destructibles.find((entity) => entity.id === selected.id) ?? null;
 }
 
 export function getSelectedStatic(world: WorldDocument, selected: SelectedTarget): StaticProp | null {
@@ -84,6 +103,18 @@ export function resolveSelectedTransformEntity(
     };
   }
 
+  const selectedDestructible = getSelectedDestructible(world, selected);
+  if (selectedDestructible) {
+    return {
+      kind: 'destructible',
+      id: selectedDestructible.id,
+      position: selectedDestructible.position,
+      rotation: selectedDestructible.rotation,
+      canRotate: true,
+      canResize: false,
+    };
+  }
+
   return null;
 }
 
@@ -106,6 +137,46 @@ export function addStaticCuboidToWorld(
       staticProps: [...current.staticProps, nextStatic],
     },
     selected: { kind: 'static', id: nextId },
+  };
+}
+
+export function addDestructibleStructureToWorld(
+  current: WorldDocument,
+): { world: WorldDocument; selected: SelectedTarget } {
+  const nextId = getNextWorldEntityId(current);
+  const baseY = sampleTerrainHeightAtWorldPosition(current, 0, 0);
+  const seed: StructureDestructible = {
+    id: nextId,
+    kind: 'structure',
+    position: [0, baseY, 0],
+    rotation: identityQuaternion(),
+    density: DEFAULT_STRUCTURE_DENSITY_KG_M3,
+    solverMaterialScale: DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE,
+    // Seed with a 2-chunk stack so the bond solver has something to wire
+    // and the native server has something to topple. Bottom is an anchor
+    // so the upper brick rests on a static support.
+    chunks: [
+      {
+        shape: 'box',
+        position: [0, 0.25, 0],
+        rotation: identityQuaternion(),
+        halfExtents: [0.25, 0.25, 0.25],
+        anchor: true,
+      },
+      {
+        shape: 'box',
+        position: [0, 0.75, 0],
+        rotation: identityQuaternion(),
+        halfExtents: [0.25, 0.25, 0.25],
+      },
+    ],
+  };
+  return {
+    world: {
+      ...current,
+      destructibles: [...current.destructibles, seed],
+    },
+    selected: { kind: 'destructible', id: nextId },
   };
 }
 
@@ -149,6 +220,12 @@ export function removeSelectedTargetFromWorld(
       staticProps: current.staticProps.filter((entity) => entity.id !== selected.id),
     };
   }
+  if (selected.kind === 'destructible') {
+    return {
+      ...current,
+      destructibles: current.destructibles.filter((entity) => entity.id !== selected.id),
+    };
+  }
   return {
     ...current,
     dynamicEntities: current.dynamicEntities.filter((entity) => entity.id !== selected.id),
@@ -169,6 +246,16 @@ export function updateSelectedTargetPosition(
       staticProps: current.staticProps.map((entity) => (
         entity.id === selected.id
           ? { ...entity, position: nextPosition }
+          : entity
+      )),
+    };
+  }
+  if (selected.kind === 'destructible') {
+    return {
+      ...current,
+      destructibles: current.destructibles.map((entity) => (
+        entity.id === selected.id
+          ? ({ ...entity, position: nextPosition } as Destructible)
           : entity
       )),
     };
@@ -274,6 +361,16 @@ export function updateSelectedTargetRotation(
       staticProps: current.staticProps.map((entity) => (
         entity.id === selected.id
           ? { ...entity, rotation: nextRotation }
+          : entity
+      )),
+    };
+  }
+  if (selected.kind === 'destructible') {
+    return {
+      ...current,
+      destructibles: current.destructibles.map((entity) => (
+        entity.id === selected.id
+          ? ({ ...entity, rotation: nextRotation } as Destructible)
           : entity
       )),
     };

--- a/client/src/physics/destructibleSpatialMetrics.ts
+++ b/client/src/physics/destructibleSpatialMetrics.ts
@@ -14,7 +14,9 @@ export const DESTRUCTIBLE_CHUNK_TRANSFORM_STRIDE = 11;
 const SIGNIFICANT_OVERLAP_EPSILON_M = 0.05;
 const NEAR_COINCIDENT_DISTANCE_EPSILON_M = 0.1;
 
-const CHUNK_HALF_EXTENTS_BY_KIND: Record<Destructible['kind'], [number, number, number]> = {
+type FactoryKind = 'wall' | 'tower';
+
+const CHUNK_HALF_EXTENTS_BY_KIND: Record<FactoryKind, [number, number, number]> = {
   wall: [0.25, 0.25, 0.16],
   tower: [0.25, 0.25, 0.25],
 };
@@ -135,9 +137,11 @@ export function computeDestructibleSpatialMetrics(
     };
   }
 
-  const kindById = new Map<number, Destructible['kind']>();
+  const kindById = new Map<number, FactoryKind>();
   for (const destructible of destructibles) {
-    kindById.set(destructible.id, destructible.kind);
+    if (destructible.kind === 'wall' || destructible.kind === 'tower') {
+      kindById.set(destructible.id, destructible.kind);
+    }
   }
 
   const samplesById = new Map<number, ChunkMetricsSample[]>();

--- a/client/src/scene/DestructibleAuthoringPreview.tsx
+++ b/client/src/scene/DestructibleAuthoringPreview.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import * as THREE from 'three';
 import type { Chunk, Destructible, WorldDocument } from '../world/worldDocument';
-import { expandFactoryKindToChunks } from '../world/destructibleFactory';
+import { expandFactoryKindToChunks, fractureChunks } from '../world/destructibleFactory';
 import type { SelectedTarget } from '../pages/godModeEditorDocument';
 
 type Props = {
@@ -24,8 +24,8 @@ function baseColor(doc: Destructible): number {
 }
 
 function chunksFor(doc: Destructible): Chunk[] {
-  if (doc.kind === 'structure') return doc.chunks;
-  return expandFactoryKindToChunks(doc.kind);
+  if (doc.kind !== 'structure') return expandFactoryKindToChunks(doc.kind);
+  return doc.fractured ? fractureChunks(doc.chunks) : doc.chunks;
 }
 
 export function DestructibleAuthoringPreview({

--- a/client/src/scene/DestructibleAuthoringPreview.tsx
+++ b/client/src/scene/DestructibleAuthoringPreview.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import type { Chunk, Destructible, WorldDocument } from '../world/worldDocument';
+import { expandFactoryKindToChunks } from '../world/destructibleFactory';
+import type { SelectedTarget } from '../pages/godModeEditorDocument';
+
+type Props = {
+  world: WorldDocument;
+  selected: SelectedTarget;
+  onSelect: (target: SelectedTarget) => void;
+  registerSelectableObject: (key: string, object: THREE.Object3D | null) => void;
+};
+
+const STRUCTURE_COLOR = 0x8c94a0;
+const WALL_COLOR = 0x9ca3a8;
+const TOWER_COLOR = 0xb89460;
+const SELECTED_COLOR = 0xffd86e;
+const ANCHOR_COLOR = 0x4a5160;
+
+function baseColor(doc: Destructible): number {
+  if (doc.kind === 'wall') return WALL_COLOR;
+  if (doc.kind === 'tower') return TOWER_COLOR;
+  return STRUCTURE_COLOR;
+}
+
+function chunksFor(doc: Destructible): Chunk[] {
+  if (doc.kind === 'structure') return doc.chunks;
+  return expandFactoryKindToChunks(doc.kind);
+}
+
+export function DestructibleAuthoringPreview({
+  world,
+  selected,
+  onSelect,
+  registerSelectableObject,
+}: Props) {
+  const docs = world.destructibles;
+  if (docs.length === 0) return null;
+
+  return (
+    <group>
+      {docs.map((doc) => (
+        <DestructibleNode
+          key={doc.id}
+          doc={doc}
+          isSelected={selected?.kind === 'destructible' && selected.id === doc.id}
+          onSelect={onSelect}
+          registerSelectableObject={registerSelectableObject}
+        />
+      ))}
+    </group>
+  );
+}
+
+function DestructibleNode({
+  doc,
+  isSelected,
+  onSelect,
+  registerSelectableObject,
+}: {
+  doc: Destructible;
+  isSelected: boolean;
+  onSelect: (target: SelectedTarget) => void;
+  registerSelectableObject: (key: string, object: THREE.Object3D | null) => void;
+}) {
+  const quaternion = useMemo(() => new THREE.Quaternion(...doc.rotation), [doc.rotation]);
+  const chunks = useMemo(() => chunksFor(doc), [doc]);
+  const highlight = isSelected ? SELECTED_COLOR : baseColor(doc);
+
+  return (
+    <group
+      ref={(object) => registerSelectableObject(`destructible:${doc.id}`, object)}
+      position={doc.position}
+      quaternion={quaternion}
+    >
+      {chunks.map((chunk, index) => (
+        <ChunkMesh
+          key={index}
+          chunk={chunk}
+          color={chunk.anchor ? ANCHOR_COLOR : highlight}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+            onSelect({ kind: 'destructible', id: doc.id });
+          }}
+        />
+      ))}
+    </group>
+  );
+}
+
+function ChunkMesh({
+  chunk,
+  color,
+  onPointerDown,
+}: {
+  chunk: Chunk;
+  color: number;
+  onPointerDown: (event: THREE.Event & { stopPropagation: () => void }) => void;
+}) {
+  const quaternion = useMemo(
+    () => new THREE.Quaternion(...chunk.rotation),
+    [chunk.rotation],
+  );
+  return (
+    <mesh
+      position={chunk.position}
+      quaternion={quaternion}
+      castShadow
+      receiveShadow
+      onPointerDown={onPointerDown as never}
+    >
+      {chunk.shape === 'box' && (
+        <boxGeometry
+          args={[
+            (chunk.halfExtents?.[0] ?? 0.25) * 2,
+            (chunk.halfExtents?.[1] ?? 0.25) * 2,
+            (chunk.halfExtents?.[2] ?? 0.25) * 2,
+          ]}
+        />
+      )}
+      {chunk.shape === 'sphere' && (
+        <sphereGeometry args={[chunk.radius ?? 0.25, 16, 12]} />
+      )}
+      {chunk.shape === 'capsule' && (
+        <capsuleGeometry args={[chunk.radius ?? 0.25, chunk.height ?? 0.5, 6, 12]} />
+      )}
+      <meshStandardMaterial color={color} roughness={0.82} metalness={0.06} />
+    </mesh>
+  );
+}

--- a/client/src/scene/DestructibleChunks.tsx
+++ b/client/src/scene/DestructibleChunks.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { WorldDocument, Destructible } from '../world/worldDocument';
+import type { Chunk, Destructible, WorldDocument } from '../world/worldDocument';
 
 /**
  * Stride of the chunk transforms buffer produced by
@@ -11,28 +11,21 @@ import type { WorldDocument, Destructible } from '../world/worldDocument';
 const CHUNK_TRANSFORM_STRIDE = 11;
 
 /**
- * Default half-extents of a single Blast chunk, derived from the scenario
- * options defaults in the blast crate:
+ * Default half-extents used for the legacy factory destructibles. Size
+ * matches the Blast scenario-option defaults:
  *
- * - Wall (`WallOptions::default`): span=6, height=3, thickness=0.32,
- *   12×6×1 grid → cell size ≈ (0.5, 0.5, 0.32), half ≈ (0.25, 0.25, 0.16).
- * - Tower (`TowerOptions::default`): spacing_{x,y,z}=0.5 → cell (0.5,0.5,0.5),
- *   half (0.25, 0.25, 0.25).
- *
- * Using these fixed sizes for the instanced box mesh avoids a per-frame
- * AABB query through the WASM boundary; the solver already guarantees
- * chunks stay inside their starting cell volumes.
+ * - Wall (`WallOptions::default`): 12×6×1 cells of 0.5×0.5×0.32m → half (0.25,0.25,0.16).
+ * - Tower (`TowerOptions::default`): spacing_{x,y,z}=0.5 → half (0.25,0.25,0.25).
  */
-const CHUNK_GEOMETRIES: Record<Destructible['kind'], { size: [number, number, number]; color: number }> = {
-  wall: { size: [0.5, 0.5, 0.32], color: 0x9ca3a8 },
-  tower: { size: [0.5, 0.5, 0.5], color: 0xb89460 },
-};
+const FACTORY_GEOMETRIES = {
+  wall: { size: [0.5, 0.5, 0.32] as [number, number, number], color: 0x9ca3a8 },
+  tower: { size: [0.5, 0.5, 0.5] as [number, number, number], color: 0xb89460 },
+} as const;
 
-/**
- * Max chunk count per destructible. Defaults (wall=72 chunks, tower=128)
- * give plenty of headroom for split children created when bonds break.
- */
-const MAX_CHUNKS_PER_DESTRUCTIBLE = 512;
+const STRUCTURE_COLOR = 0x8c94a0;
+
+/** Max chunk count per InstancedMesh bucket. Matches native MAX_CHUNKS_PER_STRUCTURE. */
+const MAX_CHUNKS_PER_BUCKET = 4096;
 
 type DestructibleChunksProps = {
   world: WorldDocument;
@@ -44,118 +37,215 @@ type DestructibleChunksProps = {
   getChunkTransforms: () => Float32Array;
 };
 
-type InstanceGroup = {
-  id: number;
-  kind: Destructible['kind'];
+/**
+ * One instanced-mesh bucket. A single bucket holds instances that share
+ * a common geometry (same shape + same size). Factory destructibles use
+ * a single uniform bucket. Structures get one bucket per
+ * (structureId, shape-key) so boxes / spheres / capsules can each use
+ * their own geometry.
+ */
+type InstanceBucket = {
+  destructibleId: number;
   mesh: THREE.InstancedMesh;
+  /** Maps `chunkIndex` (from the WASM buffer) → instance slot in `mesh`. */
+  chunkIndexToSlot: Map<number, number>;
 };
 
+function buildInstancedMeshForGeometry(
+  geometry: THREE.BufferGeometry,
+  color: number,
+  capacity: number,
+): THREE.InstancedMesh {
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    roughness: 0.85,
+    metalness: 0.05,
+  });
+  const mesh = new THREE.InstancedMesh(geometry, material, capacity);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  mesh.count = 0;
+  mesh.frustumCulled = false;
+  return mesh;
+}
+
+function geometryForChunk(chunk: Chunk): THREE.BufferGeometry {
+  switch (chunk.shape) {
+    case 'box': {
+      const he = chunk.halfExtents ?? [0.25, 0.25, 0.25];
+      return new THREE.BoxGeometry(he[0] * 2, he[1] * 2, he[2] * 2);
+    }
+    case 'sphere':
+      return new THREE.SphereGeometry(chunk.radius ?? 0.25, 16, 12);
+    case 'capsule':
+      return new THREE.CapsuleGeometry(chunk.radius ?? 0.25, chunk.height ?? 0.5, 6, 12);
+  }
+}
+
 /**
- * Renders every destructible chunk as a single InstancedMesh per
- * destructible instance. Matrices are streamed from the WASM sim each
- * frame; inactive chunks (activeFlag=0) collapse to a zero-scale matrix so
- * the instance still exists in the buffer but draws nothing.
+ * Renders every destructible chunk as an InstancedMesh. Each frame, the
+ * WASM chunk transform buffer is walked and per-chunk matrices are set on
+ * the owning bucket. Inactive chunks (present=0) collapse to a zero-scale
+ * matrix so the slot stays allocated but draws nothing.
  */
 export function DestructibleChunks({ world, getChunkTransforms }: DestructibleChunksProps) {
-  const groupsRef = useRef<InstanceGroup[]>([]);
+  const bucketsRef = useRef<InstanceBucket[]>([]);
   const tmpMatrix = useMemo(() => new THREE.Matrix4(), []);
   const tmpPosition = useMemo(() => new THREE.Vector3(), []);
   const tmpQuaternion = useMemo(() => new THREE.Quaternion(), []);
   const zeroScale = useMemo(() => new THREE.Vector3(0, 0, 0), []);
   const unitScale = useMemo(() => new THREE.Vector3(1, 1, 1), []);
 
-  // Build one InstancedMesh per destructible declared in the world doc.
-  // We create them lazily via JSX below so React handles mount/unmount,
-  // but we also stash refs to each mesh in `groupsRef` for the frame loop.
-  const instancedMeshes = useMemo(() => {
-    const meshes = world.destructibles.map((doc) => {
-      const geom = CHUNK_GEOMETRIES[doc.kind];
-      const box = new THREE.BoxGeometry(...geom.size);
-      const material = new THREE.MeshStandardMaterial({
-        color: geom.color,
-        roughness: 0.85,
-        metalness: 0.05,
-      });
-      const mesh = new THREE.InstancedMesh(box, material, MAX_CHUNKS_PER_DESTRUCTIBLE);
-      mesh.castShadow = true;
-      mesh.receiveShadow = true;
-      mesh.count = 0;
-      mesh.frustumCulled = false;
-      // Collapse all instances until the first transform update — avoids
-      // a single-frame flash of unit-cube instances at the origin.
-      for (let i = 0; i < MAX_CHUNKS_PER_DESTRUCTIBLE; i += 1) {
-        tmpMatrix.compose(tmpPosition.set(0, 0, 0), tmpQuaternion.set(0, 0, 0, 1), zeroScale);
-        mesh.setMatrixAt(i, tmpMatrix);
+  const buckets = useMemo<InstanceBucket[]>(() => {
+    const result: InstanceBucket[] = [];
+    for (const doc of world.destructibles) {
+      if (doc.kind !== 'structure') {
+        const geom = FACTORY_GEOMETRIES[doc.kind];
+        const box = new THREE.BoxGeometry(geom.size[0], geom.size[1], geom.size[2]);
+        const mesh = buildInstancedMeshForGeometry(box, geom.color, MAX_CHUNKS_PER_BUCKET);
+        // Collapse all instances until the first transform update.
+        for (let i = 0; i < MAX_CHUNKS_PER_BUCKET; i += 1) {
+          tmpMatrix.compose(tmpPosition.set(0, 0, 0), tmpQuaternion.set(0, 0, 0, 1), zeroScale);
+          mesh.setMatrixAt(i, tmpMatrix);
+        }
+        mesh.instanceMatrix.needsUpdate = true;
+        result.push({
+          destructibleId: doc.id,
+          mesh,
+          chunkIndexToSlot: new Map(),
+        });
+        continue;
       }
-      mesh.instanceMatrix.needsUpdate = true;
-      return { id: doc.id, kind: doc.kind, mesh };
-    });
-    groupsRef.current = meshes;
-    return meshes;
+      // Structure: group chunks by a (shape + size) key so each unique
+      // geometry gets its own InstancedMesh. Slot order = order within the
+      // group (not global chunk index), so we record the mapping.
+      const groupByKey = new Map<string, { key: string; indices: number[]; geom: THREE.BufferGeometry }>();
+      doc.chunks.forEach((chunk: Chunk, index: number) => {
+        const key = chunkGeometryKey(chunk);
+        const existing = groupByKey.get(key);
+        if (existing) {
+          existing.indices.push(index);
+        } else {
+          groupByKey.set(key, { key, indices: [index], geom: geometryForChunk(chunk) });
+        }
+      });
+      for (const group of groupByKey.values()) {
+        const capacity = Math.max(1, group.indices.length);
+        const mesh = buildInstancedMeshForGeometry(group.geom, STRUCTURE_COLOR, capacity);
+        const slotMap = new Map<number, number>();
+        group.indices.forEach((chunkIndex, slot) => {
+          slotMap.set(chunkIndex, slot);
+          tmpMatrix.compose(tmpPosition.set(0, 0, 0), tmpQuaternion.set(0, 0, 0, 1), zeroScale);
+          mesh.setMatrixAt(slot, tmpMatrix);
+        });
+        mesh.instanceMatrix.needsUpdate = true;
+        result.push({
+          destructibleId: doc.id,
+          mesh,
+          chunkIndexToSlot: slotMap,
+        });
+      }
+    }
+    bucketsRef.current = result;
+    return result;
   }, [world.destructibles, tmpMatrix, tmpPosition, tmpQuaternion, zeroScale]);
 
   useEffect(() => {
     return () => {
-      for (const group of instancedMeshes) {
-        group.mesh.dispose();
-        group.mesh.geometry.dispose();
-        if (Array.isArray(group.mesh.material)) {
-          group.mesh.material.forEach((m) => m.dispose());
+      for (const bucket of buckets) {
+        bucket.mesh.dispose();
+        bucket.mesh.geometry.dispose();
+        if (Array.isArray(bucket.mesh.material)) {
+          bucket.mesh.material.forEach((m) => m.dispose());
         } else {
-          group.mesh.material.dispose();
+          bucket.mesh.material.dispose();
         }
       }
     };
-  }, [instancedMeshes]);
+  }, [buckets]);
 
   useFrame(() => {
-    const groups = groupsRef.current;
-    if (groups.length === 0) return;
+    const bucketList = bucketsRef.current;
+    if (bucketList.length === 0) return;
     const buffer = getChunkTransforms();
     if (buffer.length === 0) return;
 
-    // Reset all counts each frame — we fill them from the WASM buffer.
-    const byId = new Map<number, { group: InstanceGroup; count: number }>();
-    for (const group of groups) {
-      byId.set(group.id, { group, count: 0 });
-    }
+    // Reset per-bucket "written" tracker so we know which slots to zero out.
+    const writtenByBucket = new Map<InstanceBucket, Set<number>>();
+    for (const bucket of bucketList) writtenByBucket.set(bucket, new Set());
 
     const total = Math.floor(buffer.length / CHUNK_TRANSFORM_STRIDE);
     for (let i = 0; i < total; i += 1) {
       const base = i * CHUNK_TRANSFORM_STRIDE;
       const destructibleId = buffer[base];
-      const entry = byId.get(destructibleId);
-      if (!entry) continue;
-      const slotIndex = entry.count;
-      if (slotIndex >= MAX_CHUNKS_PER_DESTRUCTIBLE) continue;
+      const chunkIndex = buffer[base + 1];
+      // A destructible may have multiple buckets (structure with mixed
+      // shapes); pick the one that owns this chunk index.
+      let bucket: InstanceBucket | null = null;
+      let slot = -1;
+      for (const candidate of bucketList) {
+        if (candidate.destructibleId !== destructibleId) continue;
+        // Factory buckets use an empty slot map and map chunkIndex → chunkIndex.
+        if (candidate.chunkIndexToSlot.size === 0) {
+          if (chunkIndex < MAX_CHUNKS_PER_BUCKET) {
+            bucket = candidate;
+            slot = chunkIndex;
+          }
+          break;
+        }
+        const mapped = candidate.chunkIndexToSlot.get(chunkIndex);
+        if (mapped !== undefined) {
+          bucket = candidate;
+          slot = mapped;
+          break;
+        }
+      }
+      if (!bucket || slot < 0) continue;
 
       tmpPosition.set(buffer[base + 2], buffer[base + 3], buffer[base + 4]);
       tmpQuaternion.set(buffer[base + 5], buffer[base + 6], buffer[base + 7], buffer[base + 8]);
       const presentFlag = buffer[base + 9] ?? 0;
       tmpMatrix.compose(tmpPosition, tmpQuaternion, presentFlag > 0 ? unitScale : zeroScale);
-      entry.group.mesh.setMatrixAt(slotIndex, tmpMatrix);
-      entry.count = slotIndex + 1;
+      bucket.mesh.setMatrixAt(slot, tmpMatrix);
+      writtenByBucket.get(bucket)!.add(slot);
     }
 
-    for (const { group, count } of byId.values()) {
-      group.mesh.count = count;
-      // Collapse the trailing unused instances to avoid rendering stale
-      // matrices when chunks disappear (debris cleanup).
-      for (let i = count; i < group.mesh.count; i += 1) {
+    for (const [bucket, written] of writtenByBucket.entries()) {
+      const capacity = bucket.mesh.instanceMatrix.count;
+      let maxWritten = -1;
+      for (const slot of written) if (slot > maxWritten) maxWritten = slot;
+      bucket.mesh.count = maxWritten + 1;
+      // Zero-scale any slots in the active range that weren't written this
+      // frame so stale matrices don't render.
+      for (let slot = 0; slot <= maxWritten && slot < capacity; slot += 1) {
+        if (written.has(slot)) continue;
         tmpMatrix.compose(tmpPosition.set(0, 0, 0), tmpQuaternion.set(0, 0, 0, 1), zeroScale);
-        group.mesh.setMatrixAt(i, tmpMatrix);
+        bucket.mesh.setMatrixAt(slot, tmpMatrix);
       }
-      group.mesh.instanceMatrix.needsUpdate = true;
+      bucket.mesh.instanceMatrix.needsUpdate = true;
     }
   });
 
-  if (instancedMeshes.length === 0) return null;
+  if (buckets.length === 0) return null;
 
   return (
     <group>
-      {instancedMeshes.map((group) => (
-        <primitive key={group.id} object={group.mesh} />
+      {buckets.map((bucket, i) => (
+        <primitive key={`${bucket.destructibleId}:${i}`} object={bucket.mesh} />
       ))}
     </group>
   );
+}
+
+function chunkGeometryKey(chunk: Chunk): string {
+  switch (chunk.shape) {
+    case 'box': {
+      const he = chunk.halfExtents ?? [0.25, 0.25, 0.25];
+      return `box:${he[0]}:${he[1]}:${he[2]}`;
+    }
+    case 'sphere':
+      return `sphere:${chunk.radius ?? 0.25}`;
+    case 'capsule':
+      return `capsule:${chunk.radius ?? 0.25}:${chunk.height ?? 0.5}`;
+  }
 }

--- a/client/src/scene/DestructibleChunks.tsx
+++ b/client/src/scene/DestructibleChunks.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { Chunk, Destructible, WorldDocument } from '../world/worldDocument';
+import type { Chunk, WorldDocument } from '../world/worldDocument';
+import { fractureChunks } from '../world/destructibleFactory';
 
 /**
  * Stride of the chunk transforms buffer produced by
@@ -119,8 +120,17 @@ export function DestructibleChunks({ world, getChunkTransforms }: DestructibleCh
       // Structure: group chunks by a (shape + size) key so each unique
       // geometry gets its own InstancedMesh. Slot order = order within the
       // group (not global chunk index), so we record the mapping.
+      //
+      // When `fractured` is true the WASM side subdivides each authored
+      // box chunk into brick-sized sub-chunks at spawn (see
+      // `fracture_chunks_default` in `destructibles_fracture.rs`), and the
+      // chunk indices returned by `get_destructible_chunk_transforms` index
+      // into that expanded list — not the authored one. Mirror the same
+      // expansion on the client so the visual chunks line up 1:1 with the
+      // physics chunks.
+      const renderChunks: Chunk[] = doc.fractured ? fractureChunks(doc.chunks) : doc.chunks;
       const groupByKey = new Map<string, { key: string; indices: number[]; geom: THREE.BufferGeometry }>();
-      doc.chunks.forEach((chunk: Chunk, index: number) => {
+      renderChunks.forEach((chunk: Chunk, index: number) => {
         const key = chunkGeometryKey(chunk);
         const existing = groupByKey.get(key);
         if (existing) {

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -75,40 +75,6 @@ import { PLAYER_PROFILE } from './characterAnim/profile';
 import { preload as preloadCharacterAssets } from './characterAnim/sharedAssets';
 import { STATE } from './characterAnim/types';
 
-/**
- * Practice-mode destructible structures.  Injected into the world
- * document at runtime (instead of authored in `trail.world.json`) so
- * the shared physics test suite — which exercises the default world —
- * stays unaffected by the Blast solver.
- *
- * The trail world's practice spawn / vehicles cluster around
- * `(0..8, *, 0)` on flat terrain (`terrain Y ≈ 0` for roughly
- * `x ∈ [-10, 12], z ∈ [-10, 6]`), with a ball pit at
- * `x ∈ [8, 15], z ∈ [8, 15]`.  Positions below are chosen to sit in
- * the flat area a short drive from each vehicle, in their own empty
- * space (no overlap with the second car at `(8, 2, 0)`, the ball pit,
- * or the hilly terrain outside the plaza). The wall is intentionally
- * placed straight ahead of the origin car so `/practice` browser
- * verification can drive into it with a single forward input.
- *
- * Shared destructible spawning now compensates for the upstream fixed
- * support row, so authored positions place the playable structure at
- * ground level instead of leaving that support lip exposed as a curb.
- * The practice coordinates below therefore remain the intuitive
- * authoring values: wall at `y=0`, tower at `y=0.5`.
- */
-const PRACTICE_DESTRUCTIBLES: ReadonlyArray<{
-  id: number;
-  kind: 'wall' | 'tower';
-  position: [number, number, number];
-  rotation: [number, number, number, number];
-}> = [
-  // Wall: 8m straight ahead of the origin vehicle — enter and drive forward.
-  { id: 2000, kind: 'wall', position: [0, 0, 8], rotation: [0, 0, 0, 1] },
-  // Tower: 5m N of the second vehicle at (8, *, 0) — drive forward to hit.
-  { id: 2001, kind: 'tower', position: [10, 0.5, -5], rotation: [0, 0, 0, 1] },
-];
-
 const VEHICLE_INTERACT_RADIUS = 4.0;
 const REMOTE_HIT_FLASH_MS = 180;
 const CROSSHAIR_MAX_DISTANCE = 1000;
@@ -1089,27 +1055,9 @@ export function GameWorld({
   sceneExtras,
 }: GameWorldProps) {
   const practiceMode = isPracticeMode(mode);
-  // In practice mode we overlay Blast destructibles onto the base world
-  // document so they flow through `loadWorldDocument` → `spawn_wall` /
-  // `spawn_tower` and through `<DestructibleChunks>` rendering without
-  // touching the authored `trail.world.json` (which the shared physics
-  // test suite loads).
-  const effectiveWorldDocument = useMemo(() => {
-    if (!practiceMode) return worldDocument;
-    if (worldDocument.destructibles.length > 0) return worldDocument;
-    return {
-      ...worldDocument,
-      destructibles: PRACTICE_DESTRUCTIBLES.map((d) => ({
-        id: d.id,
-        kind: d.kind,
-        position: [...d.position] as [number, number, number],
-        rotation: [...d.rotation] as [number, number, number, number],
-      })),
-    };
-  }, [practiceMode, worldDocument]);
   const worldJson = useMemo(
-    () => serializeWorldDocument(effectiveWorldDocument),
-    [effectiveWorldDocument],
+    () => serializeWorldDocument(worldDocument),
+    [worldDocument],
   );
   const localPlayerDebugHelper = useMemo(() => createPlayerDebugHelper(0x8cff66), []);
   const predictionWorldJson = useMemo(
@@ -2477,7 +2425,7 @@ export function GameWorld({
         debugState: destructibleDebugState,
         debugConfig: destructibleDebugConfig,
         loggingEnabled: destructibleLoggingEnabled,
-        spatialMetrics: computeDestructibleSpatialMetrics(effectiveWorldDocument.destructibles, destructibleChunkTransforms),
+        spatialMetrics: computeDestructibleSpatialMetrics(worldDocument.destructibles, destructibleChunkTransforms),
       };
       const remoteSummaries: Array<{ id: number; position: [number, number, number] }> = [];
       for (const [id, rp] of state.remotePlayers) {
@@ -2844,11 +2792,11 @@ export function GameWorld({
         shadow-normalBias={0.03}
       />
       <directionalLight position={[-28, 20, -32]} intensity={0.55} color={0xa8c8ff} />
-      <WorldTerrain world={effectiveWorldDocument} />
-      <WorldStaticProps world={effectiveWorldDocument} />
-      {practiceMode && effectiveWorldDocument.destructibles.length > 0 && (
+      <WorldTerrain world={worldDocument} />
+      <WorldStaticProps world={worldDocument} />
+      {practiceMode && worldDocument.destructibles.length > 0 && (
         <DestructibleChunks
-          world={effectiveWorldDocument}
+          world={worldDocument}
           getChunkTransforms={() => runtimeRef.current?.getDestructibleChunkTransforms() ?? new Float32Array(0)}
         />
       )}

--- a/client/src/world/destructibleFactory.ts
+++ b/client/src/world/destructibleFactory.ts
@@ -1,5 +1,5 @@
-import type { Chunk, Vec3 } from './worldDocument';
-import { identityQuaternion } from './worldDocument';
+import type { Chunk, Quaternion, Vec3 } from './worldDocument';
+import { FRACTURE_BRICK_EDGE_M, identityQuaternion } from './worldDocument';
 
 // Mirror of `WallOptions::default()` / `TowerOptions::default()` layouts used
 // by the Rust factory expansion. Keep in sync with
@@ -80,4 +80,79 @@ export function buildTowerChunks(): Chunk[] {
     }
   }
   return out;
+}
+
+/**
+ * Subdivide authored chunks into brick-sized sub-chunks so the Blast
+ * auto-bonder can wire them together into a rich bond network.
+ *
+ * Box chunks are split into an axis-aligned grid where each cell is at
+ * least `brickEdge` on every axis. Sphere/capsule chunks pass through
+ * unchanged (only their box neighbors will bond into them).
+ *
+ * Mass overrides are distributed across sub-bricks so total mass stays
+ * constant. Anchor / material flags are inherited by every sub-brick.
+ */
+export function fractureChunks(chunks: readonly Chunk[], brickEdge = FRACTURE_BRICK_EDGE_M): Chunk[] {
+  const out: Chunk[] = [];
+  for (const chunk of chunks) {
+    if (chunk.shape !== 'box' || !chunk.halfExtents) {
+      out.push(chunk);
+      continue;
+    }
+    const [hx, hy, hz] = chunk.halfExtents;
+    const cellsX = Math.max(1, Math.floor((hx * 2) / brickEdge));
+    const cellsY = Math.max(1, Math.floor((hy * 2) / brickEdge));
+    const cellsZ = Math.max(1, Math.floor((hz * 2) / brickEdge));
+    if (cellsX === 1 && cellsY === 1 && cellsZ === 1) {
+      out.push(chunk);
+      continue;
+    }
+    const cellHx = hx / cellsX;
+    const cellHy = hy / cellsY;
+    const cellHz = hz / cellsZ;
+    const parentRot = chunk.rotation;
+    const parentPos = chunk.position;
+    const totalCells = cellsX * cellsY * cellsZ;
+    for (let ix = 0; ix < cellsX; ix += 1) {
+      for (let iy = 0; iy < cellsY; iy += 1) {
+        for (let iz = 0; iz < cellsZ; iz += 1) {
+          const localCenter: Vec3 = [
+            -hx + cellHx * (2 * ix + 1),
+            -hy + cellHy * (2 * iy + 1),
+            -hz + cellHz * (2 * iz + 1),
+          ];
+          const rotated = rotateVec3ByQuaternion(localCenter, parentRot);
+          const sub: Chunk = {
+            shape: 'box',
+            position: [
+              parentPos[0] + rotated[0],
+              parentPos[1] + rotated[1],
+              parentPos[2] + rotated[2],
+            ] as Vec3,
+            rotation: [...parentRot] as Quaternion,
+            halfExtents: [cellHx, cellHy, cellHz] as Vec3,
+          };
+          if (chunk.material !== undefined) sub.material = chunk.material;
+          if (chunk.anchor === true) sub.anchor = true;
+          if (typeof chunk.mass === 'number') sub.mass = chunk.mass / totalCells;
+          out.push(sub);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function rotateVec3ByQuaternion(v: Vec3, q: Quaternion): Vec3 {
+  const [x, y, z] = v;
+  const [qx, qy, qz, qw] = q;
+  const tx = 2 * (qy * z - qz * y);
+  const ty = 2 * (qz * x - qx * z);
+  const tz = 2 * (qx * y - qy * x);
+  return [
+    x + qw * tx + (qy * tz - qz * ty),
+    y + qw * ty + (qz * tx - qx * tz),
+    z + qw * tz + (qx * ty - qy * tx),
+  ];
 }

--- a/client/src/world/destructibleFactory.ts
+++ b/client/src/world/destructibleFactory.ts
@@ -1,0 +1,83 @@
+import type { Chunk, Vec3 } from './worldDocument';
+import { identityQuaternion } from './worldDocument';
+
+// Mirror of `WallOptions::default()` / `TowerOptions::default()` layouts used
+// by the Rust factory expansion. Keep in sync with
+// `shared/src/destructibles_native_fallback.rs`.
+const WALL_SPAN_M = 6.0;
+const WALL_HEIGHT_M = 3.0;
+const WALL_THICKNESS_M = 0.32;
+const WALL_SPAN_SEGMENTS = 12;
+const WALL_HEIGHT_SEGMENTS = 6;
+const WALL_LAYERS = 1;
+
+const TOWER_SIDE = 4;
+const TOWER_STORIES = 7;
+const TOWER_SPACING_X = 0.5;
+const TOWER_SPACING_Y = 0.5;
+const TOWER_SPACING_Z = 0.5;
+
+export function expandFactoryKindToChunks(kind: 'wall' | 'tower'): Chunk[] {
+  return kind === 'wall' ? buildWallChunks() : buildTowerChunks();
+}
+
+export function buildWallChunks(): Chunk[] {
+  const cellX = WALL_SPAN_M / WALL_SPAN_SEGMENTS;
+  const cellY = WALL_HEIGHT_M / WALL_HEIGHT_SEGMENTS;
+  const cellZ = WALL_THICKNESS_M / WALL_LAYERS;
+  const originX = -WALL_SPAN_M * 0.5 + cellX * 0.5;
+  const originY = cellY * 0.5;
+  const halfExtents: Vec3 = [cellX * 0.5, cellY * 0.5, cellZ * 0.5];
+  const out: Chunk[] = [];
+  for (let ix = 0; ix < WALL_SPAN_SEGMENTS; ix += 1) {
+    for (let iy = 0; iy < WALL_HEIGHT_SEGMENTS; iy += 1) {
+      for (let iz = 0; iz < WALL_LAYERS; iz += 1) {
+        const position: Vec3 = [
+          originX + ix * cellX,
+          originY + iy * cellY,
+          (iz - (WALL_LAYERS - 1) * 0.5) * cellZ,
+        ];
+        const chunk: Chunk = {
+          shape: 'box',
+          position,
+          rotation: identityQuaternion(),
+          halfExtents: [...halfExtents] as Vec3,
+        };
+        if (iy === 0) chunk.anchor = true;
+        out.push(chunk);
+      }
+    }
+  }
+  return out;
+}
+
+export function buildTowerChunks(): Chunk[] {
+  const totalRows = TOWER_STORIES + 1;
+  const halfExtents: Vec3 = [
+    TOWER_SPACING_X * 0.5,
+    TOWER_SPACING_Y * 0.5,
+    TOWER_SPACING_Z * 0.5,
+  ];
+  const sideCenter = (TOWER_SIDE - 1) * 0.5;
+  const out: Chunk[] = [];
+  for (let iz = 0; iz < TOWER_SIDE; iz += 1) {
+    for (let iy = 0; iy < totalRows; iy += 1) {
+      for (let ix = 0; ix < TOWER_SIDE; ix += 1) {
+        const position: Vec3 = [
+          (ix - sideCenter) * TOWER_SPACING_X,
+          (iy - 1) * TOWER_SPACING_Y,
+          (iz - sideCenter) * TOWER_SPACING_Z,
+        ];
+        const chunk: Chunk = {
+          shape: 'box',
+          position,
+          rotation: identityQuaternion(),
+          halfExtents: [...halfExtents] as Vec3,
+        };
+        if (iy === 0) chunk.anchor = true;
+        out.push(chunk);
+      }
+    }
+  }
+  return out;
+}

--- a/client/src/world/destructiblesPhysics.test.ts
+++ b/client/src/world/destructiblesPhysics.test.ts
@@ -864,8 +864,8 @@ describe('Destructible scenarios (Blast stress solver)', () => {
   // ─────────────────────────────────────────────────────────────────────
   // Practice-mode placement regression tests
   //
-  // The `/practice` route places destructibles at the coordinates in
-  // `PRACTICE_DESTRUCTIBLES` inside `client/src/scene/GameWorld.tsx`:
+  // The `/practice` route loads `worlds/trail.world.json`, which
+  // authors its destructibles at:
   //
   //   Wall:  id=2000 kind=wall  position=(0, 0, 8)
   //   Tower: id=2001 kind=tower position=(10, 0.5, -5)
@@ -886,7 +886,7 @@ describe('Destructible scenarios (Blast stress solver)', () => {
         version: 2,
         meta: {
           name: 'Practice-mode destructible placement',
-          description: 'Mirrors client/src/scene/GameWorld.tsx PRACTICE_DESTRUCTIBLES.',
+          description: 'Mirrors worlds/trail.world.json destructibles array.',
         },
         terrain: {
           tileGridSize: gridSize,
@@ -1685,6 +1685,92 @@ describe('Destructible scenarios (Blast stress solver)', () => {
       if (drift > maxTowerDrift) maxTowerDrift = drift;
     }
     expect(maxTowerDrift).toBeLessThan(0.2);
+
+    sim.free();
+  });
+});
+
+describe('Authored structure destructibles', () => {
+  /** Build a stacked-box structure: bottom row anchored, 2 dynamic bricks on top. */
+  function makeStackedStructureWorld(): WorldDocument {
+    const gridSize = 9;
+    return {
+      version: 2,
+      meta: {
+        name: 'Authored stacked structure',
+        description: 'Two bricks balanced on an anchored base.',
+      },
+      terrain: {
+        tileGridSize: gridSize,
+        tileHalfExtentM: 16,
+        tiles: [{
+          tileX: 0,
+          tileZ: 0,
+          heights: makeFlatTileHeights(gridSize),
+        }],
+      },
+      staticProps: [],
+      dynamicEntities: [],
+      destructibles: [
+        {
+          id: 8001,
+          kind: 'structure',
+          position: [0, 0, 0],
+          rotation: [0, 0, 0, 1],
+          density: 2400,
+          chunks: [
+            // Bottom anchor.
+            {
+              shape: 'box',
+              position: [0, 0.25, 0],
+              rotation: [0, 0, 0, 1],
+              halfExtents: [0.25, 0.25, 0.25],
+              anchor: true,
+            },
+            // Middle brick sits on the anchor.
+            {
+              shape: 'box',
+              position: [0, 0.75, 0],
+              rotation: [0, 0, 0, 1],
+              halfExtents: [0.25, 0.25, 0.25],
+            },
+            // Top brick sits on the middle.
+            {
+              shape: 'box',
+              position: [0, 1.25, 0],
+              rotation: [0, 0, 0, 1],
+              halfExtents: [0.25, 0.25, 0.25],
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it('spawns the authored chunks and keeps them bonded under gravity', () => {
+    const sim = new WasmSimWorld();
+    sim.loadWorldDocument(serializeWorldDocument(makeStackedStructureWorld()));
+    sim.rebuildBroadPhase();
+    sim.stepDestructibles(); // prime transform buffer
+
+    const count = sim.getDestructibleChunkCount();
+    expect(count).toBe(3);
+
+    const start = Float32Array.from(sim.getDestructibleChunkTransforms());
+    for (let i = 0; i < 120; i += 1) sim.stepDynamics(1 / 60);
+    const end = sim.getDestructibleChunkTransforms();
+
+    // Every chunk must still be present (stress solver keeps them bonded).
+    let maxYDrift = 0;
+    for (let i = 0; i < count; i += 1) {
+      const base = i * CHUNK_TRANSFORM_STRIDE;
+      const present = end[base + 9] ?? 0;
+      expect(present).toBeGreaterThan(0);
+      const dy = Math.abs((end[base + 3] ?? 0) - (start[base + 3] ?? 0));
+      if (dy > maxYDrift) maxYDrift = dy;
+    }
+    // Bonded chunks should not visibly drift under the tiny bond tension.
+    expect(maxYDrift).toBeLessThan(0.05);
 
     sim.free();
   });

--- a/client/src/world/worldDocument.test.ts
+++ b/client/src/world/worldDocument.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_WORLD_DOCUMENT,
   cloneWorldDocument,
+  createEmptyWorldDocument,
+  MAX_CHUNKS_PER_STRUCTURE,
+  parseWorldDocument,
   removeVehicleEntitiesFromWorldDocument,
+  serializeWorldDocument,
+  type StructureDestructible,
+  type WorldDocument,
 } from './worldDocument';
 
 describe('WorldDocument helpers', () => {
@@ -26,5 +32,138 @@ describe('WorldDocument helpers', () => {
     };
 
     expect(removeVehicleEntitiesFromWorldDocument(world)).toBe(world);
+  });
+});
+
+describe('Destructible schema parse / serialize', () => {
+  function worldWithDestructibles(destructibles: WorldDocument['destructibles']): WorldDocument {
+    return { ...createEmptyWorldDocument(), destructibles };
+  }
+
+  it('round-trips a legacy wall factory destructible unchanged', () => {
+    const world = worldWithDestructibles([
+      { id: 100, kind: 'wall', position: [1, 0, 2], rotation: [0, 0, 0, 1] },
+    ]);
+    const reparsed = parseWorldDocument(JSON.parse(serializeWorldDocument(world)));
+    expect(reparsed.destructibles).toEqual(world.destructibles);
+  });
+
+  it('round-trips an authored structure with mixed-shape chunks', () => {
+    const structure: StructureDestructible = {
+      id: 200,
+      kind: 'structure',
+      position: [0, 0, 0],
+      rotation: [0, 0, 0, 1],
+      density: 1800,
+      solverMaterialScale: 1.5,
+      chunks: [
+        {
+          shape: 'box',
+          position: [0, 0.25, 0],
+          rotation: [0, 0, 0, 1],
+          halfExtents: [0.25, 0.25, 0.25],
+          anchor: true,
+        },
+        {
+          shape: 'sphere',
+          position: [0, 0.75, 0],
+          rotation: [0, 0, 0, 1],
+          radius: 0.25,
+          mass: 5,
+        },
+        {
+          shape: 'capsule',
+          position: [0, 1.5, 0],
+          rotation: [0, 0, 0, 1],
+          radius: 0.2,
+          height: 0.6,
+        },
+      ],
+    };
+    const world = worldWithDestructibles([structure]);
+    const reparsed = parseWorldDocument(JSON.parse(serializeWorldDocument(world)));
+    expect(reparsed.destructibles).toEqual([structure]);
+  });
+
+  it('rejects a box chunk missing halfExtents', () => {
+    const raw = {
+      ...JSON.parse(serializeWorldDocument(createEmptyWorldDocument())),
+      destructibles: [
+        {
+          id: 300,
+          kind: 'structure',
+          position: [0, 0, 0],
+          rotation: [0, 0, 0, 1],
+          chunks: [{ shape: 'box', position: [0, 0, 0], rotation: [0, 0, 0, 1] }],
+        },
+      ],
+    };
+    expect(() => parseWorldDocument(raw)).toThrow(/halfExtents/);
+  });
+
+  it('rejects a sphere chunk missing radius', () => {
+    const raw = {
+      ...JSON.parse(serializeWorldDocument(createEmptyWorldDocument())),
+      destructibles: [
+        {
+          id: 301,
+          kind: 'structure',
+          position: [0, 0, 0],
+          rotation: [0, 0, 0, 1],
+          chunks: [{ shape: 'sphere', position: [0, 0, 0], rotation: [0, 0, 0, 1] }],
+        },
+      ],
+    };
+    expect(() => parseWorldDocument(raw)).toThrow(/radius/);
+  });
+
+  it('rejects a capsule chunk missing height', () => {
+    const raw = {
+      ...JSON.parse(serializeWorldDocument(createEmptyWorldDocument())),
+      destructibles: [
+        {
+          id: 302,
+          kind: 'structure',
+          position: [0, 0, 0],
+          rotation: [0, 0, 0, 1],
+          chunks: [
+            { shape: 'capsule', position: [0, 0, 0], rotation: [0, 0, 0, 1], radius: 0.2 },
+          ],
+        },
+      ],
+    };
+    expect(() => parseWorldDocument(raw)).toThrow(/height/);
+  });
+
+  it('rejects structures that exceed MAX_CHUNKS_PER_STRUCTURE', () => {
+    const tooMany = Array.from({ length: MAX_CHUNKS_PER_STRUCTURE + 1 }, (_, i) => ({
+      shape: 'box',
+      position: [i, 0, 0],
+      rotation: [0, 0, 0, 1],
+      halfExtents: [0.1, 0.1, 0.1],
+    }));
+    const raw = {
+      ...JSON.parse(serializeWorldDocument(createEmptyWorldDocument())),
+      destructibles: [
+        {
+          id: 303,
+          kind: 'structure',
+          position: [0, 0, 0],
+          rotation: [0, 0, 0, 1],
+          chunks: tooMany,
+        },
+      ],
+    };
+    expect(() => parseWorldDocument(raw)).toThrow(/max/);
+  });
+
+  it('rejects an unknown destructible kind', () => {
+    const raw = {
+      ...JSON.parse(serializeWorldDocument(createEmptyWorldDocument())),
+      destructibles: [
+        { id: 304, kind: 'rampart', position: [0, 0, 0], rotation: [0, 0, 0, 1] },
+      ],
+    };
+    expect(() => parseWorldDocument(raw)).toThrow(/unknown kind/);
   });
 });

--- a/client/src/world/worldDocument.ts
+++ b/client/src/world/worldDocument.ts
@@ -120,16 +120,75 @@ export type DynamicEntity = {
 };
 
 /**
- * A destructible structure backed by NVIDIA Blast's stress solver. Kind
- * selects the scenario builder (wall / tower); position + rotation place
- * the resulting chunks in world space.
+ * A destructible structure backed by NVIDIA Blast's stress solver in
+ * single-player (WASM) builds; native-server multiplayer falls back to
+ * independent dynamic rigid bodies (one per chunk).
+ *
+ * `wall` and `tower` are factory kinds — opaque scenarios produced by
+ * preset Blast builders. `structure` is fully authored: chunks are
+ * composed from `box | sphere | capsule` primitives and auto-bonded by
+ * Blast at build time (chunks must be in contact for bonds to form).
+ *
+ * Chunk ordering matters: the native-server fallback assigns each chunk a
+ * stable rigid-body id of `(destructible.id << 12) | chunk_index`, so a
+ * single destructible can hold at most **4096 chunks**.
  */
-export type Destructible = {
+export type Destructible =
+  | FactoryDestructible
+  | StructureDestructible;
+
+export type FactoryDestructible = {
   id: number;
   kind: 'wall' | 'tower';
   position: Vec3;
   rotation: Quaternion;
 };
+
+export type StructureDestructible = {
+  id: number;
+  kind: 'structure';
+  position: Vec3;
+  rotation: Quaternion;
+  /** Material density in kg/m³; defaults to 2400 when omitted. */
+  density?: number;
+  /** Multiplier on Blast per-material stiffness; defaults to 1. */
+  solverMaterialScale?: number;
+  chunks: Chunk[];
+};
+
+export type ChunkShape = 'box' | 'sphere' | 'capsule';
+
+/**
+ * One authored chunk inside a `structure` destructible. Position and
+ * rotation are in the structure's local frame (applied after the
+ * structure's world pose).
+ *
+ * Shape-specific size fields:
+ *  - `box` → `halfExtents` required.
+ *  - `sphere` → `radius` required.
+ *  - `capsule` → `radius` + `height` required (cylinder segment length,
+ *    excluding the two hemispherical caps).
+ *
+ * `mass` overrides the density-derived mass. `anchor=true` marks the
+ * chunk as a static support (replaces the implicit `y==0` rule). On
+ * native servers, anchored chunks are spawned as static cuboids
+ * (sphere/capsule anchors fall back to a tight-fit cuboid AABB).
+ */
+export type Chunk = {
+  shape: ChunkShape;
+  position: Vec3;
+  rotation: Quaternion;
+  halfExtents?: Vec3;
+  radius?: number;
+  height?: number;
+  mass?: number;
+  material?: string;
+  anchor?: boolean;
+};
+
+export const DEFAULT_STRUCTURE_DENSITY_KG_M3 = 2400;
+export const DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE = 1;
+export const MAX_CHUNKS_PER_STRUCTURE = 4096;
 
 export type WorldDraftRevision = {
   id: string;
@@ -201,11 +260,94 @@ export function parseWorldDocument(raw: unknown): WorldDocument {
       ...(entity as DynamicEntity),
       rotation: normalizeQuaternion((entity as Partial<DynamicEntity>).rotation),
     })),
-    destructibles: rawDestructibles.map((entity) => ({
-      ...(entity as Destructible),
-      rotation: normalizeQuaternion((entity as Partial<Destructible>).rotation),
-    })),
+    destructibles: rawDestructibles.map((raw) => normalizeDestructible(raw)),
   };
+}
+
+function normalizeDestructible(raw: unknown): Destructible {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Destructible entry must be an object.');
+  }
+  const candidate = raw as {
+    id?: number;
+    kind?: string;
+    position?: Vec3;
+    rotation?: unknown;
+    density?: number;
+    solverMaterialScale?: number;
+    chunks?: unknown[];
+  };
+  if (typeof candidate.id !== 'number') {
+    throw new Error('Destructible is missing id.');
+  }
+  const position = (candidate.position ?? [0, 0, 0]) as Vec3;
+  const rotation = normalizeQuaternion(candidate.rotation as Partial<Quaternion> | undefined);
+  if (candidate.kind === 'wall' || candidate.kind === 'tower') {
+    return { id: candidate.id, kind: candidate.kind, position, rotation };
+  }
+  if (candidate.kind === 'structure') {
+    const rawChunks = Array.isArray(candidate.chunks) ? candidate.chunks : [];
+    if (rawChunks.length > MAX_CHUNKS_PER_STRUCTURE) {
+      throw new Error(
+        `Destructible ${candidate.id} has ${rawChunks.length} chunks (max ${MAX_CHUNKS_PER_STRUCTURE}).`,
+      );
+    }
+    const chunks = rawChunks.map((rawChunk, index) => normalizeChunk(rawChunk, candidate.id!, index));
+    return {
+      id: candidate.id,
+      kind: 'structure',
+      position,
+      rotation,
+      ...(typeof candidate.density === 'number' ? { density: candidate.density } : {}),
+      ...(typeof candidate.solverMaterialScale === 'number'
+        ? { solverMaterialScale: candidate.solverMaterialScale }
+        : {}),
+      chunks,
+    };
+  }
+  throw new Error(`Destructible ${candidate.id} has unknown kind ${String(candidate.kind)}.`);
+}
+
+function normalizeChunk(raw: unknown, structureId: number, chunkIndex: number): Chunk {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`Chunk [${structureId}:${chunkIndex}] must be an object.`);
+  }
+  const c = raw as Partial<Chunk> & { shape?: string };
+  if (c.shape !== 'box' && c.shape !== 'sphere' && c.shape !== 'capsule') {
+    throw new Error(`Chunk [${structureId}:${chunkIndex}] has unknown shape ${String(c.shape)}.`);
+  }
+  const position = (c.position ?? [0, 0, 0]) as Vec3;
+  const rotation = normalizeQuaternion(c.rotation as Partial<Quaternion> | undefined);
+  if (c.shape === 'box') {
+    if (!Array.isArray(c.halfExtents) || c.halfExtents.length !== 3) {
+      throw new Error(`Box chunk [${structureId}:${chunkIndex}] is missing halfExtents.`);
+    }
+  } else if (c.shape === 'sphere') {
+    if (typeof c.radius !== 'number' || !(c.radius > 0)) {
+      throw new Error(`Sphere chunk [${structureId}:${chunkIndex}] is missing positive radius.`);
+    }
+  } else if (c.shape === 'capsule') {
+    if (typeof c.radius !== 'number' || !(c.radius > 0)) {
+      throw new Error(`Capsule chunk [${structureId}:${chunkIndex}] is missing positive radius.`);
+    }
+    if (typeof c.height !== 'number' || !(c.height >= 0)) {
+      throw new Error(`Capsule chunk [${structureId}:${chunkIndex}] is missing non-negative height.`);
+    }
+  }
+  const chunk: Chunk = {
+    shape: c.shape,
+    position,
+    rotation,
+  };
+  if (Array.isArray(c.halfExtents) && c.halfExtents.length === 3) {
+    chunk.halfExtents = [...c.halfExtents] as Vec3;
+  }
+  if (typeof c.radius === 'number') chunk.radius = c.radius;
+  if (typeof c.height === 'number') chunk.height = c.height;
+  if (typeof c.mass === 'number') chunk.mass = c.mass;
+  if (typeof c.material === 'string') chunk.material = c.material;
+  if (c.anchor === true) chunk.anchor = true;
+  return chunk;
 }
 
 export function serializeWorldDocument(world: WorldDocument): string {

--- a/client/src/world/worldDocument.ts
+++ b/client/src/world/worldDocument.ts
@@ -153,6 +153,13 @@ export type StructureDestructible = {
   density?: number;
   /** Multiplier on Blast per-material stiffness; defaults to 1. */
   solverMaterialScale?: number;
+  /**
+   * When true, each authored chunk is subdivided into brick-sized
+   * sub-chunks at spawn time and the Blast auto-bonder wires them into
+   * a single bonded network. Disabled by default. Applies on both
+   * single-player (Blast) and native (per-chunk rigid body) paths.
+   */
+  fractured?: boolean;
   chunks: Chunk[];
 };
 
@@ -189,6 +196,12 @@ export type Chunk = {
 export const DEFAULT_STRUCTURE_DENSITY_KG_M3 = 2400;
 export const DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE = 1;
 export const MAX_CHUNKS_PER_STRUCTURE = 4096;
+/**
+ * Target brick edge length (meters) used when `StructureDestructible.fractured`
+ * is true. Authored chunks are subdivided so no resulting sub-brick is smaller
+ * than this on any axis. Picked around the size of a concrete masonry unit.
+ */
+export const FRACTURE_BRICK_EDGE_M = 0.25;
 
 export type WorldDraftRevision = {
   id: string;
@@ -275,6 +288,7 @@ function normalizeDestructible(raw: unknown): Destructible {
     rotation?: unknown;
     density?: number;
     solverMaterialScale?: number;
+    fractured?: boolean;
     chunks?: unknown[];
   };
   if (typeof candidate.id !== 'number') {
@@ -302,6 +316,7 @@ function normalizeDestructible(raw: unknown): Destructible {
       ...(typeof candidate.solverMaterialScale === 'number'
         ? { solverMaterialScale: candidate.solverMaterialScale }
         : {}),
+      ...(candidate.fractured === true ? { fractured: true } : {}),
       chunks,
     };
   }

--- a/shared/src/destructibles_fracture.rs
+++ b/shared/src/destructibles_fracture.rs
@@ -1,0 +1,186 @@
+//! Brick-grid fracturing for authored destructible structures.
+//!
+//! Used when `DestructibleDoc::Structure { fractured: true, .. }` is spawned:
+//! each authored box chunk is subdivided into an axis-aligned grid of
+//! brick-sized sub-chunks so the Blast stress solver can auto-bond them
+//! into a rich network. Sphere and capsule chunks pass through unchanged
+//! (complex-shape fracturing is out of scope for now).
+//!
+//! Keep in sync with `fractureChunks` in
+//! `client/src/world/destructibleFactory.ts`.
+
+use nalgebra::{Quaternion, UnitQuaternion, Vector3};
+
+use crate::world_document::{ChunkDoc, FRACTURE_BRICK_EDGE_M};
+
+/// Subdivide every box chunk into brick-sized sub-boxes. No sub-brick is
+/// smaller than `brick_edge` on any axis. Mass overrides are distributed
+/// across sub-bricks so total mass stays constant; anchor/material flags
+/// propagate to every sub-brick.
+pub fn fracture_chunks(chunks: &[ChunkDoc], brick_edge: f32) -> Vec<ChunkDoc> {
+    let mut out = Vec::with_capacity(chunks.len());
+    for chunk in chunks {
+        match chunk {
+            ChunkDoc::Box {
+                position,
+                rotation,
+                half_extents,
+                mass,
+                material,
+                anchor,
+            } => {
+                let cells_x = (half_extents[0] * 2.0 / brick_edge).floor().max(1.0) as usize;
+                let cells_y = (half_extents[1] * 2.0 / brick_edge).floor().max(1.0) as usize;
+                let cells_z = (half_extents[2] * 2.0 / brick_edge).floor().max(1.0) as usize;
+                if cells_x == 1 && cells_y == 1 && cells_z == 1 {
+                    out.push(chunk.clone());
+                    continue;
+                }
+                let cell_hx = half_extents[0] / cells_x as f32;
+                let cell_hy = half_extents[1] / cells_y as f32;
+                let cell_hz = half_extents[2] / cells_z as f32;
+                let rot_unit = UnitQuaternion::from_quaternion(Quaternion::new(
+                    rotation[3],
+                    rotation[0],
+                    rotation[1],
+                    rotation[2],
+                ));
+                let parent_pos = Vector3::new(position[0], position[1], position[2]);
+                let total_cells = (cells_x * cells_y * cells_z) as f32;
+                let sub_mass = mass.map(|m| m / total_cells);
+                for ix in 0..cells_x {
+                    for iy in 0..cells_y {
+                        for iz in 0..cells_z {
+                            let local_center = Vector3::new(
+                                -half_extents[0] + cell_hx * (2 * ix + 1) as f32,
+                                -half_extents[1] + cell_hy * (2 * iy + 1) as f32,
+                                -half_extents[2] + cell_hz * (2 * iz + 1) as f32,
+                            );
+                            let rotated = rot_unit.transform_vector(&local_center);
+                            let world_pos = parent_pos + rotated;
+                            out.push(ChunkDoc::Box {
+                                position: [world_pos.x, world_pos.y, world_pos.z],
+                                rotation: *rotation,
+                                half_extents: [cell_hx, cell_hy, cell_hz],
+                                mass: sub_mass,
+                                material: material.clone(),
+                                anchor: *anchor,
+                            });
+                        }
+                    }
+                }
+            }
+            ChunkDoc::Sphere { .. } | ChunkDoc::Capsule { .. } => {
+                out.push(chunk.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Convenience using the default brick edge constant.
+pub fn fracture_chunks_default(chunks: &[ChunkDoc]) -> Vec<ChunkDoc> {
+    fracture_chunks(chunks, FRACTURE_BRICK_EDGE_M)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_large_box_into_expected_grid() {
+        let chunk = ChunkDoc::Box {
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            half_extents: [0.5, 0.5, 0.125],
+            mass: None,
+            material: None,
+            anchor: false,
+        };
+        // 1.0 x 1.0 x 0.25  /  0.25  →  4 x 4 x 1  =  16 cells.
+        let out = fracture_chunks(&[chunk], 0.25);
+        assert_eq!(out.len(), 16);
+        for c in &out {
+            if let ChunkDoc::Box { half_extents, .. } = c {
+                assert!((half_extents[0] - 0.125).abs() < 1e-6);
+                assert!((half_extents[1] - 0.125).abs() < 1e-6);
+                assert!((half_extents[2] - 0.125).abs() < 1e-6);
+            } else {
+                panic!("expected box sub-chunk");
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_small_box_unchanged() {
+        let chunk = ChunkDoc::Box {
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            // All axes < brick_edge → not subdivided.
+            half_extents: [0.1, 0.1, 0.1],
+            mass: Some(2.0),
+            material: None,
+            anchor: true,
+        };
+        let out = fracture_chunks(&[chunk.clone()], 0.25);
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            ChunkDoc::Box {
+                half_extents,
+                mass,
+                anchor,
+                ..
+            } => {
+                assert_eq!(*half_extents, [0.1, 0.1, 0.1]);
+                assert_eq!(*mass, Some(2.0));
+                assert!(*anchor);
+            }
+            _ => panic!("expected box"),
+        }
+    }
+
+    #[test]
+    fn distributes_mass_across_sub_bricks() {
+        let chunk = ChunkDoc::Box {
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            half_extents: [0.25, 0.25, 0.25],
+            mass: Some(8.0),
+            material: None,
+            anchor: false,
+        };
+        // 0.5 x 0.5 x 0.5 / 0.25 → 2 x 2 x 2 = 8 cells, each 1.0 kg.
+        let out = fracture_chunks(&[chunk], 0.25);
+        assert_eq!(out.len(), 8);
+        for c in &out {
+            if let ChunkDoc::Box { mass, .. } = c {
+                assert!((mass.unwrap() - 1.0).abs() < 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    fn passes_spheres_and_capsules_through_unchanged() {
+        let s = ChunkDoc::Sphere {
+            position: [1.0, 2.0, 3.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            radius: 0.5,
+            mass: None,
+            material: None,
+            anchor: false,
+        };
+        let c = ChunkDoc::Capsule {
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            radius: 0.2,
+            height: 1.0,
+            mass: None,
+            material: None,
+            anchor: false,
+        };
+        let out = fracture_chunks(&[s, c], 0.25);
+        assert_eq!(out.len(), 2);
+        assert!(matches!(out[0], ChunkDoc::Sphere { .. }));
+        assert!(matches!(out[1], ChunkDoc::Capsule { .. }));
+    }
+}

--- a/shared/src/destructibles_native_fallback.rs
+++ b/shared/src/destructibles_native_fallback.rs
@@ -1,0 +1,185 @@
+//! Native-server destructible fallback.
+//!
+//! On the native server the NVIDIA Blast crate is not available (it ships
+//! prebuilt wasm32 static libraries only). This module expands every
+//! authored destructible into independent dynamic rigid bodies so a
+//! structure still falls apart under gravity, just without stress-solver
+//! bonding or fracture propagation.
+//!
+//! Layout of factory `Wall` / `Tower` chunks mirrors the Blast
+//! `WallOptions::default` / `TowerOptions::default` scenarios used by the
+//! WASM client, so a world that looks identical in single-player and
+//! multiplayer spawns the same number of chunks at the same poses. The
+//! bottom row of each factory scenario is a fixed support — it becomes a
+//! static cuboid here (the implicit `y == 0` support-row rule).
+//!
+//! Stable body ids follow `(destructible_id << 12) | chunk_index` so
+//! snapshots and destructible-level operations stay addressable.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use nalgebra::{UnitQuaternion, Vector3};
+
+use crate::physics_arena::PhysicsArena;
+use crate::world_document::{ChunkDoc, DestructibleKind};
+
+// Mirror of `WallOptions::default()` from the upstream blast-stress-solver
+// crate. Keeping these in sync with the WASM build lets authored worlds
+// render the same geometry in both single-player and multiplayer.
+const WALL_SPAN_M: f32 = 6.0;
+const WALL_HEIGHT_M: f32 = 3.0;
+const WALL_THICKNESS_M: f32 = 0.32;
+const WALL_SPAN_SEGMENTS: usize = 12;
+const WALL_HEIGHT_SEGMENTS: usize = 6;
+const WALL_LAYERS: usize = 1;
+
+// Mirror of `TowerOptions::default()` (side=4, stories=7, spacing=0.5).
+const TOWER_SIDE: usize = 4;
+const TOWER_STORIES: usize = 7;
+const TOWER_SPACING_X: f32 = 0.5;
+const TOWER_SPACING_Y: f32 = 0.5;
+const TOWER_SPACING_Z: f32 = 0.5;
+
+/// Returns the chunk list that the Blast wall / tower scenarios would
+/// produce, expressed as authored box chunks in the destructible's local
+/// frame. Bottom row is marked `anchor = true`.
+pub fn factory_chunks_for_fallback(kind: DestructibleKind) -> Vec<ChunkDoc> {
+    match kind {
+        DestructibleKind::Wall => build_wall_chunks(),
+        DestructibleKind::Tower => build_tower_chunks(),
+    }
+}
+
+fn build_wall_chunks() -> Vec<ChunkDoc> {
+    let cell_x = WALL_SPAN_M / WALL_SPAN_SEGMENTS as f32;
+    let cell_y = WALL_HEIGHT_M / WALL_HEIGHT_SEGMENTS as f32;
+    let cell_z = WALL_THICKNESS_M / WALL_LAYERS as f32;
+    let origin_x = -WALL_SPAN_M * 0.5 + cell_x * 0.5;
+    let origin_y = cell_y * 0.5;
+    let half_extents = [cell_x * 0.5, cell_y * 0.5, cell_z * 0.5];
+
+    let mut out = Vec::with_capacity(WALL_SPAN_SEGMENTS * WALL_HEIGHT_SEGMENTS * WALL_LAYERS);
+    for ix in 0..WALL_SPAN_SEGMENTS {
+        for iy in 0..WALL_HEIGHT_SEGMENTS {
+            for iz in 0..WALL_LAYERS {
+                let centroid = [
+                    origin_x + ix as f32 * cell_x,
+                    origin_y + iy as f32 * cell_y,
+                    (iz as f32 - (WALL_LAYERS as f32 - 1.0) * 0.5) * cell_z,
+                ];
+                out.push(ChunkDoc::Box {
+                    position: centroid,
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    half_extents,
+                    mass: None,
+                    material: None,
+                    anchor: iy == 0,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn build_tower_chunks() -> Vec<ChunkDoc> {
+    let total_rows = TOWER_STORIES + 1;
+    let half_extents = [
+        TOWER_SPACING_X * 0.5,
+        TOWER_SPACING_Y * 0.5,
+        TOWER_SPACING_Z * 0.5,
+    ];
+    let side_center = (TOWER_SIDE as f32 - 1.0) * 0.5;
+
+    let mut out = Vec::with_capacity(TOWER_SIDE * TOWER_SIDE * total_rows);
+    for iz in 0..TOWER_SIDE {
+        for iy in 0..total_rows {
+            for ix in 0..TOWER_SIDE {
+                let centroid = [
+                    (ix as f32 - side_center) * TOWER_SPACING_X,
+                    (iy as f32 - 1.0) * TOWER_SPACING_Y,
+                    (iz as f32 - side_center) * TOWER_SPACING_Z,
+                ];
+                out.push(ChunkDoc::Box {
+                    position: centroid,
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    half_extents,
+                    mass: None,
+                    material: None,
+                    anchor: iy == 0,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Place a single chunk in the arena: anchor chunks become static
+/// cuboids, regular chunks spawn as dynamic rigid bodies. `structure_pos`
+/// and `structure_rot` compose onto the chunk's local transform.
+pub fn spawn_native_chunk(
+    arena: &mut PhysicsArena,
+    body_id: u32,
+    chunk: &ChunkDoc,
+    structure_pos: Vector3<f32>,
+    structure_rot: UnitQuaternion<f32>,
+    _density: f32,
+) {
+    let local_pos = chunk.position();
+    let chunk_world_pos = structure_pos
+        + structure_rot.transform_vector(&Vector3::new(local_pos[0], local_pos[1], local_pos[2]));
+    let chunk_local_rot = chunk.rotation();
+    let chunk_local_unit = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
+        chunk_local_rot[3],
+        chunk_local_rot[0],
+        chunk_local_rot[1],
+        chunk_local_rot[2],
+    ));
+    let world_rot = structure_rot * chunk_local_unit;
+    let world_rot_quat = world_rot.quaternion();
+    let world_rot_arr = [
+        world_rot_quat.i,
+        world_rot_quat.j,
+        world_rot_quat.k,
+        world_rot_quat.w,
+    ];
+
+    if chunk.anchor() {
+        // Anchors become static cuboids regardless of shape — the native
+        // arena has no frozen-dynamic concept, so sphere/capsule anchors
+        // fall back to their tight-fit AABB cuboid.
+        let half = chunk.aabb_half_extents();
+        arena.add_static_cuboid_rotated(
+            chunk_world_pos,
+            world_rot_arr,
+            Vector3::new(half[0], half[1], half[2]),
+            body_id as u128,
+        );
+        return;
+    }
+
+    match chunk {
+        ChunkDoc::Box { half_extents, .. } => {
+            arena.spawn_dynamic_box_with_id(
+                body_id,
+                chunk_world_pos,
+                world_rot_arr,
+                Vector3::new(half_extents[0], half_extents[1], half_extents[2]),
+            );
+        }
+        ChunkDoc::Sphere { radius, .. } => {
+            arena.spawn_dynamic_ball_with_id(body_id, chunk_world_pos, *radius);
+        }
+        ChunkDoc::Capsule { radius, height, .. } => {
+            // Native build has no dynamic capsule spawn helper yet, so
+            // fall back to a tight-fit dynamic box. This matches the
+            // visual AABB used for rendering.
+            let half = [*radius, height * 0.5 + *radius, *radius];
+            arena.spawn_dynamic_box_with_id(
+                body_id,
+                chunk_world_pos,
+                world_rot_arr,
+                Vector3::new(half[0], half[1], half[2]),
+            );
+        }
+    }
+}

--- a/shared/src/destructibles_real.rs
+++ b/shared/src/destructibles_real.rs
@@ -1087,6 +1087,7 @@ impl DestructibleRegistry {
             rotation,
             density,
             solver_material_scale,
+            fractured,
             chunks,
         } = doc
         else {
@@ -1095,16 +1096,21 @@ impl DestructibleRegistry {
         if chunks.is_empty() {
             return false;
         }
-        if chunks.len() > MAX_CHUNKS_PER_STRUCTURE {
+        let expanded_chunks = if *fractured {
+            crate::destructibles_fracture::fracture_chunks_default(chunks)
+        } else {
+            chunks.clone()
+        };
+        if expanded_chunks.len() > MAX_CHUNKS_PER_STRUCTURE {
             dlog(&format!(
                 "[destructibles] structure id={} has {} chunks (> MAX_CHUNKS_PER_STRUCTURE={})",
                 id,
-                chunks.len(),
+                expanded_chunks.len(),
                 MAX_CHUNKS_PER_STRUCTURE
             ));
             return false;
         }
-        let pieces = pieces_from_doc_chunks(chunks, *density);
+        let pieces = pieces_from_doc_chunks(&expanded_chunks, *density);
         let scenario = match build_scenario_from_pieces(&pieces, &BondingOptions::default()) {
             Ok(scenario) => scenario,
             Err(error) => {

--- a/shared/src/destructibles_real.rs
+++ b/shared/src/destructibles_real.rs
@@ -23,8 +23,10 @@ use wasm_bindgen::prelude::*;
 use blast_stress_solver::authoring::{build_scenario_from_pieces, BondingOptions, ScenarioPiece};
 use blast_stress_solver::rapier::{DebrisCollisionMode, DestructibleSet, FracturePolicy};
 use blast_stress_solver::scenarios::{TowerOptions, WallOptions};
-use blast_stress_solver::types::{SolverSettings, Vec3 as BlastVec3};
+use blast_stress_solver::types::{ScenarioCollider, SolverSettings, Vec3 as BlastVec3};
 use blast_stress_solver::ScenarioNode;
+
+use crate::world_document::{ChunkDoc as DocChunk, DestructibleDoc, MAX_CHUNKS_PER_STRUCTURE};
 
 use crate::destructibles_math::{
     authored_position_to_solver_position, effective_solver_material_scale,
@@ -283,6 +285,213 @@ fn build_authored_tower_scenario() -> Result<blast_stress_solver::types::Scenari
     .map_err(|error| format!("failed to auto-bond tower pieces: {error}"))
 }
 
+#[inline]
+fn rotate_vec(v: BlastVec3, rot: &UnitQuaternion<f32>) -> BlastVec3 {
+    let rotated = rot.transform_vector(&Vector3::new(v.x, v.y, v.z));
+    BlastVec3::new(rotated.x, rotated.y, rotated.z)
+}
+
+#[inline]
+fn chunk_unit_rotation(chunk: &DocChunk) -> UnitQuaternion<f32> {
+    let rot = chunk.rotation();
+    let q = Quaternion::new(rot[3], rot[0], rot[1], rot[2]);
+    UnitQuaternion::from_quaternion(q)
+}
+
+fn box_piece_triangles(half_extents: [f32; 3], rot: &UnitQuaternion<f32>) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
+    let hx = half_extents[0];
+    let hy = half_extents[1];
+    let hz = half_extents[2];
+    let raw_corners = [
+        BlastVec3::new(-hx, -hy, -hz),
+        BlastVec3::new(hx, -hy, -hz),
+        BlastVec3::new(-hx, hy, -hz),
+        BlastVec3::new(hx, hy, -hz),
+        BlastVec3::new(-hx, -hy, hz),
+        BlastVec3::new(hx, -hy, hz),
+        BlastVec3::new(-hx, hy, hz),
+        BlastVec3::new(hx, hy, hz),
+    ];
+    let corners: Vec<BlastVec3> = raw_corners.iter().map(|c| rotate_vec(*c, rot)).collect();
+    let p000 = corners[0];
+    let p100 = corners[1];
+    let p010 = corners[2];
+    let p110 = corners[3];
+    let p001 = corners[4];
+    let p101 = corners[5];
+    let p011 = corners[6];
+    let p111 = corners[7];
+    let triangles = vec![
+        p000, p101, p001, p000, p100, p101, p010, p011, p111, p010, p111, p110, p000, p001, p011,
+        p000, p011, p010, p100, p110, p111, p100, p111, p101, p000, p010, p110, p000, p110, p100,
+        p001, p101, p111, p001, p111, p011,
+    ];
+    (triangles, corners)
+}
+
+fn sphere_piece_triangles(radius: f32, rot: &UnitQuaternion<f32>) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
+    // 8-face octahedron is enough for bonding-surface coverage at low radius.
+    let r = radius;
+    let raw_pts = [
+        BlastVec3::new(r, 0.0, 0.0),
+        BlastVec3::new(-r, 0.0, 0.0),
+        BlastVec3::new(0.0, r, 0.0),
+        BlastVec3::new(0.0, -r, 0.0),
+        BlastVec3::new(0.0, 0.0, r),
+        BlastVec3::new(0.0, 0.0, -r),
+    ];
+    let pts: Vec<BlastVec3> = raw_pts.iter().map(|p| rotate_vec(*p, rot)).collect();
+    let faces: [(usize, usize, usize); 8] = [
+        (0, 2, 4),
+        (2, 1, 4),
+        (1, 3, 4),
+        (3, 0, 4),
+        (2, 0, 5),
+        (1, 2, 5),
+        (3, 1, 5),
+        (0, 3, 5),
+    ];
+    let mut triangles = Vec::with_capacity(faces.len() * 3);
+    for (a, b, c) in faces {
+        triangles.extend_from_slice(&[pts[a], pts[b], pts[c]]);
+    }
+    (triangles, pts)
+}
+
+fn capsule_piece_triangles(
+    radius: f32,
+    height: f32,
+    rot: &UnitQuaternion<f32>,
+) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
+    const SIDES: usize = 8;
+    let half_h = height * 0.5;
+    let mut ring_top: Vec<BlastVec3> = Vec::with_capacity(SIDES);
+    let mut ring_bot: Vec<BlastVec3> = Vec::with_capacity(SIDES);
+    for i in 0..SIDES {
+        let theta = (i as f32) / (SIDES as f32) * std::f32::consts::TAU;
+        let x = radius * theta.cos();
+        let z = radius * theta.sin();
+        ring_top.push(BlastVec3::new(x, half_h, z));
+        ring_bot.push(BlastVec3::new(x, -half_h, z));
+    }
+    let top_pole = BlastVec3::new(0.0, half_h + radius, 0.0);
+    let bot_pole = BlastVec3::new(0.0, -half_h - radius, 0.0);
+
+    let mut triangles: Vec<BlastVec3> = Vec::new();
+    for i in 0..SIDES {
+        let j = (i + 1) % SIDES;
+        triangles.extend_from_slice(&[ring_bot[i], ring_bot[j], ring_top[j]]);
+        triangles.extend_from_slice(&[ring_bot[i], ring_top[j], ring_top[i]]);
+    }
+    for i in 0..SIDES {
+        let j = (i + 1) % SIDES;
+        triangles.extend_from_slice(&[ring_top[i], ring_top[j], top_pole]);
+    }
+    for i in 0..SIDES {
+        let j = (i + 1) % SIDES;
+        triangles.extend_from_slice(&[ring_bot[j], ring_bot[i], bot_pole]);
+    }
+    let triangles = triangles.into_iter().map(|p| rotate_vec(p, rot)).collect();
+
+    let mut hull_points: Vec<BlastVec3> = Vec::with_capacity(SIDES * 2 + 2);
+    for p in ring_top.iter().chain(ring_bot.iter()) {
+        hull_points.push(rotate_vec(*p, rot));
+    }
+    hull_points.push(rotate_vec(top_pole, rot));
+    hull_points.push(rotate_vec(bot_pole, rot));
+    (triangles, hull_points)
+}
+
+/// Convert an authored [`DocChunk`] to a Blast [`ScenarioPiece`].
+///
+/// Triangles and hull points are pre-rotated by the chunk's local
+/// rotation and offset by its centroid so the scenario is defined in
+/// the structure's local frame. `spawn_scenario` then applies the
+/// structure-level pose to every node body.
+fn chunk_to_piece(chunk: &DocChunk, density: f32) -> ScenarioPiece {
+    let pos = chunk.position();
+    let centroid = BlastVec3::new(pos[0], pos[1], pos[2]);
+    let rotation = chunk_unit_rotation(chunk);
+
+    let is_support = chunk.anchor();
+    let volume = if is_support { 0.0 } else { chunk.volume_m3() };
+    let mass = if is_support {
+        0.0
+    } else {
+        chunk.mass_override().unwrap_or(volume * density).max(0.0)
+    };
+
+    let aabb = chunk.aabb_half_extents();
+    let node_size = Some(BlastVec3::new(
+        aabb[0] * 2.0,
+        aabb[1] * 2.0,
+        aabb[2] * 2.0,
+    ));
+
+    let (local_triangles, hull_points, collider_shape) = match chunk {
+        DocChunk::Box { half_extents, .. } => {
+            let (tris, corners) = box_piece_triangles(*half_extents, &rotation);
+            // When chunk has no rotation, Rapier's Cuboid collider is the
+            // correct visual match — fall back to it so mass/inertia are
+            // computed from the authored half-extents.
+            let rot_arr = chunk.rotation();
+            let identity = rot_arr[3].abs() >= 1.0 - 1.0e-5
+                && rot_arr[0].abs() <= 1.0e-4
+                && rot_arr[1].abs() <= 1.0e-4
+                && rot_arr[2].abs() <= 1.0e-4;
+            let collider = if identity {
+                Some(ScenarioCollider::Cuboid {
+                    half_extents: BlastVec3::new(half_extents[0], half_extents[1], half_extents[2]),
+                })
+            } else {
+                Some(ScenarioCollider::ConvexHull { points: corners })
+            };
+            (tris, Vec::new(), collider)
+        }
+        DocChunk::Sphere { radius, .. } => {
+            let (tris, pts) = sphere_piece_triangles(*radius, &rotation);
+            (tris, pts, None)
+        }
+        DocChunk::Capsule { radius, height, .. } => {
+            let (tris, pts) = capsule_piece_triangles(*radius, *height, &rotation);
+            (tris, pts.clone(), Some(ScenarioCollider::ConvexHull { points: pts }))
+        }
+    };
+
+    let triangles = local_triangles
+        .into_iter()
+        .map(|p| BlastVec3::new(centroid.x + p.x, centroid.y + p.y, centroid.z + p.z))
+        .collect();
+
+    // Sphere: use ConvexHull collider in world-local space (translated to centroid)
+    // so Rapier's generated collider matches the visible sphere bounds.
+    let collider_shape = match (chunk, collider_shape) {
+        (DocChunk::Sphere { .. }, _) => {
+            // Translate hull points to sit at origin in body-local frame
+            // (centroid is applied separately via node pose); leave as-is.
+            Some(ScenarioCollider::ConvexHull { points: hull_points })
+        }
+        (_, other) => other,
+    };
+
+    ScenarioPiece {
+        node: ScenarioNode {
+            centroid,
+            mass,
+            volume,
+        },
+        triangles,
+        bondable: true,
+        node_size,
+        collider_shape,
+    }
+}
+
+/// Build Blast pieces from an authored structure's chunk list.
+pub fn pieces_from_doc_chunks(chunks: &[DocChunk], density: f32) -> Vec<ScenarioPiece> {
+    chunks.iter().map(|c| chunk_to_piece(c, density)).collect()
+}
+
 fn configured_fracture_policy() -> FracturePolicy {
     FracturePolicy {
         // Match the upstream wall/tower demo behavior. Leaving this enabled
@@ -302,6 +511,9 @@ fn configured_debris_collision_mode() -> DebrisCollisionMode {
 pub enum DestructibleKind {
     Wall,
     Tower,
+    /// Authored [`DestructibleDoc::Structure`] with a per-instance chunk
+    /// list. Used for arbitrary box / sphere / capsule compositions.
+    Structure,
 }
 
 /// A single destructible instance placed in the world.  Owns a
@@ -857,6 +1069,63 @@ impl DestructibleRegistry {
             pose,
             scenario,
             self.runtime_config.tower_material_scale,
+        )
+    }
+
+    /// Spawn an authored structure described by a
+    /// [`DestructibleDoc::Structure`]. The chunks are auto-bonded via
+    /// Blast's default bonding options; the structure-level
+    /// `solver_material_scale` is passed through to solver tuning.
+    ///
+    /// Returns `false` if the doc is not a `Structure` variant, the
+    /// chunk list exceeds [`MAX_CHUNKS_PER_STRUCTURE`], or bonding
+    /// fails.
+    pub fn spawn_structure(&mut self, sim: &mut SimWorld, doc: &DestructibleDoc) -> bool {
+        let DestructibleDoc::Structure {
+            id,
+            position,
+            rotation,
+            density,
+            solver_material_scale,
+            chunks,
+        } = doc
+        else {
+            return false;
+        };
+        if chunks.is_empty() {
+            return false;
+        }
+        if chunks.len() > MAX_CHUNKS_PER_STRUCTURE {
+            dlog(&format!(
+                "[destructibles] structure id={} has {} chunks (> MAX_CHUNKS_PER_STRUCTURE={})",
+                id,
+                chunks.len(),
+                MAX_CHUNKS_PER_STRUCTURE
+            ));
+            return false;
+        }
+        let pieces = pieces_from_doc_chunks(chunks, *density);
+        let scenario = match build_scenario_from_pieces(&pieces, &BondingOptions::default()) {
+            Ok(scenario) => scenario,
+            Err(error) => {
+                dlog(&format!(
+                    "[destructibles] structure id={} bond failed: {error}",
+                    id
+                ));
+                return false;
+            }
+        };
+        let translation = Translation3::new(position[0], position[1], position[2]);
+        let q = Quaternion::new(rotation[3], rotation[0], rotation[1], rotation[2]);
+        let unit = UnitQuaternion::from_quaternion(q);
+        let pose = Isometry3::from_parts(translation, unit);
+        self.spawn_scenario(
+            sim,
+            *id,
+            DestructibleKind::Structure,
+            pose,
+            scenario,
+            *solver_material_scale,
         )
     }
 

--- a/shared/src/destructibles_real.rs
+++ b/shared/src/destructibles_real.rs
@@ -298,7 +298,10 @@ fn chunk_unit_rotation(chunk: &DocChunk) -> UnitQuaternion<f32> {
     UnitQuaternion::from_quaternion(q)
 }
 
-fn box_piece_triangles(half_extents: [f32; 3], rot: &UnitQuaternion<f32>) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
+fn box_piece_triangles(
+    half_extents: [f32; 3],
+    rot: &UnitQuaternion<f32>,
+) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
     let hx = half_extents[0];
     let hy = half_extents[1];
     let hz = half_extents[2];
@@ -329,7 +332,10 @@ fn box_piece_triangles(half_extents: [f32; 3], rot: &UnitQuaternion<f32>) -> (Ve
     (triangles, corners)
 }
 
-fn sphere_piece_triangles(radius: f32, rot: &UnitQuaternion<f32>) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
+fn sphere_piece_triangles(
+    radius: f32,
+    rot: &UnitQuaternion<f32>,
+) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
     // 8-face octahedron is enough for bonding-surface coverage at low radius.
     let r = radius;
     let raw_pts = [
@@ -422,11 +428,7 @@ fn chunk_to_piece(chunk: &DocChunk, density: f32) -> ScenarioPiece {
     };
 
     let aabb = chunk.aabb_half_extents();
-    let node_size = Some(BlastVec3::new(
-        aabb[0] * 2.0,
-        aabb[1] * 2.0,
-        aabb[2] * 2.0,
-    ));
+    let node_size = Some(BlastVec3::new(aabb[0] * 2.0, aabb[1] * 2.0, aabb[2] * 2.0));
 
     let (local_triangles, hull_points, collider_shape) = match chunk {
         DocChunk::Box { half_extents, .. } => {
@@ -454,7 +456,11 @@ fn chunk_to_piece(chunk: &DocChunk, density: f32) -> ScenarioPiece {
         }
         DocChunk::Capsule { radius, height, .. } => {
             let (tris, pts) = capsule_piece_triangles(*radius, *height, &rotation);
-            (tris, pts.clone(), Some(ScenarioCollider::ConvexHull { points: pts }))
+            (
+                tris,
+                pts.clone(),
+                Some(ScenarioCollider::ConvexHull { points: pts }),
+            )
         }
     };
 
@@ -469,7 +475,9 @@ fn chunk_to_piece(chunk: &DocChunk, density: f32) -> ScenarioPiece {
         (DocChunk::Sphere { .. }, _) => {
             // Translate hull points to sit at origin in body-local frame
             // (centroid is applied separately via node pose); leave as-is.
-            Some(ScenarioCollider::ConvexHull { points: hull_points })
+            Some(ScenarioCollider::ConvexHull {
+                points: hull_points,
+            })
         }
         (_, other) => other,
     };

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -2,6 +2,7 @@ pub mod constants;
 pub mod debug_render;
 #[cfg(target_arch = "wasm32")]
 pub mod destructibles;
+pub mod destructibles_fracture;
 pub mod destructibles_math;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod destructibles_native_fallback;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -3,6 +3,8 @@ pub mod debug_render;
 #[cfg(target_arch = "wasm32")]
 pub mod destructibles;
 pub mod destructibles_math;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod destructibles_native_fallback;
 #[cfg(target_arch = "wasm32")]
 pub mod destructibles_real;
 pub mod local_session;

--- a/shared/src/physics_arena/mod.rs
+++ b/shared/src/physics_arena/mod.rs
@@ -381,7 +381,15 @@ impl PhysicsArena {
             | crate::world_document::DestructibleDoc::Tower { .. } => {
                 factory_chunks_for_fallback(doc.factory_kind().expect("factory"))
             }
-            crate::world_document::DestructibleDoc::Structure { chunks, .. } => chunks.clone(),
+            crate::world_document::DestructibleDoc::Structure {
+                chunks, fractured, ..
+            } => {
+                if *fractured {
+                    crate::destructibles_fracture::fracture_chunks_default(chunks)
+                } else {
+                    chunks.clone()
+                }
+            }
         };
         if chunks.len() > crate::world_document::MAX_CHUNKS_PER_STRUCTURE {
             return false;

--- a/shared/src/physics_arena/mod.rs
+++ b/shared/src/physics_arena/mod.rs
@@ -337,36 +337,71 @@ impl PhysicsArena {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub fn spawn_destructible(
-        &mut self,
-        id: u32,
-        kind: DestructibleKind,
-        position: [f32; 3],
-        rotation: [f32; 4],
-    ) -> bool {
-        let pose = pose_from_world_doc(kind, position, rotation);
-        match kind {
-            DestructibleKind::Wall => {
+    pub fn spawn_destructible(&mut self, doc: &crate::world_document::DestructibleDoc) -> bool {
+        match doc {
+            crate::world_document::DestructibleDoc::Wall { id, position, rotation } => {
+                let pose = pose_from_world_doc(DestructibleKind::Wall, *position, *rotation);
                 self.destructibles
-                    .spawn_wall(&mut self.dynamic.sim, id, pose)
+                    .spawn_wall(&mut self.dynamic.sim, *id, pose)
             }
-            DestructibleKind::Tower => {
+            crate::world_document::DestructibleDoc::Tower { id, position, rotation } => {
+                let pose = pose_from_world_doc(DestructibleKind::Tower, *position, *rotation);
                 self.destructibles
-                    .spawn_tower(&mut self.dynamic.sim, id, pose)
+                    .spawn_tower(&mut self.dynamic.sim, *id, pose)
+            }
+            crate::world_document::DestructibleDoc::Structure { .. } => {
+                self.destructibles.spawn_structure(&mut self.dynamic.sim, doc)
             }
         }
     }
 
+    /// Native (non-wasm) fallback: expand destructibles into independent
+    /// dynamic rigid bodies since the native build has no Blast solver.
+    /// Each chunk becomes its own body with stable id
+    /// `(destructible_id << 12) | chunk_index`. Anchor chunks become
+    /// static cuboids (sphere/capsule anchors fall back to a tight-fit
+    /// AABB cuboid).
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn spawn_destructible(
-        &mut self,
-        id: u32,
-        kind: crate::world_document::DestructibleKind,
-        position: [f32; 3],
-        rotation: [f32; 4],
-    ) -> bool {
-        let _ = (id, kind, position, rotation);
-        false
+    pub fn spawn_destructible(&mut self, doc: &crate::world_document::DestructibleDoc) -> bool {
+        use crate::destructibles_native_fallback::{
+            factory_chunks_for_fallback, spawn_native_chunk,
+        };
+        use nalgebra::UnitQuaternion;
+        let doc_pos = doc.position();
+        let doc_rot = doc.rotation();
+        let doc_id = doc.id();
+        let rot = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
+            doc_rot[3],
+            doc_rot[0],
+            doc_rot[1],
+            doc_rot[2],
+        ));
+        let chunks = match doc {
+            crate::world_document::DestructibleDoc::Wall { .. }
+            | crate::world_document::DestructibleDoc::Tower { .. } => {
+                factory_chunks_for_fallback(doc.factory_kind().expect("factory"))
+            }
+            crate::world_document::DestructibleDoc::Structure { chunks, .. } => chunks.clone(),
+        };
+        if chunks.len() > crate::world_document::MAX_CHUNKS_PER_STRUCTURE {
+            return false;
+        }
+        let density = match doc {
+            crate::world_document::DestructibleDoc::Structure { density, .. } => *density,
+            _ => crate::world_document::DEFAULT_STRUCTURE_DENSITY_KG_M3,
+        };
+        for (chunk_index, chunk) in chunks.iter().enumerate() {
+            let body_id = (doc_id << 12) | (chunk_index as u32 & 0x0fff);
+            spawn_native_chunk(
+                self,
+                body_id,
+                chunk,
+                Vector3::new(doc_pos[0], doc_pos[1], doc_pos[2]),
+                rot,
+                density,
+            );
+        }
+        true
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/shared/src/physics_arena/mod.rs
+++ b/shared/src/physics_arena/mod.rs
@@ -339,19 +339,27 @@ impl PhysicsArena {
     #[cfg(target_arch = "wasm32")]
     pub fn spawn_destructible(&mut self, doc: &crate::world_document::DestructibleDoc) -> bool {
         match doc {
-            crate::world_document::DestructibleDoc::Wall { id, position, rotation } => {
+            crate::world_document::DestructibleDoc::Wall {
+                id,
+                position,
+                rotation,
+            } => {
                 let pose = pose_from_world_doc(DestructibleKind::Wall, *position, *rotation);
                 self.destructibles
                     .spawn_wall(&mut self.dynamic.sim, *id, pose)
             }
-            crate::world_document::DestructibleDoc::Tower { id, position, rotation } => {
+            crate::world_document::DestructibleDoc::Tower {
+                id,
+                position,
+                rotation,
+            } => {
                 let pose = pose_from_world_doc(DestructibleKind::Tower, *position, *rotation);
                 self.destructibles
                     .spawn_tower(&mut self.dynamic.sim, *id, pose)
             }
-            crate::world_document::DestructibleDoc::Structure { .. } => {
-                self.destructibles.spawn_structure(&mut self.dynamic.sim, doc)
-            }
+            crate::world_document::DestructibleDoc::Structure { .. } => self
+                .destructibles
+                .spawn_structure(&mut self.dynamic.sim, doc),
         }
     }
 
@@ -371,10 +379,7 @@ impl PhysicsArena {
         let doc_rot = doc.rotation();
         let doc_id = doc.id();
         let rot = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
-            doc_rot[3],
-            doc_rot[0],
-            doc_rot[1],
-            doc_rot[2],
+            doc_rot[3], doc_rot[0], doc_rot[1], doc_rot[2],
         ));
         let chunks = match doc {
             crate::world_document::DestructibleDoc::Wall { .. }

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -297,13 +297,18 @@ impl WasmSimWorld {
         }
 
         for doc in &world.destructibles {
-            let pose = pose_from_world_doc(doc.kind, doc.position, doc.rotation);
-            match doc.kind {
-                DocDestructibleKind::Wall => {
-                    self.destructibles.spawn_wall(&mut self.sim, doc.id, pose);
+            match doc {
+                crate::world_document::DestructibleDoc::Wall { id, position, rotation } => {
+                    let pose = pose_from_world_doc(DocDestructibleKind::Wall, *position, *rotation);
+                    self.destructibles.spawn_wall(&mut self.sim, *id, pose);
                 }
-                DocDestructibleKind::Tower => {
-                    self.destructibles.spawn_tower(&mut self.sim, doc.id, pose);
+                crate::world_document::DestructibleDoc::Tower { id, position, rotation } => {
+                    let pose =
+                        pose_from_world_doc(DocDestructibleKind::Tower, *position, *rotation);
+                    self.destructibles.spawn_tower(&mut self.sim, *id, pose);
+                }
+                crate::world_document::DestructibleDoc::Structure { .. } => {
+                    self.destructibles.spawn_structure(&mut self.sim, doc);
                 }
             }
         }
@@ -340,6 +345,22 @@ impl WasmSimWorld {
                 pose_from_world_doc(DocDestructibleKind::Tower, [px, py, pz], [qx, qy, qz, qw]),
             ),
             _ => false,
+        }
+    }
+
+    /// Spawn an authored `DestructibleDoc::Structure` from a JSON doc.
+    /// The JSON must deserialize to a full `DestructibleDoc` (tagged
+    /// `"kind":"structure"`). Returns `true` if the structure was
+    /// spawned.
+    #[wasm_bindgen(js_name = spawnDestructibleStructure)]
+    pub fn spawn_destructible_structure(&mut self, json_doc: &str) -> Result<bool, JsValue> {
+        let doc: crate::world_document::DestructibleDoc = serde_json::from_str(json_doc)
+            .map_err(|error| JsValue::from_str(&error.to_string()))?;
+        match &doc {
+            crate::world_document::DestructibleDoc::Structure { .. } => {
+                Ok(self.destructibles.spawn_structure(&mut self.sim, &doc))
+            }
+            _ => Ok(false),
         }
     }
 

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -298,11 +298,19 @@ impl WasmSimWorld {
 
         for doc in &world.destructibles {
             match doc {
-                crate::world_document::DestructibleDoc::Wall { id, position, rotation } => {
+                crate::world_document::DestructibleDoc::Wall {
+                    id,
+                    position,
+                    rotation,
+                } => {
                     let pose = pose_from_world_doc(DocDestructibleKind::Wall, *position, *rotation);
                     self.destructibles.spawn_wall(&mut self.sim, *id, pose);
                 }
-                crate::world_document::DestructibleDoc::Tower { id, position, rotation } => {
+                crate::world_document::DestructibleDoc::Tower {
+                    id,
+                    position,
+                    rotation,
+                } => {
                     let pose =
                         pose_from_world_doc(DocDestructibleKind::Tower, *position, *rotation);
                     self.destructibles.spawn_tower(&mut self.sim, *id, pose);

--- a/shared/src/world_document.rs
+++ b/shared/src/world_document.rs
@@ -122,6 +122,9 @@ pub const DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE: f32 = 1.0;
 /// `(destructible_id << 12) | chunk_index`. Authors must keep chunks per
 /// structure ≤ 4096 so the id stays unique in the native arena.
 pub const MAX_CHUNKS_PER_STRUCTURE: usize = 4096;
+/// Target brick edge length (meters) used when `Structure.fractured` is
+/// true. Mirrors `FRACTURE_BRICK_EDGE_M` in the TS schema.
+pub const FRACTURE_BRICK_EDGE_M: f32 = 0.25;
 
 fn default_structure_density() -> f32 {
     DEFAULT_STRUCTURE_DENSITY_KG_M3
@@ -165,6 +168,12 @@ pub enum DestructibleDoc {
             rename = "solverMaterialScale"
         )]
         solver_material_scale: f32,
+        /// When true, each authored chunk is subdivided into
+        /// brick-sized sub-chunks at spawn time and the Blast
+        /// auto-bonder wires them into a single bonded network.
+        /// Defaults to `false` so existing worlds behave unchanged.
+        #[serde(default)]
+        fractured: bool,
         #[serde(default)]
         chunks: Vec<ChunkDoc>,
     },
@@ -1942,6 +1951,7 @@ mod tests {
             rotation: [0.0, 0.0, 0.0, 1.0],
             density: DEFAULT_STRUCTURE_DENSITY_KG_M3,
             solver_material_scale: DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE,
+            fractured: false,
             chunks: vec![
                 ChunkDoc::Box {
                     position: [0.0, 0.25, 0.0],

--- a/shared/src/world_document.rs
+++ b/shared/src/world_document.rs
@@ -113,18 +113,95 @@ pub enum DynamicEntityKind {
     Battery,
 }
 
-/// A destructible structure placed in the world, backed by the Blast
-/// stress-solver (see `destructibles` module).  The Blast scenario is
-/// chosen by `kind`; position/rotation place the resulting chunks in the
-/// world.  `id` must be unique within the document.
+/// Default per-chunk material density in kg/m³ used when a structure
+/// destructible does not specify `density` explicitly. Mirrors
+/// `DEFAULT_STRUCTURE_DENSITY_KG_M3` in the TS schema.
+pub const DEFAULT_STRUCTURE_DENSITY_KG_M3: f32 = 2400.0;
+pub const DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE: f32 = 1.0;
+/// Reserved high-bits in the chunk-body id scheme
+/// `(destructible_id << 12) | chunk_index`. Authors must keep chunks per
+/// structure ≤ 4096 so the id stays unique in the native arena.
+pub const MAX_CHUNKS_PER_STRUCTURE: usize = 4096;
+
+fn default_structure_density() -> f32 {
+    DEFAULT_STRUCTURE_DENSITY_KG_M3
+}
+
+fn default_solver_material_scale() -> f32 {
+    DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE
+}
+
+/// A destructible structure placed in the world. `Wall`/`Tower` pick
+/// preset Blast scenarios (opaque factory scenarios). `Structure` is
+/// fully authored: its `chunks` array describes primitives (box /
+/// sphere / capsule) composed in the structure's local frame, which are
+/// auto-bonded by the Blast stress solver in single-player (WASM) and
+/// expanded into independent dynamic rigid bodies on the native server
+/// (multiplayer).
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DestructibleDoc {
-    pub id: u32,
-    pub kind: DestructibleKind,
-    pub position: [f32; 3],
-    #[serde(default = "identity_rotation")]
-    pub rotation: [f32; 4],
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum DestructibleDoc {
+    Wall {
+        id: u32,
+        position: [f32; 3],
+        #[serde(default = "identity_rotation")]
+        rotation: [f32; 4],
+    },
+    Tower {
+        id: u32,
+        position: [f32; 3],
+        #[serde(default = "identity_rotation")]
+        rotation: [f32; 4],
+    },
+    Structure {
+        id: u32,
+        position: [f32; 3],
+        #[serde(default = "identity_rotation")]
+        rotation: [f32; 4],
+        #[serde(default = "default_structure_density")]
+        density: f32,
+        #[serde(
+            default = "default_solver_material_scale",
+            rename = "solverMaterialScale"
+        )]
+        solver_material_scale: f32,
+        #[serde(default)]
+        chunks: Vec<ChunkDoc>,
+    },
+}
+
+impl DestructibleDoc {
+    pub fn id(&self) -> u32 {
+        match self {
+            Self::Wall { id, .. } | Self::Tower { id, .. } | Self::Structure { id, .. } => *id,
+        }
+    }
+
+    pub fn position(&self) -> [f32; 3] {
+        match self {
+            Self::Wall { position, .. }
+            | Self::Tower { position, .. }
+            | Self::Structure { position, .. } => *position,
+        }
+    }
+
+    pub fn rotation(&self) -> [f32; 4] {
+        match self {
+            Self::Wall { rotation, .. }
+            | Self::Tower { rotation, .. }
+            | Self::Structure { rotation, .. } => *rotation,
+        }
+    }
+
+    /// Returns the factory kind for `Wall`/`Tower`, or `None` for an
+    /// authored `Structure`.
+    pub fn factory_kind(&self) -> Option<DestructibleKind> {
+        match self {
+            Self::Wall { .. } => Some(DestructibleKind::Wall),
+            Self::Tower { .. } => Some(DestructibleKind::Tower),
+            Self::Structure { .. } => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -132,6 +209,128 @@ pub struct DestructibleDoc {
 pub enum DestructibleKind {
     Wall,
     Tower,
+}
+
+/// One authored chunk inside a `DestructibleDoc::Structure`.
+///
+/// Transforms are in the structure's local frame. Sizes:
+/// - `Box` → `half_extents` (meters).
+/// - `Sphere` → `radius`.
+/// - `Capsule` → `radius` + `height` (cylindrical segment; caps are
+///   hemispheres of the same radius).
+///
+/// `mass` overrides `density * volume`. `anchor = true` marks the chunk
+/// as a support (replaces the implicit `y == 0` rule). On the native
+/// server, anchored sphere/capsule chunks are spawned as tight-fit
+/// static cuboids (the native build has no frozen dynamic body concept).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "shape", rename_all = "lowercase")]
+pub enum ChunkDoc {
+    Box {
+        position: [f32; 3],
+        #[serde(default = "identity_rotation")]
+        rotation: [f32; 4],
+        #[serde(rename = "halfExtents")]
+        half_extents: [f32; 3],
+        #[serde(default)]
+        mass: Option<f32>,
+        #[serde(default)]
+        material: Option<String>,
+        #[serde(default)]
+        anchor: bool,
+    },
+    Sphere {
+        position: [f32; 3],
+        #[serde(default = "identity_rotation")]
+        rotation: [f32; 4],
+        radius: f32,
+        #[serde(default)]
+        mass: Option<f32>,
+        #[serde(default)]
+        material: Option<String>,
+        #[serde(default)]
+        anchor: bool,
+    },
+    Capsule {
+        position: [f32; 3],
+        #[serde(default = "identity_rotation")]
+        rotation: [f32; 4],
+        radius: f32,
+        height: f32,
+        #[serde(default)]
+        mass: Option<f32>,
+        #[serde(default)]
+        material: Option<String>,
+        #[serde(default)]
+        anchor: bool,
+    },
+}
+
+impl ChunkDoc {
+    pub fn position(&self) -> [f32; 3] {
+        match self {
+            Self::Box { position, .. }
+            | Self::Sphere { position, .. }
+            | Self::Capsule { position, .. } => *position,
+        }
+    }
+
+    pub fn rotation(&self) -> [f32; 4] {
+        match self {
+            Self::Box { rotation, .. }
+            | Self::Sphere { rotation, .. }
+            | Self::Capsule { rotation, .. } => *rotation,
+        }
+    }
+
+    pub fn anchor(&self) -> bool {
+        match self {
+            Self::Box { anchor, .. }
+            | Self::Sphere { anchor, .. }
+            | Self::Capsule { anchor, .. } => *anchor,
+        }
+    }
+
+    pub fn mass_override(&self) -> Option<f32> {
+        match self {
+            Self::Box { mass, .. } | Self::Sphere { mass, .. } | Self::Capsule { mass, .. } => {
+                *mass
+            }
+        }
+    }
+
+    /// Physical volume in m³, used by the default density → mass rule
+    /// when `mass` is not overridden.
+    pub fn volume_m3(&self) -> f32 {
+        match self {
+            Self::Box { half_extents, .. } => {
+                8.0 * half_extents[0] * half_extents[1] * half_extents[2]
+            }
+            Self::Sphere { radius, .. } => {
+                (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3)
+            }
+            Self::Capsule { radius, height, .. } => {
+                let sphere = (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3);
+                let cyl = std::f32::consts::PI * radius.powi(2) * *height;
+                sphere + cyl
+            }
+        }
+    }
+
+    /// Tight axis-aligned half-extents used by the native fallback for
+    /// sphere/capsule anchors (the native server has no frozen-dynamic
+    /// concept, so anchors degrade to static cuboids).
+    pub fn aabb_half_extents(&self) -> [f32; 3] {
+        match self {
+            Self::Box { half_extents, .. } => *half_extents,
+            Self::Sphere { radius, .. } => [*radius, *radius, *radius],
+            // Capsule aligned along local Y: caps extend beyond `height/2`
+            // by `radius` on top and bottom.
+            Self::Capsule { radius, height, .. } => {
+                [*radius, height * 0.5 + *radius, *radius]
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -300,13 +499,7 @@ pub trait WorldDocumentArena {
         rotation: [f32; 4],
     );
 
-    fn spawn_destructible(
-        &mut self,
-        id: u32,
-        kind: DestructibleKind,
-        position: [f32; 3],
-        rotation: [f32; 4],
-    );
+    fn spawn_destructible(&mut self, doc: &DestructibleDoc);
 
     fn spawn_battery_with_id(
         &mut self,
@@ -386,14 +579,8 @@ impl WorldDocumentArena for crate::physics_arena::PhysicsArena {
         );
     }
 
-    fn spawn_destructible(
-        &mut self,
-        id: u32,
-        kind: DestructibleKind,
-        position: [f32; 3],
-        rotation: [f32; 4],
-    ) {
-        crate::physics_arena::PhysicsArena::spawn_destructible(self, id, kind, position, rotation);
+    fn spawn_destructible(&mut self, doc: &DestructibleDoc) {
+        crate::physics_arena::PhysicsArena::spawn_destructible(self, doc);
     }
 
     fn spawn_battery_with_id(
@@ -789,12 +976,7 @@ impl WorldDocument {
         arena.rebuild_broad_phase();
 
         for destructible in &self.destructibles {
-            arena.spawn_destructible(
-                destructible.id,
-                destructible.kind,
-                destructible.position,
-                destructible.rotation,
-            );
+            arena.spawn_destructible(destructible);
         }
 
         for entity in &self.dynamic_entities {
@@ -1096,15 +1278,13 @@ mod tests {
     fn instantiate_spawns_destructibles_into_local_preview_arena() {
         let mut world = WorldDocument::demo();
         world.destructibles = vec![
-            DestructibleDoc {
+            DestructibleDoc::Wall {
                 id: 2000,
-                kind: DestructibleKind::Wall,
                 position: [0.0, 0.0, 8.0],
                 rotation: identity_rotation(),
             },
-            DestructibleDoc {
+            DestructibleDoc::Tower {
                 id: 2001,
-                kind: DestructibleKind::Tower,
                 position: [10.0, 0.5, -5.0],
                 rotation: identity_rotation(),
             },
@@ -1262,13 +1442,23 @@ mod tests {
             .instantiate(&mut arena)
             .expect("instantiate clamped world");
 
+        // Native fallback expands destructible structures into dynamic
+        // bodies with stable ids `(destructible_id << 12) | chunk_index`.
+        // Those chunks are authored at structure-local poses and should
+        // not be clamped against the current terrain — only authored
+        // dynamic entities participate in clamping.
+        const DESTRUCTIBLE_CHUNK_ID_THRESHOLD: u32 = 1 << 12;
         let dynamic_snapshot = arena.snapshot_dynamic_bodies();
+        let authored_dynamics: Vec<_> = dynamic_snapshot
+            .iter()
+            .filter(|(id, _, _, _, _, _, _)| *id < DESTRUCTIBLE_CHUNK_ID_THRESHOLD)
+            .collect();
         assert!(
-            dynamic_snapshot
+            authored_dynamics
                 .iter()
                 .all(|(_, pos, _, _, _, _, _)| pos[1] > 4.0),
             "dynamic entities should be clamped above terrain: {:?}",
-            dynamic_snapshot
+            authored_dynamics
                 .iter()
                 .map(|(id, pos, _, _, _, _, _)| (*id, pos[1]))
                 .collect::<Vec<_>>()
@@ -1735,5 +1925,96 @@ mod tests {
                 normal
             );
         }
+    }
+
+    /// Native multiplayer fallback: an authored structure should expand
+    /// into one dynamic rigid body per non-anchor chunk, with stable ids
+    /// following `(destructible_id << 12) | chunk_index`. Anchor chunks
+    /// become static cuboids, so they do not show up in the dynamic-body
+    /// snapshot.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_fallback_expands_structure_into_per_chunk_dynamic_bodies() {
+        let structure_id: u32 = 400;
+        let structure = DestructibleDoc::Structure {
+            id: structure_id,
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            density: DEFAULT_STRUCTURE_DENSITY_KG_M3,
+            solver_material_scale: DEFAULT_STRUCTURE_SOLVER_MATERIAL_SCALE,
+            chunks: vec![
+                ChunkDoc::Box {
+                    position: [0.0, 0.25, 0.0],
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    half_extents: [0.25, 0.25, 0.25],
+                    mass: None,
+                    material: None,
+                    anchor: true,
+                },
+                ChunkDoc::Box {
+                    position: [0.0, 0.75, 0.0],
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    half_extents: [0.25, 0.25, 0.25],
+                    mass: None,
+                    material: None,
+                    anchor: false,
+                },
+                ChunkDoc::Sphere {
+                    position: [0.0, 1.5, 0.0],
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    radius: 0.25,
+                    mass: None,
+                    material: None,
+                    anchor: false,
+                },
+                ChunkDoc::Capsule {
+                    position: [0.0, 2.5, 0.0],
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    radius: 0.2,
+                    height: 0.6,
+                    mass: None,
+                    material: None,
+                    anchor: false,
+                },
+            ],
+        };
+
+        let mut arena = PhysicsArena::new(MoveConfig::default());
+        let before = arena.snapshot_dynamic_bodies().len();
+        assert!(arena.spawn_destructible(&structure));
+        let after = arena.snapshot_dynamic_bodies();
+        assert_eq!(
+            after.len() - before,
+            3,
+            "expected 3 dynamic bodies (1 box + 1 sphere + 1 capsule); got {:?}",
+            after
+        );
+        let expected_ids: Vec<u32> = (1..=3)
+            .map(|chunk_index| (structure_id << 12) | chunk_index as u32)
+            .collect();
+        for id in expected_ids {
+            assert!(
+                after.iter().any(|snap| snap.0 == id),
+                "missing chunk body id {} (bodies: {:?})",
+                id,
+                after.iter().map(|s| s.0).collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_fallback_expands_factory_wall_into_dynamic_bodies() {
+        let wall = DestructibleDoc::Wall {
+            id: 500,
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+        };
+        let mut arena = PhysicsArena::new(MoveConfig::default());
+        let before = arena.snapshot_dynamic_bodies().len();
+        assert!(arena.spawn_destructible(&wall));
+        // Default wall is 12x6x1 cells; bottom row (12 cells) is anchored
+        // → 60 dynamic bodies after expansion.
+        assert_eq!(arena.snapshot_dynamic_bodies().len() - before, 60);
     }
 }

--- a/shared/src/world_document.rs
+++ b/shared/src/world_document.rs
@@ -315,9 +315,7 @@ impl ChunkDoc {
             Self::Box { half_extents, .. } => {
                 8.0 * half_extents[0] * half_extents[1] * half_extents[2]
             }
-            Self::Sphere { radius, .. } => {
-                (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3)
-            }
+            Self::Sphere { radius, .. } => (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3),
             Self::Capsule { radius, height, .. } => {
                 let sphere = (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3);
                 let cyl = std::f32::consts::PI * radius.powi(2) * *height;
@@ -335,9 +333,7 @@ impl ChunkDoc {
             Self::Sphere { radius, .. } => [*radius, *radius, *radius],
             // Capsule aligned along local Y: caps extend beyond `height/2`
             // by `radius` on top and bottom.
-            Self::Capsule { radius, height, .. } => {
-                [*radius, height * 0.5 + *radius, *radius]
-            }
+            Self::Capsule { radius, height, .. } => [*radius, height * 0.5 + *radius, *radius],
         }
     }
 }

--- a/worlds/trail.world.json
+++ b/worlds/trail.world.json
@@ -50016,6 +50016,38 @@
       ]
     }
   ],
+  "destructibles": [
+    {
+      "id": 2000,
+      "kind": "wall",
+      "position": [
+        0,
+        0,
+        8
+      ],
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "id": 2001,
+      "kind": "tower",
+      "position": [
+        10,
+        0.5,
+        -5
+      ],
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ]
+    }
+  ],
   "dynamicEntities": [
     {
       "id": 1,


### PR DESCRIPTION
## Summary

This PR introduces a new destructible type called "structures" that allows fully authored assemblies of chunks (box, sphere, capsule primitives) to be composed and placed in worlds. Previously, only factory-preset destructibles (wall/tower) were supported. The new structure type enables custom destructible designs with per-chunk control over shape, size, density, and physics properties.

## Key Changes

**Schema & Type System:**
- Refactored `DestructibleDoc` from a struct to a tagged enum supporting `Wall`, `Tower`, and `Structure` variants
- Added `ChunkDoc` enum with three shape types: `Box`, `Sphere`, and `Capsule`
- Introduced `Chunk` TypeScript type with shape-specific properties (halfExtents, radius, height)
- Added structure-level properties: `density` (kg/m³, default 2400) and `solverMaterialScale` (Blast stiffness multiplier, default 1)
- Defined `MAX_CHUNKS_PER_STRUCTURE = 4096` limit to keep chunk-body IDs unique via `(destructible_id << 12) | chunk_index`

**World Context API (TypeScript):**
- Added destructible management methods to `WorldCtx`:
  - `listDestructibles()`, `getDestructible(id)` — read operations
  - `addDestructibleStructure(spec)` — create new structures with chunks
  - `removeDestructible(id)`, `updateDestructible(id, patch)` — modify structures
  - `addChunk()`, `updateChunk()`, `removeChunk()`, `duplicateChunk()` — chunk-level operations
  - `convertFactoryToStructure(id)` — convert wall/tower to editable structure
- Full validation of chunk inputs and structure constraints

**Physics & Rendering:**
- Updated `DestructibleChunks.tsx` to handle mixed-shape chunks with per-shape geometries (box, sphere, capsule)
- Refactored instance bucket system to support multiple geometries per destructible
- Added `geometryForChunk()` helper to generate Three.js geometries from chunk specs
- Updated chunk transform streaming to map chunk indices to instance slots

**Native Server Fallback:**
- Added `destructibles_native_fallback.rs` module for multiplayer servers (non-WASM)
- Expands authored structures into independent dynamic rigid bodies (one per chunk)
- Mirrors factory scenario layouts (wall/tower) so single-player and multiplayer render identical geometry
- Anchored chunks become static cuboids; sphere/capsule anchors fall back to tight-fit cuboid AABBs

**Rust Physics Integration:**
- Extended `destructibles_real.rs` with chunk-to-Blast conversion:
  - `chunk_unit_rotation()`, `rotate_vec()` helpers for local-frame transforms
  - `box_piece_triangles()`, `sphere_piece_triangles()`, `capsule_piece_triangles()` for bonding-surface generation
  - `doc_chunk_to_scenario_piece()` to convert authored chunks to Blast scenario pieces
- Updated `PhysicsArena::spawn_destructible()` to accept `DestructibleDoc` enum and dispatch to appropriate handler

**Editor & Testing:**
- Extended god-mode editor to support destructible selection and transformation
- Added `SelectedTarget` variant for destructibles
- Added comprehensive round-trip serialization tests for factory and structure destructibles
- Updated practice-mode world (`trail.world.json`) with wall and tower examples

## Notable Implementation Details

- Chunk ordering is stable and meaningful: native servers assign rigid-body IDs based on chunk index, enabling snapshot-level destructible operations
- Chunks are composed in the structure's local frame; transforms are applied after the structure's world pose
- Density and solver material scale are structure-level properties that apply uniformly to all chunks (unless overridden per-chunk via `mass`)
- Factory destructibles (wall/tower) remain immutable; conversion to structure is one-way via `convertFactoryToStructure()`
- The Blast stress solver auto-bonds chunks that are in contact at build time; loose chunks remain independent

https://claude.ai/code/session_01LgLTqBWfvi1AW8Tsf46vY2