### PR TITLE
Format: Reflow long line in spawn area candidate loop

### DIFF
--- a/shared/src/physics_arena/spawn.rs
+++ b/shared/src/physics_arena/spawn.rs
@@ -138,9 +138,7 @@ impl PhysicsArena {
                     area.radius as f64,
                 )
             };
-            for (candidate_rank, (x, z)) in
-                spawn_area_candidates(cx, cz, radius).enumerate()
-            {
+            for (candidate_rank, (x, z)) in spawn_area_candidates(cx, cz, radius).enumerate() {
                 let score = self.min_player_distance_sq(x, z);
                 let clear = self.spawn_lane_is_clear(x, z);
                 let candidate_rank = candidate_rank as u32;


### PR DESCRIPTION
## Summary
This PR reformats a multi-line for loop statement in the spawn area candidate selection logic to fit within standard line length constraints.

## Changes
- Reflowed the `for` loop iterating over `spawn_area_candidates()` from 3 lines to a single line for improved readability and consistency with code style guidelines

## Details
The change is purely stylistic and does not alter any functional behavior. The loop that evaluates spawn location candidates based on player distance and lane clarity remains logically identical.

https://claude.ai/code/session_013puJKDc91vi4n1hKzr4XxK