### PR TITLE
Add scoreboard, kills/deaths tracking, and username persistence

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,6 +50,8 @@ import {
 } from './bots';
 import { getSharedPlayerNavigationProfileAsync } from './wasm/sharedPhysics';
 import { PracticeBotsPanel } from './ui/PracticeBotsPanel';
+import { KillDeathHUD } from './ui/KillDeathHUD';
+import { LeaderboardOverlay } from './ui/LeaderboardOverlay';
 import { updateE2EBridgeAppState } from './e2eBridge';
 import { updateFogSettings, useFogSettings } from './graphics/fogSettings';
 
@@ -165,6 +167,7 @@ export function App({
       : '/practice'
   );
   const [connected, setConnected] = useState(effectiveAutoConnect);
+  const [leaderboardOpen, setLeaderboardOpen] = useState(false);
   const [playerId, setPlayerId] = useState(0);
   const [status, setStatus] = useState(
     effectiveAutoConnect
@@ -769,6 +772,19 @@ export function App({
     };
 
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.code === 'Escape' && connected) {
+        const target = event.target as HTMLElement | null;
+        const isEditable =
+          !!target
+          && (target.tagName === 'INPUT'
+            || target.tagName === 'TEXTAREA'
+            || target.isContentEditable);
+        if (!isEditable) {
+          event.preventDefault();
+          setLeaderboardOpen((prev) => !prev);
+          return;
+        }
+      }
       const isMac = navigator.platform.includes('Mac');
       const modPressed = isMac ? event.metaKey : event.ctrlKey;
       const wantsCopyDebug =
@@ -787,6 +803,34 @@ export function App({
       }
     };
   }, [connected, deepCaptureEnabled, getDeepCaptureMarkdown, getStatsSnapshot, localRenderSmoothingEnabled, status, vehicleSmoothingEnabled]);
+
+  // Gamepad Menu/Start (button index 9) toggles the leaderboard overlay.
+  // Polls via requestAnimationFrame and rising-edge detection so holding the
+  // button doesn't flicker.
+  useEffect(() => {
+    if (!connected || typeof navigator === 'undefined' || !navigator.getGamepads) return;
+    let frame = 0;
+    let prevPressed = false;
+    const poll = () => {
+      const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+      let pressed = false;
+      for (const pad of pads) {
+        if (pad && pad.buttons[9]?.pressed) {
+          pressed = true;
+          break;
+        }
+      }
+      if (pressed && !prevPressed) {
+        setLeaderboardOpen((prev) => !prev);
+      }
+      prevPressed = pressed;
+      frame = window.requestAnimationFrame(poll);
+    };
+    frame = window.requestAnimationFrame(poll);
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [connected]);
 
   const crosshairColor =
     crosshairState === 'head'
@@ -834,6 +878,8 @@ export function App({
           </div>
         </div>
       )}
+      {connected && <KillDeathHUD />}
+      <LeaderboardOverlay open={leaderboardOpen && connected} onClose={() => setLeaderboardOpen(false)} />
       <div
         data-testid="status-banner"
         style={{

--- a/client/src/app/runtimeConfig.ts
+++ b/client/src/app/runtimeConfig.ts
@@ -10,7 +10,12 @@ export type MultiplayerBackend = {
   httpOrigin: string;
   sessionConfigEndpoint: string;
   statsWebSocketUrl: string;
-  createMatchWebSocketUrl: (matchId: string, identity: string, token: string) => string;
+  createMatchWebSocketUrl: (
+    matchId: string,
+    identity: string,
+    token: string,
+    options?: { username?: string },
+  ) => string;
 };
 
 function normalizeOrigin(rawValue: string | undefined, fallbackOrigin: string): string {
@@ -37,10 +42,19 @@ export function resolveMultiplayerBackend(
     httpOrigin,
     sessionConfigEndpoint: withPath(httpOrigin, '/session-config'),
     statsWebSocketUrl: withPath(wsOrigin, '/ws/stats'),
-    createMatchWebSocketUrl: (matchId: string, identity: string, token: string) => {
+    createMatchWebSocketUrl: (
+      matchId: string,
+      identity: string,
+      token: string,
+      options?: { username?: string },
+    ) => {
       const url = new URL(`/ws/${encodeURIComponent(matchId)}`, `${wsOrigin}/`);
       url.searchParams.set('identity', identity);
       url.searchParams.set('token', token);
+      const username = options?.username?.trim();
+      if (username) {
+        url.searchParams.set('username', username);
+      }
       return url.toString();
     },
   };

--- a/client/src/app/username.ts
+++ b/client/src/app/username.ts
@@ -1,0 +1,80 @@
+// Client-side username store. Persists the player's preferred display name to
+// localStorage, publishes changes to subscribers, and exposes a React hook for
+// UI components. The server only accepts printable ASCII up to 20 bytes, so
+// `sanitizeUsername` mirrors the server-side rules to keep wire traffic clean.
+
+import { useSyncExternalStore } from 'react';
+import { MAX_USERNAME_LEN, sanitizeUsername } from '../net/protocol';
+
+const STORAGE_KEY = 'vibe-land/username';
+
+function randomDefault(): string {
+  const suffix = Math.floor(1000 + Math.random() * 9000);
+  return `Player-${suffix}`;
+}
+
+let current: string | null = null;
+const listeners = new Set<(name: string) => void>();
+
+function safeReadStorage(): string | null {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage.getItem(STORAGE_KEY) : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeWriteStorage(value: string): void {
+  try {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, value);
+    }
+  } catch (error) {
+    console.warn('Failed to persist username', error);
+  }
+}
+
+function ensureLoaded(): string {
+  if (current !== null) return current;
+  const raw = safeReadStorage();
+  if (raw) {
+    const sanitized = sanitizeUsername(raw);
+    if (sanitized.length > 0) {
+      current = sanitized;
+      return current;
+    }
+  }
+  current = randomDefault();
+  safeWriteStorage(current);
+  return current;
+}
+
+export function getUsername(): string {
+  return ensureLoaded();
+}
+
+export function setUsername(next: string): string {
+  const sanitized = sanitizeUsername(next);
+  const value = sanitized.length > 0 ? sanitized : randomDefault();
+  current = value;
+  safeWriteStorage(value);
+  for (const fn of listeners) fn(value);
+  return value;
+}
+
+export function subscribeUsername(fn: (name: string) => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+export function useUsername(): string {
+  return useSyncExternalStore(
+    (onStoreChange) => subscribeUsername(onStoreChange),
+    () => getUsername(),
+    () => '',
+  );
+}
+
+export { MAX_USERNAME_LEN };

--- a/client/src/net/localPracticeClient.ts
+++ b/client/src/net/localPracticeClient.ts
@@ -111,6 +111,14 @@ export class LocalPracticeClient implements PracticeBotHost {
 
   ping(): void {}
 
+  setLocalDisplayName(name: string): void {
+    this.session?.setLocalDisplayName(name);
+  }
+
+  getLeaderboardJson(): string | null {
+    return this.session?.leaderboardJson() ?? null;
+  }
+
   disconnect(): void {
     this.closedByClient = true;
     if (this.frameHandle != null) {

--- a/client/src/net/netcodeClient.ts
+++ b/client/src/net/netcodeClient.ts
@@ -29,11 +29,13 @@ import {
   type NetPlayerState,
   type NetVehicleState,
   type PlayerRosterPacket,
+  type PlayerStatsUpdatePacket,
   type SnapshotV2Packet,
   type ServerPacket,
   type ServerWorldPacket,
   type ShotFiredPacket,
   type VehicleStateMeters,
+  type WelcomePacket,
   FLAG_IN_VEHICLE,
 } from './protocol';
 
@@ -49,12 +51,15 @@ export type RemotePlayer = {
 
 export type NetcodeClientConfig = {
   onWelcome?: (playerId: number) => void;
+  onWelcomePacket?: (packet: WelcomePacket) => void;
   onDisconnect?: (reason?: string) => void;
   onLocalSnapshot?: (ackInputSeq: number, state: NetPlayerState) => void;
   onLocalVehicleSnapshot?: (vehicleState: NetVehicleState, ackInputSeq: number) => void;
   onWorldPacket?: (packet: ServerWorldPacket) => void;
   onShotResult?: (packet: ServerPacket) => void;
   onShotFired?: (packet: ShotFiredPacket) => void;
+  onRoster?: (packet: PlayerRosterPacket) => void;
+  onStatsUpdate?: (packet: PlayerStatsUpdatePacket) => void;
   onPacket?: (packet: ServerPacket) => void;
 };
 
@@ -662,9 +667,14 @@ export class NetcodeClient {
         // The first snapshot will initialize the estimator instead.
         console.info('[netcode] Welcome — playerId:', packet.playerId, { transport: this.transport, simHz: packet.simHz, interpolationDelayMs: packet.interpolationDelayMs });
         this.config.onWelcome?.(packet.playerId);
+        this.config.onWelcomePacket?.(packet);
         break;
       case 'playerRoster':
         this.applyPlayerRoster(packet);
+        this.config.onRoster?.(packet);
+        break;
+      case 'playerStatsUpdate':
+        this.config.onStatsUpdate?.(packet);
         break;
       case 'dynamicBodyMeta':
         this.applyDynamicBodyMeta(packet);

--- a/client/src/net/protocol.test.ts
+++ b/client/src/net/protocol.test.ts
@@ -447,14 +447,20 @@ describe('snapshot V2 decode', () => {
 });
 
 function buildPlayerRosterBinary(): Uint8Array {
-  const size = 1 + 1 + 5;
+  const username = 'alice';
+  const nameBytes = new TextEncoder().encode(username);
+  const size = 1 + 1 + 1 + 4 + 1 + nameBytes.length + 2 + 2;
   const buf = new Uint8Array(size);
   const view = new DataView(buf.buffer);
   let o = 0;
   view.setUint8(o++, PKT_PLAYER_ROSTER);
   view.setUint8(o++, 1);
   view.setUint8(o++, 7);
-  view.setUint32(o, 44, true);
+  view.setUint32(o, 44, true); o += 4;
+  view.setUint8(o++, nameBytes.length);
+  buf.set(nameBytes, o); o += nameBytes.length;
+  view.setUint16(o, 3, true); o += 2;
+  view.setUint16(o, 1, true); o += 2;
   return buf;
 }
 
@@ -478,7 +484,9 @@ describe('V2 metadata decode', () => {
   it('decodes player roster packets', () => {
     const packet = decodeServerReliablePacket(buildPlayerRosterBinary());
     expect(packet.type).toBe('playerRoster');
-    expect(packet.entries).toEqual([{ handle: 7, playerId: 44 }]);
+    expect(packet.entries).toEqual([
+      { handle: 7, playerId: 44, username: 'alice', kills: 3, deaths: 1 },
+    ]);
   });
 
   it('decodes dynamic body metadata with canonical body ids', () => {
@@ -559,8 +567,10 @@ function buildWelcomeBinary(opts: {
   snapshotHz?: number;
   serverTimeUs?: number;
   interpolationDelayMs?: number;
+  kills?: number;
+  deaths?: number;
 }): Uint8Array {
-  const size = 1 + 4 + 2 + 2 + 8 + 2;
+  const size = 1 + 4 + 2 + 2 + 8 + 2 + 2 + 2;
   const buf = new Uint8Array(size);
   const view = new DataView(buf.buffer);
   let o = 0;
@@ -573,7 +583,9 @@ function buildWelcomeBinary(opts: {
   view.setUint32(o, timeUs & 0xffffffff, true);
   view.setUint32(o + 4, Math.floor(timeUs / 0x100000000), true);
   o += 8;
-  view.setUint16(o, opts.interpolationDelayMs ?? 66, true);
+  view.setUint16(o, opts.interpolationDelayMs ?? 66, true); o += 2;
+  view.setUint16(o, opts.kills ?? 0, true); o += 2;
+  view.setUint16(o, opts.deaths ?? 0, true);
 
   return buf;
 }

--- a/client/src/net/protocol.ts
+++ b/client/src/net/protocol.ts
@@ -18,6 +18,7 @@ import {
   PKT_CHUNK_FULL,
   PKT_CHUNK_DIFF,
   PKT_PLAYER_ROSTER,
+  PKT_PLAYER_STATS_UPDATE,
   PKT_DYNAMIC_BODY_META,
   PKT_LOCAL_PLAYER_ENERGY,
   PKT_BATTERY_SYNC,
@@ -29,8 +30,11 @@ import {
   BTN_RIGHT,
 } from './sharedConstants';
 
+export const MAX_USERNAME_LEN = 20;
+
 export type ClientHello = {
   matchId: string;
+  username: string;
 };
 
 export type InputFrame = {
@@ -144,6 +148,8 @@ export type WelcomePacket = {
   snapshotHz: number;
   serverTimeUs: number;
   interpolationDelayMs: number;
+  kills: number;
+  deaths: number;
 };
 
 export type NetVehicleState = {
@@ -193,11 +199,25 @@ export type SnapshotPacket = {
 export type PlayerRosterEntry = {
   handle: number;
   playerId: number;
+  username: string;
+  kills: number;
+  deaths: number;
 };
 
 export type PlayerRosterPacket = {
   type: 'playerRoster';
   entries: PlayerRosterEntry[];
+};
+
+export type PlayerStatsEntry = {
+  playerId: number;
+  kills: number;
+  deaths: number;
+};
+
+export type PlayerStatsUpdatePacket = {
+  type: 'playerStatsUpdate';
+  entries: PlayerStatsEntry[];
 };
 
 export type DynamicBodyMetaEntry = {
@@ -352,6 +372,7 @@ export type ServerReliablePacket =
   | ChunkDiffPacket
   | SnapshotPacket
   | PlayerRosterPacket
+  | PlayerStatsUpdatePacket
   | DynamicBodyMetaPacket
   | ServerPingPacket
   | PongPacket;
@@ -371,6 +392,7 @@ export type ServerPacket =
   | ChunkFullPacket
   | ChunkDiffPacket
   | PlayerRosterPacket
+  | PlayerStatsUpdatePacket
   | DynamicBodyMetaPacket
   | ServerPingPacket
   | PongPacket;
@@ -434,15 +456,34 @@ export type ProjectileStateMeters = {
 const TEXT_ENCODER = new TextEncoder();
 const TEXT_DECODER = new TextDecoder();
 
+export function sanitizeUsername(name: string): string {
+  const trimmed = (name ?? '').trim();
+  let out = '';
+  for (const ch of trimmed) {
+    const code = ch.charCodeAt(0);
+    if (code >= 0x20 && code <= 0x7e) {
+      out += ch;
+      if (out.length >= MAX_USERNAME_LEN) break;
+    }
+  }
+  return out;
+}
+
 export function encodeClientHello(packet: ClientHello): Uint8Array {
   const encodedMatchId = TEXT_ENCODER.encode(packet.matchId);
-  const out = new Uint8Array(1 + 2 + encodedMatchId.length);
+  const sanitized = sanitizeUsername(packet.username ?? '');
+  const encodedUsername = TEXT_ENCODER.encode(sanitized);
+  const out = new Uint8Array(1 + 2 + encodedMatchId.length + 2 + encodedUsername.length);
   const view = new DataView(out.buffer);
   let o = 0;
   view.setUint8(o++, PKT_CLIENT_HELLO);
   view.setUint16(o, encodedMatchId.length, true);
   o += 2;
   out.set(encodedMatchId, o);
+  o += encodedMatchId.length;
+  view.setUint16(o, encodedUsername.length, true);
+  o += 2;
+  out.set(encodedUsername, o);
   return out;
 }
 
@@ -519,7 +560,9 @@ export function decodeServerReliablePacket(data: ArrayBuffer | Uint8Array): Serv
       const simHz = view.getUint16(o, true); o += 2;
       const snapshotHz = view.getUint16(o, true); o += 2;
       const serverTimeUs = getUint64(view, o); o += 8;
-      const interpolationDelayMs = view.getUint16(o, true);
+      const interpolationDelayMs = view.getUint16(o, true); o += 2;
+      const kills = view.getUint16(o, true); o += 2;
+      const deaths = view.getUint16(o, true);
       return {
         type: 'welcome',
         playerId,
@@ -527,6 +570,8 @@ export function decodeServerReliablePacket(data: ArrayBuffer | Uint8Array): Serv
         snapshotHz,
         serverTimeUs,
         interpolationDelayMs,
+        kills,
+        deaths,
       };
     }
     case PKT_SHOT_RESULT: {
@@ -587,6 +632,8 @@ export function decodeServerReliablePacket(data: ArrayBuffer | Uint8Array): Serv
       return decodeChunkDiffPacket(data);
     case PKT_PLAYER_ROSTER:
       return decodePlayerRosterPacket(view, o);
+    case PKT_PLAYER_STATS_UPDATE:
+      return decodePlayerStatsUpdatePacket(view, o);
     case PKT_DYNAMIC_BODY_META:
       return decodeDynamicBodyMetaPacket(view, o);
     case PKT_LOCAL_PLAYER_ENERGY:
@@ -839,14 +886,30 @@ export function decodeSnapshotV2Packet(view: DataView, o: number): SnapshotV2Pac
 function decodePlayerRosterPacket(view: DataView, o: number): PlayerRosterPacket {
   const count = view.getUint8(o++);
   const entries: PlayerRosterEntry[] = [];
+  const bytes = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
   for (let i = 0; i < count; i += 1) {
-    entries.push({
-      handle: view.getUint8(o),
-      playerId: view.getUint32(o + 1, true),
-    });
-    o += 5;
+    const handle = view.getUint8(o); o += 1;
+    const playerId = view.getUint32(o, true); o += 4;
+    const nameLen = view.getUint8(o); o += 1;
+    const username = TEXT_DECODER.decode(bytes.subarray(o, o + nameLen));
+    o += nameLen;
+    const kills = view.getUint16(o, true); o += 2;
+    const deaths = view.getUint16(o, true); o += 2;
+    entries.push({ handle, playerId, username, kills, deaths });
   }
   return { type: 'playerRoster', entries };
+}
+
+function decodePlayerStatsUpdatePacket(view: DataView, o: number): PlayerStatsUpdatePacket {
+  const count = view.getUint8(o++);
+  const entries: PlayerStatsEntry[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const playerId = view.getUint32(o, true); o += 4;
+    const kills = view.getUint16(o, true); o += 2;
+    const deaths = view.getUint16(o, true); o += 2;
+    entries.push({ playerId, kills, deaths });
+  }
+  return { type: 'playerStatsUpdate', entries };
 }
 
 function decodeDynamicBodyMetaPacket(view: DataView, o: number): DynamicBodyMetaPacket {
@@ -1237,6 +1300,8 @@ export function decodeServerPacket(data: ArrayBuffer | Uint8Array): ServerPacket
       return decodeChunkDiffPacket(data);
     case PKT_PLAYER_ROSTER:
       return decodePlayerRosterPacket(view, 1);
+    case PKT_PLAYER_STATS_UPDATE:
+      return decodePlayerStatsUpdatePacket(view, 1);
     case PKT_DYNAMIC_BODY_META:
       return decodeDynamicBodyMetaPacket(view, 1);
     case PKT_LOCAL_PLAYER_ENERGY:

--- a/client/src/net/sharedConstants.ts
+++ b/client/src/net/sharedConstants.ts
@@ -42,6 +42,7 @@ export const PKT_DYNAMIC_BODY_META = 114;
 export const PKT_LOCAL_PLAYER_ENERGY = 115;
 export const PKT_BATTERY_SYNC = 116;
 export const PKT_SHOT_FIRED = 117;
+export const PKT_PLAYER_STATS_UPDATE = 118;
 
 // ── Weapon types ────────────────────────────────
 export const WEAPON_HITSCAN = 1;

--- a/client/src/net/webTransportClient.ts
+++ b/client/src/net/webTransportClient.ts
@@ -21,6 +21,7 @@ import {
   type ServerReliablePacket,
   type WelcomePacket,
 } from './protocol';
+import { getUsername } from '../app/username';
 
 type WebTransportHash = {
   algorithm: string;
@@ -140,7 +141,10 @@ export class WebTransportGameClient {
 
     const control = await transport.createBidirectionalStream();
     const controlWriter = control.writable.getWriter();
-    await controlWriter.write(frameReliablePacket(encodeClientHello({ matchId: this.options.matchId })));
+    await controlWriter.write(frameReliablePacket(encodeClientHello({
+      matchId: this.options.matchId,
+      username: getUsername(),
+    })));
     await controlWriter.close();
     console.info('[webtransport] ClientHello sent, waiting for Welcome...');
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,3 +1,54 @@
+import { useCallback, useState } from 'react';
+import { MAX_USERNAME_LEN, setUsername, useUsername } from '../app/username';
+
+function UsernameField() {
+  const stored = useUsername();
+  const [draft, setDraft] = useState(stored);
+  const [saved, setSaved] = useState(false);
+
+  if (draft === '' && stored !== '') {
+    setDraft(stored);
+  }
+
+  const commit = useCallback(() => {
+    const next = setUsername(draft);
+    setDraft(next);
+    setSaved(true);
+    window.setTimeout(() => setSaved(false), 1500);
+  }, [draft]);
+
+  return (
+    <div className="mb-6 sm:mb-8 flex items-center gap-3 flex-wrap">
+      <label className="font-mono text-[10px] uppercase tracking-[0.25em] text-sky-500/60">
+        Your name
+      </label>
+      <input
+        type="text"
+        value={draft}
+        maxLength={MAX_USERNAME_LEN}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.currentTarget.blur();
+          }
+        }}
+        spellCheck={false}
+        autoComplete="off"
+        className={[
+          'bg-white/[0.04] border border-white/[0.12] rounded-md',
+          'px-3 py-1.5 text-sm text-white/90 font-mono',
+          'focus:outline-none focus:border-sky-400/60 focus:bg-white/[0.07]',
+          'transition-colors duration-200 min-w-[180px]',
+        ].join(' ')}
+      />
+      {saved ? (
+        <span className="text-emerald-300/75 text-xs font-mono">saved</span>
+      ) : null}
+    </div>
+  );
+}
+
 interface CardProps {
   href: string;
   tag: string;
@@ -72,6 +123,8 @@ export function HomePage() {
             a world from scratch and share it. No install. No login. Just play.
           </p>
         </div>
+
+        <UsernameField />
 
         {/* Mode cards — 3 columns */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3.5 mb-3.5">

--- a/client/src/runtime/gameRuntime.ts
+++ b/client/src/runtime/gameRuntime.ts
@@ -1,4 +1,12 @@
 import { resolveMultiplayerBackend } from '../app/runtimeConfig';
+import { getUsername } from '../app/username';
+import {
+  applyPracticeSnapshot,
+  applyRoster as applyScoreboardRoster,
+  applyStatsDelta as applyScoreboardStatsDelta,
+  resetScoreboard,
+  upsertLocalPlayer as upsertLocalScoreboardPlayer,
+} from '../ui/scoreboardStore';
 import { initSharedPhysics, WasmSimWorld, type WasmDebugRenderBuffers, type WasmSimWorldInstance } from '../wasm/sharedPhysics';
 import { LocalPracticeClient, type PracticeBotHost } from '../net/localPracticeClient';
 import { NetDebugTelemetry } from '../net/debugTelemetry';
@@ -626,6 +634,9 @@ export class LocalGameRuntime extends BaseGameRuntime {
         client.currentLocalPlayerState ? netPlayerStateToMeters(client.currentLocalPlayerState).position : [0, 2, 0],
       );
       this.syncState();
+      client.setLocalDisplayName(getUsername());
+      resetScoreboard();
+      this.startScoreboardPolling();
       this.callbacks.onWelcome(client.playerId);
       client.emitCurrentState();
     } catch (error) {
@@ -635,7 +646,45 @@ export class LocalGameRuntime extends BaseGameRuntime {
     }
   }
 
+  private scoreboardTimer: number | null = null;
+
+  private startScoreboardPolling(): void {
+    if (this.scoreboardTimer != null) return;
+    const tick = () => {
+      const json = this.client?.getLeaderboardJson();
+      if (json) {
+        try {
+          const raw = JSON.parse(json) as Array<{
+            id: number;
+            username: string;
+            kills: number;
+            deaths: number;
+            isBot: boolean;
+            isLocal: boolean;
+          }>;
+          applyPracticeSnapshot({
+            localPlayerId: this.client?.playerId ?? 0,
+            entries: raw,
+          });
+        } catch (err) {
+          console.warn('Failed to parse practice leaderboard JSON', err);
+        }
+      }
+    };
+    tick();
+    this.scoreboardTimer = window.setInterval(tick, 500);
+  }
+
+  private stopScoreboardPolling(): void {
+    if (this.scoreboardTimer != null) {
+      window.clearInterval(this.scoreboardTimer);
+      this.scoreboardTimer = null;
+    }
+  }
+
   disconnect(): void {
+    this.stopScoreboardPolling();
+    resetScoreboard();
     this.client?.disconnect();
     this.client = null;
     this.cosmeticWorld?.dispose();
@@ -1056,6 +1105,7 @@ export class MultiplayerGameRuntime extends BaseGameRuntime {
     sim.rebuildBroadPhase();
     this.sim = sim;
     this.cosmeticWorld = await CosmeticPhysicsWorld.create(this.worldJson);
+    resetScoreboard();
 
     try {
       this.prediction = new PredictionManager(sim);
@@ -1068,6 +1118,24 @@ export class MultiplayerGameRuntime extends BaseGameRuntime {
         onWelcome: (playerId) => {
           this.syncState();
           this.callbacks.onWelcome(playerId);
+        },
+        onWelcomePacket: (packet) => {
+          upsertLocalScoreboardPlayer(packet.playerId, getUsername(), packet.kills, packet.deaths);
+        },
+        onRoster: (packet) => {
+          applyScoreboardRoster(packet.entries.map((entry) => ({
+            playerId: entry.playerId,
+            username: entry.username,
+            kills: entry.kills,
+            deaths: entry.deaths,
+          })));
+        },
+        onStatsUpdate: (packet) => {
+          applyScoreboardStatsDelta(packet.entries.map((entry) => ({
+            playerId: entry.playerId,
+            kills: entry.kills,
+            deaths: entry.deaths,
+          })));
         },
         onDisconnect: (reason) => {
           this.callbacks.onDisconnect(reason);
@@ -1113,7 +1181,9 @@ export class MultiplayerGameRuntime extends BaseGameRuntime {
 
       const identity = 'player-' + Math.random().toString(36).slice(2, 8);
       const token = 'mvp-token';
-      const wsUrl = this.backend.createMatchWebSocketUrl(this.matchId, identity, token);
+      const wsUrl = this.backend.createMatchWebSocketUrl(this.matchId, identity, token, {
+        username: getUsername(),
+      });
       await client.connectWithFallback(this.matchId, wsUrl, this.backend.sessionConfigEndpoint);
     } catch (error) {
       this.client?.disconnect();
@@ -1132,6 +1202,7 @@ export class MultiplayerGameRuntime extends BaseGameRuntime {
   }
 
   disconnect(): void {
+    resetScoreboard();
     this.client?.disconnect();
     this.client = null;
     this.prediction?.dispose();

--- a/client/src/ui/KillDeathHUD.tsx
+++ b/client/src/ui/KillDeathHUD.tsx
@@ -1,0 +1,30 @@
+import { useLocalKD } from './scoreboardStore';
+
+export function KillDeathHUD() {
+  const { kills, deaths } = useLocalKD();
+  return (
+    <div
+      data-testid="kd-hud"
+      style={{
+        position: 'absolute',
+        top: 42,
+        left: 8,
+        zIndex: 5,
+        background: 'rgba(0,0,0,0.6)',
+        padding: '4px 10px',
+        borderRadius: 4,
+        fontSize: 13,
+        fontFamily: 'monospace',
+        pointerEvents: 'none',
+        color: 'rgba(255,255,255,0.92)',
+        letterSpacing: '0.02em',
+      }}
+    >
+      <span style={{ color: 'rgba(134, 239, 172, 0.95)' }}>K</span>
+      <span> {kills}</span>
+      <span style={{ opacity: 0.5, margin: '0 6px' }}>·</span>
+      <span style={{ color: 'rgba(252, 165, 165, 0.95)' }}>D</span>
+      <span> {deaths}</span>
+    </div>
+  );
+}

--- a/client/src/ui/LeaderboardOverlay.tsx
+++ b/client/src/ui/LeaderboardOverlay.tsx
@@ -1,0 +1,153 @@
+import { useScoreboard } from './scoreboardStore';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function LeaderboardOverlay({ open, onClose }: Props) {
+  const { localPlayerId, entries } = useScoreboard();
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="leaderboard-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Leaderboard"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        background: 'rgba(5, 12, 22, 0.72)',
+        backdropFilter: 'blur(4px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'auto',
+        color: '#edf6ff',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          minWidth: 380,
+          maxWidth: 'min(640px, 90vw)',
+          maxHeight: '80vh',
+          overflowY: 'auto',
+          background: 'rgba(15, 23, 42, 0.92)',
+          border: '1px solid rgba(255,255,255,0.1)',
+          borderRadius: 12,
+          padding: '20px 24px',
+          boxShadow: '0 18px 60px -10px rgba(0,0,0,0.6)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 14,
+          }}
+        >
+          <h2 style={{ margin: 0, fontSize: 18, letterSpacing: '0.05em' }}>
+            Leaderboard
+          </h2>
+          <span style={{ fontSize: 11, opacity: 0.55, fontFamily: 'monospace' }}>
+            Esc · Start
+          </span>
+        </div>
+        {entries.length === 0 ? (
+          <div style={{ opacity: 0.6, fontSize: 14, padding: '12px 0' }}>
+            No players yet.
+          </div>
+        ) : (
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: 14,
+            }}
+          >
+            <thead>
+              <tr
+                style={{
+                  textAlign: 'left',
+                  fontSize: 11,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.15em',
+                  opacity: 0.45,
+                }}
+              >
+                <th style={{ padding: '4px 8px 4px 0', fontWeight: 500 }}>Player</th>
+                <th style={{ padding: '4px 8px', fontWeight: 500, textAlign: 'right' }}>K</th>
+                <th style={{ padding: '4px 8px', fontWeight: 500, textAlign: 'right' }}>D</th>
+                <th style={{ padding: '4px 0 4px 8px', fontWeight: 500, textAlign: 'right' }}>K/D</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => {
+                const isLocal = entry.playerId === localPlayerId || entry.isLocal;
+                const ratio = entry.deaths === 0
+                  ? (entry.kills === 0 ? '0.00' : `${entry.kills.toFixed(2)}`)
+                  : (entry.kills / entry.deaths).toFixed(2);
+                return (
+                  <tr
+                    key={entry.playerId}
+                    style={{
+                      background: isLocal ? 'rgba(56, 189, 248, 0.12)' : 'transparent',
+                    }}
+                  >
+                    <td
+                      style={{
+                        padding: '6px 8px 6px 0',
+                        fontWeight: isLocal ? 600 : 400,
+                        color: isLocal ? '#7dd3fc' : (entry.isBot ? 'rgba(255,255,255,0.6)' : '#edf6ff'),
+                      }}
+                    >
+                      {entry.username || `Player ${entry.playerId}`}
+                      {entry.isBot ? (
+                        <span
+                          style={{
+                            marginLeft: 6,
+                            fontSize: 10,
+                            padding: '1px 6px',
+                            borderRadius: 4,
+                            background: 'rgba(255,255,255,0.08)',
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.08em',
+                            opacity: 0.8,
+                          }}
+                        >
+                          bot
+                        </span>
+                      ) : null}
+                    </td>
+                    <td style={{ padding: '6px 8px', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                      {entry.kills}
+                    </td>
+                    <td style={{ padding: '6px 8px', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                      {entry.deaths}
+                    </td>
+                    <td
+                      style={{
+                        padding: '6px 0 6px 8px',
+                        textAlign: 'right',
+                        fontVariantNumeric: 'tabular-nums',
+                        opacity: 0.75,
+                      }}
+                    >
+                      {ratio}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/ui/scoreboardStore.ts
+++ b/client/src/ui/scoreboardStore.ts
@@ -1,0 +1,159 @@
+// Central scoreboard store consumed by the leaderboard overlay and HUD chip.
+//
+// Fed by:
+//   - NetcodeClient (multiplayer): welcome, roster resync, stats delta
+//   - LocalPracticeClient (singleplayer): `WasmLocalSession.leaderboardJson()`
+//
+// Exposes a React hook via `useSyncExternalStore` so UI can subscribe
+// without per-frame renders. State is replaced wholesale whenever the
+// scoreboard changes; consumers should treat entries as immutable per tick.
+
+import { useSyncExternalStore } from 'react';
+
+export type ScoreboardEntry = {
+  playerId: number;
+  username: string;
+  kills: number;
+  deaths: number;
+  /** True for the player controlling the local session. */
+  isLocal: boolean;
+  /** True for AI-driven bots (practice mode only). */
+  isBot: boolean;
+};
+
+export type ScoreboardState = {
+  localPlayerId: number;
+  entries: ReadonlyArray<ScoreboardEntry>;
+};
+
+const EMPTY_STATE: ScoreboardState = { localPlayerId: 0, entries: [] };
+
+let current: ScoreboardState = EMPTY_STATE;
+const listeners = new Set<(state: ScoreboardState) => void>();
+
+function publish(next: ScoreboardState): void {
+  current = next;
+  for (const fn of listeners) fn(current);
+}
+
+function sortEntries(entries: ScoreboardEntry[]): ScoreboardEntry[] {
+  return [...entries].sort((a, b) => {
+    if (b.kills !== a.kills) return b.kills - a.kills;
+    if (a.deaths !== b.deaths) return a.deaths - b.deaths;
+    return a.playerId - b.playerId;
+  });
+}
+
+export function resetScoreboard(): void {
+  publish(EMPTY_STATE);
+}
+
+export function setScoreboard(next: {
+  localPlayerId: number;
+  entries: ScoreboardEntry[];
+}): void {
+  publish({ localPlayerId: next.localPlayerId, entries: sortEntries(next.entries) });
+}
+
+export function setLocalPlayerId(playerId: number): void {
+  publish({ ...current, localPlayerId: playerId });
+}
+
+export function upsertLocalPlayer(playerId: number, username: string, kills: number, deaths: number): void {
+  const entries = current.entries.filter((e) => e.playerId !== playerId);
+  entries.push({ playerId, username, kills, deaths, isLocal: true, isBot: false });
+  publish({ localPlayerId: playerId, entries: sortEntries(entries) });
+}
+
+/**
+ * Replace the roster wholesale (multiplayer resync). Preserves `isLocal`
+ * by comparing against `current.localPlayerId`. Bots are never sent over
+ * the wire, so everything from the network roster is a real player.
+ */
+export function applyRoster(entries: Array<{ playerId: number; username: string; kills: number; deaths: number }>): void {
+  const rebuilt = entries.map<ScoreboardEntry>((entry) => ({
+    playerId: entry.playerId,
+    username: entry.username,
+    kills: entry.kills,
+    deaths: entry.deaths,
+    isLocal: entry.playerId === current.localPlayerId,
+    isBot: false,
+  }));
+  publish({ localPlayerId: current.localPlayerId, entries: sortEntries(rebuilt) });
+}
+
+/**
+ * Apply a stats delta (single-kill event). Creates a placeholder entry if the
+ * player hasn't arrived via roster yet — the next roster resync will fill in
+ * the username.
+ */
+export function applyStatsDelta(deltas: Array<{ playerId: number; kills: number; deaths: number }>): void {
+  const byId = new Map(current.entries.map((e) => [e.playerId, e] as const));
+  for (const delta of deltas) {
+    const existing = byId.get(delta.playerId);
+    if (existing) {
+      byId.set(delta.playerId, { ...existing, kills: delta.kills, deaths: delta.deaths });
+    } else {
+      byId.set(delta.playerId, {
+        playerId: delta.playerId,
+        username: `Player ${delta.playerId}`,
+        kills: delta.kills,
+        deaths: delta.deaths,
+        isLocal: delta.playerId === current.localPlayerId,
+        isBot: false,
+      });
+    }
+  }
+  publish({
+    localPlayerId: current.localPlayerId,
+    entries: sortEntries(Array.from(byId.values())),
+  });
+}
+
+/**
+ * Practice-mode replacement. The WASM session serializes its full leaderboard
+ * so we overwrite whatever's present.
+ */
+export function applyPracticeSnapshot(params: {
+  localPlayerId: number;
+  entries: Array<{ id: number; username: string; kills: number; deaths: number; isBot: boolean; isLocal: boolean }>;
+}): void {
+  publish({
+    localPlayerId: params.localPlayerId,
+    entries: sortEntries(
+      params.entries.map((e) => ({
+        playerId: e.id,
+        username: e.username,
+        kills: e.kills,
+        deaths: e.deaths,
+        isLocal: e.isLocal,
+        isBot: e.isBot,
+      })),
+    ),
+  });
+}
+
+export function getScoreboard(): ScoreboardState {
+  return current;
+}
+
+export function subscribeScoreboard(fn: (state: ScoreboardState) => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+export function useScoreboard(): ScoreboardState {
+  return useSyncExternalStore(
+    (onStoreChange) => subscribeScoreboard(onStoreChange),
+    getScoreboard,
+    () => EMPTY_STATE,
+  );
+}
+
+export function useLocalKD(): { kills: number; deaths: number } {
+  const state = useScoreboard();
+  const local = state.entries.find((e) => e.playerId === state.localPlayerId);
+  return { kills: local?.kills ?? 0, deaths: local?.deaths ?? 0 };
+}

--- a/client/src/wasm/sharedPhysics.ts
+++ b/client/src/wasm/sharedPhysics.ts
@@ -248,6 +248,11 @@ type WasmLocalSessionInstance = InstanceType<typeof RawWasmLocalSession> & {
     limitMin: number, limitMax: number,
   ): void;
   removeRagdollJoint(jointId: number): void;
+
+  setLocalDisplayName(name: string): void;
+  localPlayerKills(): number;
+  localPlayerDeaths(): number;
+  leaderboardJson(): string;
 };
 
 type WasmLocalSessionCtor = {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -51,8 +51,9 @@ use crate::{
         client_datagram_to_packet, cms_to_mps, decode_client_datagram, decode_client_hello,
         decode_client_packet, encode_server_packet, energy_to_centi, f32_to_snorm16,
         make_net_battery_state, make_net_dynamic_body_state, make_net_player_state,
-        make_net_shot_fired, mm_to_meters, BatterySyncPacket, ClientPacket, FireCmd, InputCmd,
-        LocalPlayerEnergyPacket, MeleeCmd, NetBatteryState, ServerPacket, ShotResultPacket,
+        make_net_shot_fired, mm_to_meters, sanitize_username, BatterySyncPacket, ClientPacket,
+        FireCmd, InputCmd, LocalPlayerEnergyPacket, MeleeCmd, NetBatteryState,
+        PlayerStatsEntry, PlayerStatsUpdatePacket, ServerPacket, ShotResultPacket,
         SnapshotPacket, WelcomePacket, BTN_RELOAD, HIT_ZONE_BODY, HIT_ZONE_HEAD, HIT_ZONE_NONE,
         PKT_BATTERY_SYNC, PKT_LOCAL_PLAYER_ENERGY, PKT_PING, PKT_SNAPSHOT, PKT_SNAPSHOT_V2,
         SHOT_RESOLUTION_BLOCKED_BY_WORLD, SHOT_RESOLUTION_DYNAMIC, SHOT_RESOLUTION_MISS,
@@ -577,6 +578,8 @@ struct SpacetimeVerifier {
 struct WsQuery {
     identity: String,
     token: String,
+    #[serde(default)]
+    username: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -599,6 +602,7 @@ struct PlayerConnection {
     identity: String,
     transport: ClientTransport,
     tx: mpsc::Sender<Vec<u8>>,
+    username: String,
 }
 
 enum MatchEvent {
@@ -614,6 +618,9 @@ enum MatchEvent {
 
 struct PlayerRuntime {
     identity: String,
+    username: String,
+    kills: u16,
+    deaths: u16,
     transport: ClientTransport,
     tx: mpsc::Sender<Vec<u8>>,
     pending_inputs: VecDeque<InputCmd>,
@@ -918,6 +925,7 @@ async fn handle_wt_session(app: Arc<AppState>, connection: Connection) -> Result
         identity: format!("wt-player-{player_id}"),
         transport: ClientTransport::WebTransport,
         tx: out_tx,
+        username: hello.username.clone(),
     }))?;
 
     // Writer: prefer datagrams for snapshots/pings; fall back to reliable stream
@@ -1070,6 +1078,7 @@ async fn handle_socket(
         identity: query.identity.clone(),
         transport: ClientTransport::WebSocket,
         tx: out_tx.clone(),
+        username: sanitize_username(query.username.as_deref().unwrap_or("")),
     }))?;
 
     let telemetry = handle.telemetry.clone();
@@ -1361,9 +1370,18 @@ impl MatchState {
         let mut entries: Vec<_> = self
             .player_handles
             .iter()
-            .map(|(player_id, handle)| protocol::PlayerRosterEntry {
-                handle: *handle,
-                player_id: *player_id,
+            .map(|(player_id, handle)| {
+                let (username, kills, deaths) = match self.players.get(player_id) {
+                    Some(runtime) => (runtime.username.clone(), runtime.kills, runtime.deaths),
+                    None => (String::new(), 0, 0),
+                };
+                protocol::PlayerRosterEntry {
+                    handle: *handle,
+                    player_id: *player_id,
+                    username,
+                    kills,
+                    deaths,
+                }
             })
             .collect();
         entries.sort_by_key(|entry| entry.handle);
@@ -1419,6 +1437,9 @@ impl MatchState {
                     conn.player_id,
                     PlayerRuntime {
                         identity: conn.identity,
+                        username: conn.username.clone(),
+                        kills: 0,
+                        deaths: 0,
                         transport: conn.transport,
                         tx: conn.tx.clone(),
                         pending_inputs: VecDeque::new(),
@@ -1466,6 +1487,8 @@ impl MatchState {
                     snapshot_hz: SNAPSHOT_HZ,
                     server_time_us,
                     interpolation_delay_ms: (1000 / SNAPSHOT_HZ) * 2,
+                    kills: 0,
+                    deaths: 0,
                 });
                 let _ = try_queue_packet(&conn.tx, encode_server_packet(&welcome), &self.io);
                 self.send_initial_metadata(&conn.tx);
@@ -1763,7 +1786,12 @@ impl MatchState {
             {
                 player_centers.push(pos);
                 if hp > 0 && pos[1] < OUT_OF_BOUNDS_Y_M {
-                    self.kill_player_with_cause(player_id, server_time_ms, DeathCause::OutOfBounds);
+                    self.kill_player_with_cause(
+                        player_id,
+                        server_time_ms,
+                        DeathCause::OutOfBounds,
+                        None,
+                    );
                     self.void_kills += 1;
                 }
                 let alive = hp > 0 && (flags & 0x4) == 0;
@@ -1855,7 +1883,12 @@ impl MatchState {
 
         let (vehicle_ms, dynamics_ms) = self.arena.step_vehicles_and_dynamics(dt);
         for player_id in self.arena.apply_vehicle_player_collisions() {
-            self.kill_player_with_cause(player_id, server_time_ms, DeathCause::VehicleCollision);
+            self.kill_player_with_cause(
+                player_id,
+                server_time_ms,
+                DeathCause::VehicleCollision,
+                None,
+            );
         }
         let (awake_dynamic_bodies_total, awake_dynamic_bodies_near_players) =
             awake_dynamic_body_counts(&self.arena, &player_centers);
@@ -1911,11 +1944,21 @@ impl MatchState {
                 was_on_ground,
                 dt,
             ) {
-                self.kill_player_with_cause(player_id, server_time_ms, DeathCause::EnergyDepletion);
+                self.kill_player_with_cause(
+                    player_id,
+                    server_time_ms,
+                    DeathCause::EnergyDepletion,
+                    None,
+                );
             }
         }
         for player_id in self.arena.apply_vehicle_energy_drain(dt) {
-            self.kill_player_with_cause(player_id, server_time_ms, DeathCause::EnergyDepletion);
+            self.kill_player_with_cause(
+                player_id,
+                server_time_ms,
+                DeathCause::EnergyDepletion,
+                None,
+            );
         }
 
         let hitscan_started = Instant::now();
@@ -2366,11 +2409,17 @@ impl MatchState {
         }
     }
 
-    fn kill_player(&mut self, player_id: u32, server_time_ms: u32) {
-        self.kill_player_with_cause(player_id, server_time_ms, DeathCause::HpDamage);
+    fn kill_player(&mut self, player_id: u32, server_time_ms: u32, attacker_id: Option<u32>) {
+        self.kill_player_with_cause(player_id, server_time_ms, DeathCause::HpDamage, attacker_id);
     }
 
-    fn kill_player_with_cause(&mut self, player_id: u32, server_time_ms: u32, cause: DeathCause) {
+    fn kill_player_with_cause(
+        &mut self,
+        player_id: u32,
+        server_time_ms: u32,
+        cause: DeathCause,
+        attacker_id: Option<u32>,
+    ) {
         let battery_drop = if matches!(cause, DeathCause::HpDamage | DeathCause::VehicleCollision) {
             self.arena.players.get(&player_id).and_then(|state| {
                 if !state.dead && state.energy > 0.0 {
@@ -2400,13 +2449,49 @@ impl MatchState {
         if let Some(state) = self.arena.players.get_mut(&player_id) {
             state.energy = 0.0;
         }
+        let mut stats_changed: Vec<u32> = Vec::new();
         if let Some(runtime) = self.players.get_mut(&player_id) {
             runtime.respawn_at_ms = Some(server_time_ms.saturating_add(self.respawn_delay_ms));
             runtime.pending_inputs.clear();
             runtime.last_applied_input = InputCmd::default();
             runtime.last_sent_energy_centi = None;
+            runtime.deaths = runtime.deaths.saturating_add(1);
+            stats_changed.push(player_id);
+        }
+        if let Some(attacker_id) = attacker_id {
+            if attacker_id != player_id {
+                if let Some(attacker) = self.players.get_mut(&attacker_id) {
+                    attacker.kills = attacker.kills.saturating_add(1);
+                    stats_changed.push(attacker_id);
+                }
+            }
         }
         self.clear_spawn_protection(player_id);
+        if !stats_changed.is_empty() {
+            self.broadcast_player_stats_update(&stats_changed);
+        }
+    }
+
+    fn broadcast_player_stats_update(&self, player_ids: &[u32]) {
+        let entries: Vec<PlayerStatsEntry> = player_ids
+            .iter()
+            .filter_map(|pid| {
+                self.players.get(pid).map(|runtime| PlayerStatsEntry {
+                    player_id: *pid,
+                    kills: runtime.kills,
+                    deaths: runtime.deaths,
+                })
+            })
+            .collect();
+        if entries.is_empty() {
+            return;
+        }
+        let packet = encode_server_packet(&ServerPacket::PlayerStatsUpdate(
+            PlayerStatsUpdatePacket { entries },
+        ));
+        for runtime in self.players.values() {
+            let _ = try_queue_packet(&runtime.tx, packet.clone(), &self.io);
+        }
     }
 
     fn maybe_send_local_player_energy_update(&mut self, player_id: u32) {
@@ -2593,6 +2678,7 @@ impl MatchState {
                     queued.player_id,
                     server_time_ms,
                     DeathCause::EnergyDepletion,
+                    None,
                 );
                 continue;
             }
@@ -2694,7 +2780,7 @@ impl MatchState {
                     self.stagger_melee_after_damage(hit.victim_id, server_time_ms);
                 }
                 if matches!(damage_outcome, PlayerDamageOutcome::Killed) {
-                    self.kill_player(hit.victim_id, server_time_ms);
+                    self.kill_player(hit.victim_id, server_time_ms, Some(queued.player_id));
                 }
                 self.build_shot_result(
                     queued.cmd.shot_id,
@@ -2852,6 +2938,7 @@ impl MatchState {
                     queued.player_id,
                     server_time_ms,
                     DeathCause::EnergyDepletion,
+                    None,
                 );
                 continue;
             }
@@ -2926,7 +3013,7 @@ impl MatchState {
                         self.stagger_melee_after_damage(victim_id, server_time_ms);
                     }
                     if matches!(damage_outcome, PlayerDamageOutcome::Killed) {
-                        self.kill_player(victim_id, server_time_ms);
+                        self.kill_player(victim_id, server_time_ms, Some(queued.player_id));
                     }
                 }
             }
@@ -3750,6 +3837,9 @@ mod tests {
         let (tx, _rx) = mpsc::channel(PLAYER_OUTBOUND_QUEUE_CAPACITY);
         PlayerRuntime {
             identity: "test-player".to_string(),
+            username: String::new(),
+            kills: 0,
+            deaths: 0,
             transport: super::ClientTransport::WebSocket,
             tx,
             pending_inputs: VecDeque::new(),

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -11,6 +11,7 @@ pub use vibe_land_shared::unit_conv::*;
 #[derive(Clone, Debug)]
 pub struct ClientHello {
     pub match_id: String,
+    pub username: String,
 }
 
 #[derive(Clone, Debug)]
@@ -38,6 +39,7 @@ pub enum ServerPacket {
     ChunkDiff(ChunkDiffPacket),
     PlayerRoster(PlayerRosterPacket),
     DynamicBodyMeta(DynamicBodyMetaPacket),
+    PlayerStatsUpdate(PlayerStatsUpdatePacket),
     Ping(u32),
     Pong(u32),
 }
@@ -65,6 +67,7 @@ pub enum ServerReliablePacket {
     ChunkDiff(ChunkDiffPacket),
     PlayerRoster(PlayerRosterPacket),
     DynamicBodyMeta(DynamicBodyMetaPacket),
+    PlayerStatsUpdate(PlayerStatsUpdatePacket),
 }
 
 #[derive(Clone, Debug)]
@@ -166,10 +169,13 @@ pub struct SnapshotV2Packet {
     pub vehicle_states: Vec<VehicleStateV2>,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PlayerRosterEntry {
     pub handle: u8,
     pub player_id: u32,
+    pub username: String,
+    pub kills: u16,
+    pub deaths: u16,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -215,7 +221,37 @@ pub fn decode_client_hello(bytes: &[u8]) -> Result<ClientHello> {
     let match_len = buf.get_u16_le() as usize;
     ensure!(buf.remaining() >= match_len, "truncated match id");
     let match_id = std::str::from_utf8(&buf[..match_len])?.to_string();
-    Ok(ClientHello { match_id })
+    buf.advance(match_len);
+
+    // Username is optional for backwards compatibility with older clients.
+    let username = if buf.remaining() >= 2 {
+        let name_len = buf.get_u16_le() as usize;
+        ensure!(
+            name_len <= MAX_USERNAME_LEN,
+            "username too long ({name_len} > {MAX_USERNAME_LEN})"
+        );
+        ensure!(buf.remaining() >= name_len, "truncated username");
+        let raw = std::str::from_utf8(&buf[..name_len])?;
+        sanitize_username(raw)
+    } else {
+        String::new()
+    };
+
+    Ok(ClientHello { match_id, username })
+}
+
+pub fn sanitize_username(input: &str) -> String {
+    let mut out = String::with_capacity(input.len().min(MAX_USERNAME_LEN));
+    for ch in input.chars() {
+        if out.len() >= MAX_USERNAME_LEN {
+            break;
+        }
+        // Keep printable ASCII (0x20..=0x7E) only.
+        if (0x20u32..=0x7E).contains(&(ch as u32)) {
+            out.push(ch);
+        }
+    }
+    out.trim().to_string()
 }
 
 pub fn decode_client_datagram(bytes: &[u8]) -> Result<ClientDatagram> {
@@ -340,6 +376,8 @@ pub fn encode_server_reliable(packet: &ServerReliablePacket) -> Vec<u8> {
             out.put_u16_le(pkt.snapshot_hz);
             out.put_u64_le(pkt.server_time_us);
             out.put_u16_le(pkt.interpolation_delay_ms);
+            out.put_u16_le(pkt.kills);
+            out.put_u16_le(pkt.deaths);
         }
         ServerReliablePacket::ShotResult(pkt) => {
             out.put_u8(PKT_SHOT_RESULT);
@@ -425,6 +463,12 @@ pub fn encode_server_reliable(packet: &ServerReliablePacket) -> Vec<u8> {
             for entry in &pkt.entries {
                 out.put_u8(entry.handle);
                 out.put_u32_le(entry.player_id);
+                let name_bytes = entry.username.as_bytes();
+                let name_len = name_bytes.len().min(MAX_USERNAME_LEN);
+                out.put_u8(name_len as u8);
+                out.put_slice(&name_bytes[..name_len]);
+                out.put_u16_le(entry.kills);
+                out.put_u16_le(entry.deaths);
             }
         }
         ServerReliablePacket::DynamicBodyMeta(pkt) => {
@@ -437,6 +481,16 @@ pub fn encode_server_reliable(packet: &ServerReliablePacket) -> Vec<u8> {
                 out.put_u16_le(entry.hx_cm);
                 out.put_u16_le(entry.hy_cm);
                 out.put_u16_le(entry.hz_cm);
+            }
+        }
+        ServerReliablePacket::PlayerStatsUpdate(pkt) => {
+            out.put_u8(PKT_PLAYER_STATS_UPDATE);
+            let count = pkt.entries.len().min(u8::MAX as usize);
+            out.put_u8(count as u8);
+            for entry in pkt.entries.iter().take(count) {
+                out.put_u32_le(entry.player_id);
+                out.put_u16_le(entry.kills);
+                out.put_u16_le(entry.deaths);
             }
         }
     }
@@ -734,6 +788,8 @@ pub fn encode_server_packet(packet: &ServerPacket) -> Vec<u8> {
             out.put_u16_le(pkt.snapshot_hz);
             out.put_u64_le(pkt.server_time_us);
             out.put_u16_le(pkt.interpolation_delay_ms);
+            out.put_u16_le(pkt.kills);
+            out.put_u16_le(pkt.deaths);
         }
         ServerPacket::Snapshot(pkt) => {
             out.put_u8(PKT_SNAPSHOT);
@@ -850,6 +906,9 @@ pub fn encode_server_packet(packet: &ServerPacket) -> Vec<u8> {
         ServerPacket::DynamicBodyMeta(pkt) => {
             return encode_server_reliable(&ServerReliablePacket::DynamicBodyMeta(pkt.clone()))
         }
+        ServerPacket::PlayerStatsUpdate(pkt) => {
+            return encode_server_reliable(&ServerReliablePacket::PlayerStatsUpdate(pkt.clone()))
+        }
         ServerPacket::Ping(v) => {
             out.put_u8(PKT_PING);
             out.put_u32_le(*v);
@@ -916,12 +975,106 @@ mod tests {
             snapshot_hz: 30,
             server_time_us: 5_000_000,
             interpolation_delay_ms: 100,
+            kills: 7,
+            deaths: 3,
         });
         let encoded = encode_server_packet(&packet);
         assert_eq!(encoded[0], PKT_WELCOME);
         let view = &encoded[1..];
         assert_eq!(u32::from_le_bytes([view[0], view[1], view[2], view[3]]), 42);
         assert_eq!(u16::from_le_bytes([view[4], view[5]]), 60);
+        // Offsets: 4 (player_id) + 2 (sim_hz) + 2 (snapshot_hz) + 8 (time) + 2 (interp) = 18
+        assert_eq!(u16::from_le_bytes([view[18], view[19]]), 7);
+        assert_eq!(u16::from_le_bytes([view[20], view[21]]), 3);
+    }
+
+    #[test]
+    fn client_hello_accepts_username() {
+        let match_id = b"match-1";
+        let name = b"Alpha";
+        let mut bytes = vec![PKT_CLIENT_HELLO];
+        bytes.extend_from_slice(&(match_id.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(match_id);
+        bytes.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(name);
+        let hello = decode_client_hello(&bytes).expect("hello decodes");
+        assert_eq!(hello.match_id, "match-1");
+        assert_eq!(hello.username, "Alpha");
+    }
+
+    #[test]
+    fn client_hello_without_username_is_ok() {
+        let match_id = b"match-1";
+        let mut bytes = vec![PKT_CLIENT_HELLO];
+        bytes.extend_from_slice(&(match_id.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(match_id);
+        let hello = decode_client_hello(&bytes).expect("legacy hello decodes");
+        assert_eq!(hello.username, "");
+    }
+
+    #[test]
+    fn client_hello_strips_non_printable() {
+        let match_id = b"m";
+        let name = b"Hi\x01there";
+        let mut bytes = vec![PKT_CLIENT_HELLO];
+        bytes.extend_from_slice(&(match_id.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(match_id);
+        bytes.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(name);
+        let hello = decode_client_hello(&bytes).expect("hello decodes");
+        assert_eq!(hello.username, "Hithere");
+    }
+
+    #[test]
+    fn player_stats_update_round_trip() {
+        let packet = ServerReliablePacket::PlayerStatsUpdate(PlayerStatsUpdatePacket {
+            entries: vec![
+                PlayerStatsEntry {
+                    player_id: 42,
+                    kills: 7,
+                    deaths: 2,
+                },
+                PlayerStatsEntry {
+                    player_id: 9,
+                    kills: 0,
+                    deaths: 5,
+                },
+            ],
+        });
+        let encoded = encode_server_reliable(&packet);
+        assert_eq!(encoded[0], PKT_PLAYER_STATS_UPDATE);
+        assert_eq!(encoded[1], 2);
+        assert_eq!(
+            u32::from_le_bytes([encoded[2], encoded[3], encoded[4], encoded[5]]),
+            42
+        );
+        assert_eq!(u16::from_le_bytes([encoded[6], encoded[7]]), 7);
+        assert_eq!(u16::from_le_bytes([encoded[8], encoded[9]]), 2);
+    }
+
+    #[test]
+    fn player_roster_includes_username_and_stats() {
+        let packet = ServerReliablePacket::PlayerRoster(PlayerRosterPacket {
+            entries: vec![PlayerRosterEntry {
+                handle: 3,
+                player_id: 1001,
+                username: "Alpha".to_string(),
+                kills: 4,
+                deaths: 1,
+            }],
+        });
+        let encoded = encode_server_reliable(&packet);
+        assert_eq!(encoded[0], PKT_PLAYER_ROSTER);
+        assert_eq!(encoded[1], 1);
+        assert_eq!(encoded[2], 3);
+        assert_eq!(
+            u32::from_le_bytes([encoded[3], encoded[4], encoded[5], encoded[6]]),
+            1001
+        );
+        assert_eq!(encoded[7], 5);
+        assert_eq!(&encoded[8..13], b"Alpha");
+        assert_eq!(u16::from_le_bytes([encoded[13], encoded[14]]), 4);
+        assert_eq!(u16::from_le_bytes([encoded[15], encoded[16]]), 1);
     }
 
     #[test]

--- a/shared/src/constants.rs
+++ b/shared/src/constants.rs
@@ -39,6 +39,7 @@ pub const PKT_DYNAMIC_BODY_META: u8 = 114;
 pub const PKT_LOCAL_PLAYER_ENERGY: u8 = 115;
 pub const PKT_BATTERY_SYNC: u8 = 116;
 pub const PKT_SHOT_FIRED: u8 = 117;
+pub const PKT_PLAYER_STATS_UPDATE: u8 = 118;
 
 // ── Weapon types ────────────────────────────────
 pub const WEAPON_HITSCAN: u8 = 1;

--- a/shared/src/local_session.rs
+++ b/shared/src/local_session.rs
@@ -44,6 +44,11 @@ struct PlayerRuntime {
     is_bot: bool,
     respawn_cooldown_ticks: u32,
     respawn_at_ms: Option<u32>,
+    /// Human-readable display name. Local player is seeded from the client;
+    /// bots are `Bot <n>`.
+    display_name: String,
+    kills: u32,
+    deaths: u32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -118,6 +123,8 @@ impl LocalSession {
                 snapshot_hz: SNAPSHOT_HZ_LOCAL,
                 server_time_us,
                 interpolation_delay_ms: 0,
+                kills: 0,
+                deaths: 0,
             }));
     }
 
@@ -142,6 +149,7 @@ impl LocalSession {
         }
         let mut runtime = PlayerRuntime::default();
         runtime.is_bot = true;
+        runtime.display_name = format!("Bot {}", bot_id);
         self.players.insert(bot_id, runtime);
         self.arena.spawn_player(bot_id);
         self.activate_spawn_protection(bot_id);
@@ -161,6 +169,67 @@ impl LocalSession {
             return false;
         }
         self.arena.set_player_max_speed_override(bot_id, max_speed)
+    }
+
+    pub fn set_local_display_name(&mut self, name: &str) {
+        let sanitized = sanitize_local_username(name);
+        if let Some(runtime) = self.players.get_mut(&LOCAL_PLAYER_ID) {
+            runtime.display_name = sanitized;
+        }
+    }
+
+    pub fn local_player_kills(&self) -> u32 {
+        self.players
+            .get(&LOCAL_PLAYER_ID)
+            .map(|runtime| runtime.kills)
+            .unwrap_or(0)
+    }
+
+    pub fn local_player_deaths(&self) -> u32 {
+        self.players
+            .get(&LOCAL_PLAYER_ID)
+            .map(|runtime| runtime.deaths)
+            .unwrap_or(0)
+    }
+
+    pub fn leaderboard_json(&self) -> String {
+        let mut entries: Vec<_> = self
+            .players
+            .iter()
+            .map(|(id, runtime)| {
+                let name = if !runtime.display_name.is_empty() {
+                    runtime.display_name.clone()
+                } else if *id == LOCAL_PLAYER_ID {
+                    "You".to_string()
+                } else {
+                    format!("Player {}", id)
+                };
+                (*id, name, runtime.kills, runtime.deaths, runtime.is_bot)
+            })
+            .collect();
+        entries.sort_by(|a, b| {
+            b.2.cmp(&a.2)
+                .then_with(|| a.3.cmp(&b.3))
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        let mut out = String::from("[");
+        for (i, (id, name, kills, deaths, is_bot)) in entries.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            let escaped = escape_json_str(name);
+            out.push_str(&format!(
+                "{{\"id\":{},\"name\":\"{}\",\"kills\":{},\"deaths\":{},\"isBot\":{},\"isLocal\":{}}}",
+                id,
+                escaped,
+                kills,
+                deaths,
+                is_bot,
+                *id == LOCAL_PLAYER_ID
+            ));
+        }
+        out.push(']');
+        out
     }
 
     pub fn disconnect_bot(&mut self, bot_id: u32) -> bool {
@@ -517,6 +586,7 @@ impl LocalSession {
             runtime.respawn_at_ms = Some(server_time_ms.saturating_add(LOCAL_RESPAWN_DELAY_MS));
             runtime.pending_inputs.clear();
             runtime.last_applied_input = InputCmd::default();
+            runtime.deaths = runtime.deaths.saturating_add(1);
         }
         self.clear_spawn_protection(LOCAL_PLAYER_ID);
     }
@@ -618,7 +688,7 @@ impl LocalSession {
                         HitZone::Head => HITSCAN_HEAD_DAMAGE,
                         HitZone::Body => HITSCAN_BODY_DAMAGE,
                     };
-                    self.apply_damage(victim_id, damage, server_time_ms);
+                    self.apply_damage(victim_id, damage, server_time_ms, Some(shooter_id));
                 }
             } else if let Some((dynamic_body_id, dynamic_toi, normal)) = dynamic_hit {
                 if world_toi.map(|world| world >= dynamic_toi).unwrap_or(true) {
@@ -775,7 +845,7 @@ impl LocalSession {
             }
 
             if let Some((victim_id, _dist)) = best {
-                self.apply_damage(victim_id, MELEE_DAMAGE, server_time_ms);
+                self.apply_damage(victim_id, MELEE_DAMAGE, server_time_ms, Some(attacker_id));
             }
 
             if let Some(runtime) = self.players.get_mut(&attacker_id) {
@@ -824,7 +894,13 @@ impl LocalSession {
         best
     }
 
-    fn apply_damage(&mut self, victim_id: u32, damage: u8, server_time_ms: u32) {
+    fn apply_damage(
+        &mut self,
+        victim_id: u32,
+        damage: u8,
+        server_time_ms: u32,
+        attacker_id: Option<u32>,
+    ) {
         let is_bot = self
             .players
             .get(&victim_id)
@@ -844,9 +920,23 @@ impl LocalSession {
         if !matches!(damage_outcome, PlayerDamageOutcome::Killed) {
             return;
         }
+        // Credit the kill to the attacker (ignoring self-kills).
+        if let Some(attacker_id) = attacker_id {
+            if attacker_id != victim_id {
+                if let Some(attacker) = self.players.get_mut(&attacker_id) {
+                    attacker.kills = attacker.kills.saturating_add(1);
+                }
+            }
+        }
+        // Count the death for non-local victims here; the local player's
+        // deaths are counted inside `kill_local_player` so every death path
+        // (HP, energy, out-of-bounds, vehicle) is handled in one place.
         if victim_id == LOCAL_PLAYER_ID {
             self.kill_local_player(server_time_ms, LocalDeathCause::HpDamage);
             return;
+        }
+        if let Some(runtime) = self.players.get_mut(&victim_id) {
+            runtime.deaths = runtime.deaths.saturating_add(1);
         }
         if is_bot {
             if let Some(runtime) = self.players.get_mut(&victim_id) {
@@ -1334,14 +1424,47 @@ fn decode_vehicle_exit(buf: &mut &[u8]) -> Result<u32, String> {
     Ok(buf.get_u32_le())
 }
 
+pub const LOCAL_USERNAME_MAX_LEN: usize = 20;
+
+fn sanitize_local_username(input: &str) -> String {
+    let mut out = String::with_capacity(input.len().min(LOCAL_USERNAME_MAX_LEN));
+    for ch in input.chars() {
+        if out.len() >= LOCAL_USERNAME_MAX_LEN {
+            break;
+        }
+        if (0x20u32..=0x7E).contains(&(ch as u32)) {
+            out.push(ch);
+        }
+    }
+    out.trim().to_string()
+}
+
+fn escape_json_str(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 fn encode_welcome_packet(pkt: &WelcomePacket) -> Vec<u8> {
-    let mut out = BytesMut::with_capacity(19);
+    let mut out = BytesMut::with_capacity(23);
     out.put_u8(PKT_WELCOME);
     out.put_u32_le(pkt.player_id);
     out.put_u16_le(pkt.sim_hz);
     out.put_u16_le(pkt.snapshot_hz);
     out.put_u64_le(pkt.server_time_us);
     out.put_u16_le(pkt.interpolation_delay_ms);
+    out.put_u16_le(pkt.kills);
+    out.put_u16_le(pkt.deaths);
     out.to_vec()
 }
 

--- a/shared/src/protocol.rs
+++ b/shared/src/protocol.rs
@@ -144,7 +144,25 @@ pub struct WelcomePacket {
     pub snapshot_hz: u16,
     pub server_time_us: u64,
     pub interpolation_delay_ms: u16,
+    pub kills: u16,
+    pub deaths: u16,
 }
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PlayerStatsEntry {
+    pub player_id: u32,
+    pub kills: u16,
+    pub deaths: u16,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PlayerStatsUpdatePacket {
+    pub entries: Vec<PlayerStatsEntry>,
+}
+
+/// Maximum bytes accepted for a username on the wire.
+/// Server clamps/sanitises; we reject anything longer.
+pub const MAX_USERNAME_LEN: usize = 20;
 
 #[derive(Clone, Debug)]
 pub struct SnapshotPacket {

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -1895,6 +1895,26 @@ impl WasmLocalSession {
         self.inner.drain_packet_blob().into_boxed_slice()
     }
 
+    #[wasm_bindgen(js_name = setLocalDisplayName)]
+    pub fn set_local_display_name(&mut self, name: &str) {
+        self.inner.set_local_display_name(name);
+    }
+
+    #[wasm_bindgen(js_name = localPlayerKills)]
+    pub fn local_player_kills(&self) -> u32 {
+        self.inner.local_player_kills()
+    }
+
+    #[wasm_bindgen(js_name = localPlayerDeaths)]
+    pub fn local_player_deaths(&self) -> u32 {
+        self.inner.local_player_deaths()
+    }
+
+    #[wasm_bindgen(js_name = leaderboardJson)]
+    pub fn leaderboard_json(&self) -> String {
+        self.inner.leaderboard_json()
+    }
+
     // ── Client-local ragdoll bodies ──────────────────────────────────────────
 
     #[wasm_bindgen(js_name = spawnRagdollBody)]


### PR DESCRIPTION
## Summary
This PR implements a complete scoreboard system with kill/death tracking, player statistics, and username persistence. Players can now see a leaderboard overlay showing all players' kills, deaths, and K/D ratios, with their own stats displayed in a HUD chip. Usernames are persisted locally and transmitted to the server.

## Key Changes

### Client-Side
- **Scoreboard Store** (`scoreboardStore.ts`): New centralized state management for leaderboard data, fed by both multiplayer (NetcodeClient) and singleplayer (LocalPracticeClient) sources. Exposes React hooks via `useSyncExternalStore` for efficient UI updates without per-frame renders.
- **Username Management** (`username.ts`): Client-side username store with localStorage persistence, sanitization matching server rules (printable ASCII, max 20 bytes), and React hook integration.
- **Leaderboard Overlay** (`LeaderboardOverlay.tsx`): Full-screen modal showing sorted player list with kills, deaths, and K/D ratio. Toggleable via Escape key or gamepad Start button.
- **Kill/Death HUD** (`KillDeathHUD.tsx`): Compact top-left display of local player's current K/D stats.
- **Home Page Enhancement**: Added username input field with localStorage persistence and visual feedback.
- **Protocol Updates**: Extended `ClientHello` and `WelcomePacket` to include username and initial K/D stats. Added `PlayerStatsUpdatePacket` type for incremental stat deltas.

### Server-Side
- **Protocol Extensions** (`protocol.rs`): 
  - `ClientHello` now includes optional username field (backwards compatible)
  - `PlayerRosterEntry` expanded with username, kills, deaths
  - New `PlayerStatsUpdatePacket` for broadcasting kill/death events
  - `WelcomePacket` includes initial player K/D stats
  - Username sanitization function (printable ASCII only, max 20 bytes)
- **Match State** (`main.rs`): 
  - `PlayerRuntime` tracks username, kills, deaths per player
  - Roster building includes stats from player runtimes
  - Kill attribution: increments killer's stats, increments victim's death count
  - Handles out-of-bounds deaths and self-kills appropriately

### Shared/WASM
- **Local Session** (`local_session.rs`): 
  - `PlayerRuntime` now tracks display_name, kills, deaths
  - `leaderboard_json()` method serializes full leaderboard for practice mode
  - Kill/death tracking on damage application with attacker attribution
  - Username sanitization for local players
- **WASM API** (`wasm_api.rs`): Exposed methods for setting display name and querying leaderboard JSON

### Game Runtime Integration
- **LocalGameRuntime**: Polls WASM leaderboard JSON every 500ms and updates scoreboard store
- **MultiplayerGameRuntime**: Subscribes to welcome packets and stats deltas, updates scoreboard accordingly
- **Keyboard/Gamepad**: Escape key and gamepad Start button toggle leaderboard overlay

## Notable Implementation Details
- Scoreboard entries are sorted by kills (descending), then deaths (ascending), then player ID
- Local player is highlighted in the leaderboard UI
- Bots are marked with a "bot" badge in practice mode
- Username field validates input client-side and server-side with identical sanitization rules
- Stats are immutable per tick; consumers treat entries as read-only
- Backwards compatible: older clients without username support still work
- Practice mode leaderboard updates via polling; multiplayer uses event-driven updates

https://claude.ai/code/session_01Xi51iNUJZCvJ9eiffB4n9q