### PR TITLE
Add debug rendering support to local practice sessions

### DIFF
--- a/client/src/net/localPracticeClient.ts
+++ b/client/src/net/localPracticeClient.ts
@@ -32,7 +32,7 @@ import {
   VEHICLE_STATE_STRIDE,
 } from '../runtime/localSessionDecode';
 import { decodeVehicleDebugSnapshot, type VehicleDebugSnapshot } from '../runtime/vehicleDebug';
-import { initSharedPhysics, WasmLocalSession, type WasmLocalSessionInstance } from '../wasm/sharedPhysics';
+import { initSharedPhysics, WasmLocalSession, type WasmDebugRenderBuffers, type WasmLocalSessionInstance } from '../wasm/sharedPhysics';
 import type { RemotePlayer } from './netcodeClient';
 
 export type LocalPracticeClientConfig = {
@@ -113,6 +113,10 @@ export class LocalPracticeClient implements PracticeBotHost {
   }
 
   ping(): void {}
+
+  debugRender(modeBits: number): WasmDebugRenderBuffers | null {
+    return this.session?.debugRender(modeBits) ?? null;
+  }
 
   disconnect(): void {
     this.closedByClient = true;

--- a/client/src/runtime/gameRuntime.ts
+++ b/client/src/runtime/gameRuntime.ts
@@ -846,8 +846,9 @@ export class LocalGameRuntime extends BaseGameRuntime {
     return 0;
   }
 
-  getDebugRenderBuffers(_modeBits: number): WasmDebugRenderBuffers | null {
-    return null;
+  getDebugRenderBuffers(modeBits: number): WasmDebugRenderBuffers | null {
+    if (!this.client || modeBits === 0) return null;
+    return this.client.debugRender(modeBits);
   }
 
   getDebugStats(): RuntimeDebugStats {

--- a/client/src/wasm/sharedPhysics.ts
+++ b/client/src/wasm/sharedPhysics.ts
@@ -217,6 +217,7 @@ type WasmLocalSessionInstance = InstanceType<typeof RawWasmLocalSession> & {
     blockerToi: number,
   ): number[];
   getVehicleDebug(vehicleId: number): number[];
+  debugRender(modeBits: number): WasmDebugRenderBuffers;
   drainPackets(): Uint8Array;
 
   // ── Client-local ragdoll bodies ──────────────────────────────────────────

--- a/shared/src/local_session.rs
+++ b/shared/src/local_session.rs
@@ -10,6 +10,7 @@ use crate::{
         PKT_VEHICLE_EXIT, PKT_WELCOME, PLAYER_EYE_HEIGHT_M, RIFLE_BODY_DAMAGE,
         RIFLE_FIRE_INTERVAL_MS, RIFLE_HEAD_DAMAGE, SIM_HZ, SNAPSHOT_HZ_LOCAL,
     },
+    debug_render::{render_debug_buffers, DebugLineBuffers},
     physics_arena::{MoveConfig, PhysicsArena, PlayerDamageOutcome},
     protocol::*,
     seq::seq_is_newer,
@@ -19,6 +20,7 @@ use crate::{
 };
 use bytes::{Buf, BufMut, BytesMut};
 use nalgebra::{vector, Isometry3, Point3, Quaternion, Translation3, Unit, UnitQuaternion};
+use rapier3d::pipeline::DebugRenderPipeline;
 use rapier3d::prelude::{
     ColliderBuilder, Group, ImpulseJointHandle, InteractionGroups, RevoluteJointBuilder,
     RigidBodyBuilder, RigidBodyHandle, SphericalJointBuilder,
@@ -1258,6 +1260,21 @@ impl LocalSession {
         if let Some(handle) = self.ragdoll_joint_handles.remove(&joint_id) {
             self.arena.dynamic.impulse_joints.remove(handle, false);
         }
+    }
+
+    pub fn debug_render(&mut self, pipeline: &mut DebugRenderPipeline, mode_bits: u32) -> DebugLineBuffers {
+        self.arena.dynamic.sim.rigid_bodies
+            .propagate_modified_body_positions_to_colliders(&mut self.arena.dynamic.sim.colliders);
+        self.arena.sync_broad_phase();
+        render_debug_buffers(
+            pipeline,
+            mode_bits,
+            &self.arena.dynamic.sim.rigid_bodies,
+            &self.arena.dynamic.sim.colliders,
+            &self.arena.dynamic.impulse_joints,
+            &self.arena.dynamic.multibody_joints,
+            &self.arena.dynamic.sim.narrow_phase,
+        )
     }
 }
 

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -1612,6 +1612,7 @@ impl WasmSimWorld {
 #[wasm_bindgen]
 pub struct WasmLocalSession {
     inner: LocalSession,
+    debug_pipeline: DebugRenderPipeline,
 }
 
 const LOCAL_DYNAMIC_BODY_STATE_STRIDE: usize = 18;
@@ -1630,7 +1631,7 @@ impl WasmLocalSession {
             }
             None => LocalSession::new(),
         };
-        Ok(Self { inner })
+        Ok(Self { inner, debug_pipeline: default_debug_pipeline() })
     }
 
     pub fn connect(&mut self) {
@@ -2005,6 +2006,12 @@ impl WasmLocalSession {
     #[wasm_bindgen(js_name = removeRagdollJoint)]
     pub fn remove_ragdoll_joint(&mut self, joint_id: u32) {
         self.inner.remove_ragdoll_joint(joint_id);
+    }
+
+    #[wasm_bindgen(js_name = debugRender)]
+    pub fn debug_render(&mut self, mode_bits: u32) -> DebugRenderBuffers {
+        let buffers = self.inner.debug_render(&mut self.debug_pipeline, mode_bits);
+        DebugRenderBuffers::from_line_buffers(buffers)
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds debug rendering capabilities to local practice sessions, enabling visualization of physics objects and joints for debugging purposes.

## Key Changes
- **Rust backend (`local_session.rs`)**:
  - Added `debug_render()` method to `LocalSession` that synchronizes physics state and generates debug line buffers
  - Imports `DebugRenderPipeline` from rapier3d and debug rendering utilities
  - Properly propagates modified body positions to colliders before rendering

- **WASM API (`wasm_api.rs`)**:
  - Added `debug_pipeline` field to `WasmLocalSession` struct
  - Initialized debug pipeline with `default_debug_pipeline()` in constructor
  - Exposed `debug_render()` method to JavaScript with `#[wasm_bindgen]` attribute
  - Converts internal `DebugLineBuffers` to `DebugRenderBuffers` for JavaScript consumption

- **TypeScript client (`localPracticeClient.ts`)**:
  - Added `debugRender()` method that delegates to the WASM session
  - Updated imports to include `WasmDebugRenderBuffers` type

- **Game runtime (`gameRuntime.ts`)**:
  - Implemented `getDebugRenderBuffers()` in `LocalGameRuntime` to call client's debug render method
  - Added null checks for client availability and mode bits validation

## Implementation Details
- The debug rendering pipeline is maintained as part of the `WasmLocalSession` state, ensuring it persists across multiple render calls
- Physics state synchronization (body position propagation and broad phase sync) occurs before rendering to ensure accurate debug visualization
- The implementation follows the existing pattern of exposing Rust functionality through WASM bindings to JavaScript

https://claude.ai/code/session_0174yGDnxCpoQWuEAddv6fC1