### PR TITLE
Fix object selection in GodMode editor to prevent nested mesh selection

### DIFF
--- a/client/src/pages/GodMode.tsx
+++ b/client/src/pages/GodMode.tsx
@@ -2284,6 +2284,7 @@ function GodModeEditorScene({
             receiveShadow
             onPointerDown={(event) => {
               event.stopPropagation();
+              if (event.intersections[0]?.object !== event.object) return;
               onSelect({ kind: 'static', id: entity.id });
             }}
           >
@@ -2301,6 +2302,7 @@ function GodModeEditorScene({
             receiveShadow
             onPointerDown={(event) => {
               event.stopPropagation();
+              if (event.intersections[0]?.object !== event.object) return;
               onSelect({ kind: 'dynamic', id: entity.id });
             }}
           >
@@ -2343,6 +2345,7 @@ function GodModeEditorScene({
                 rotation-x={-Math.PI / 2}
                 onPointerDown={(event) => {
                   event.stopPropagation();
+                  if (event.intersections[0]?.object !== event.object) return;
                   onSelect({ kind: 'spawnArea', id: area.id });
                 }}
               >


### PR DESCRIPTION
## Summary
Fixed an issue in the GodMode editor where clicking on nested or overlapping 3D objects would incorrectly select child meshes instead of the intended parent object.

## Key Changes
- Added intersection validation checks to three pointer down event handlers for static entities, dynamic entities, and spawn areas
- Each handler now verifies that the clicked object matches the first intersection in the ray cast before proceeding with selection
- This prevents selection of unintended objects when clicking on areas with nested or overlapping meshes

## Implementation Details
The fix adds a guard clause `if (event.intersections[0]?.object !== event.object) return;` to three `onPointerDown` handlers in the GodModeEditorScene component. This ensures that only the topmost intersected object (the one the user intended to click) triggers the selection callback, while clicks on child meshes or overlapping geometry are ignored.

https://claude.ai/code/session_015G7uCpHmzGj5vKNbKtMkeW