### PR TITLE
Remove contour line rendering from terrain shaders

### DIFF
--- a/client/src/scene/DemoTerrain.tsx
+++ b/client/src/scene/DemoTerrain.tsx
@@ -71,26 +71,16 @@ export function DemoTerrain() {
     });
 
     material.onBeforeCompile = (shader) => {
-      shader.vertexShader = shader.vertexShader
-        .replace('#include <common>', '#include <common>\nvarying vec3 vWorldPosition;')
-        .replace('#include <worldpos_vertex>', '#include <worldpos_vertex>\nvWorldPosition = worldPosition.xyz;');
-
-      shader.fragmentShader = shader.fragmentShader
-        .replace('#include <common>', '#include <common>\nvarying vec3 vWorldPosition;')
-        .replace(
-          '#include <dithering_fragment>',
-          `
-            float contourHeight = vWorldPosition.y * 4.75 + 0.075 * (vWorldPosition.x + vWorldPosition.z);
-            float contourBand = min(fract(contourHeight), 1.0 - fract(contourHeight));
-            float contourLine = 1.0 - smoothstep(0.03, 0.11, contourBand);
-            float slopeShade = clamp(1.0 - normal.y, 0.0, 1.0);
-            gl_FragColor.rgb *= 1.0 - contourLine * (0.16 + slopeShade * 0.28);
-            gl_FragColor.rgb += vec3(0.05, 0.04, 0.02) * slopeShade;
-            #include <dithering_fragment>
-          `,
-        );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        '#include <dithering_fragment>',
+        `
+          float slopeShade = clamp(1.0 - normal.y, 0.0, 1.0);
+          gl_FragColor.rgb += vec3(0.05, 0.04, 0.02) * slopeShade;
+          #include <dithering_fragment>
+        `,
+      );
     };
-    material.customProgramCacheKey = () => 'demo-terrain-contours-v1';
+    material.customProgramCacheKey = () => 'demo-terrain-slopeshade-v1';
 
     return material;
   }, []);

--- a/client/src/scene/WorldTerrain.tsx
+++ b/client/src/scene/WorldTerrain.tsx
@@ -201,26 +201,16 @@ function buildTerrainMaterial(materials: TerrainMaterial[]): THREE.MeshStandardM
   });
 
   mat.onBeforeCompile = (shader) => {
-    shader.vertexShader = shader.vertexShader
-      .replace('#include <common>', '#include <common>\nvarying vec3 vWorldPosition;')
-      .replace('#include <worldpos_vertex>', '#include <worldpos_vertex>\nvWorldPosition = worldPosition.xyz;');
-
-    shader.fragmentShader = shader.fragmentShader
-      .replace('#include <common>', '#include <common>\nvarying vec3 vWorldPosition;')
-      .replace(
-        '#include <dithering_fragment>',
-        `
-          float contourHeight = vWorldPosition.y * 4.75 + 0.075 * (vWorldPosition.x + vWorldPosition.z);
-          float contourBand = min(fract(contourHeight), 1.0 - fract(contourHeight));
-          float contourLine = 1.0 - smoothstep(0.03, 0.11, contourBand);
-          float slopeShade = clamp(1.0 - normal.y, 0.0, 1.0);
-          gl_FragColor.rgb *= 1.0 - contourLine * (0.12 + slopeShade * 0.22);
-          gl_FragColor.rgb += vec3(0.04, 0.03, 0.015) * slopeShade;
-          #include <dithering_fragment>
-        `,
-      );
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <dithering_fragment>',
+      `
+        float slopeShade = clamp(1.0 - normal.y, 0.0, 1.0);
+        gl_FragColor.rgb += vec3(0.04, 0.03, 0.015) * slopeShade;
+        #include <dithering_fragment>
+      `,
+    );
   };
-  mat.customProgramCacheKey = () => 'world-terrain-splatmap-v2';
+  mat.customProgramCacheKey = () => 'world-terrain-splatmap-v3';
   return mat;
 }
 


### PR DESCRIPTION
## Summary
Simplified terrain shader implementations by removing contour line rendering logic while retaining slope shading effects. This reduces shader complexity and improves maintainability across both demo and world terrain materials.

## Key Changes
- **Removed contour line calculations**: Eliminated `vWorldPosition` varying variable and all associated contour height/band/line computations from both vertex and fragment shaders
- **Retained slope shading**: Kept the slope-based color adjustments that enhance terrain visual depth
- **Updated cache keys**: Bumped shader program cache keys to reflect the simplified shader implementations
  - `DemoTerrain`: `demo-terrain-contours-v1` → `demo-terrain-slopeshade-v1`
  - `WorldTerrain`: `world-terrain-splatmap-v2` → `world-terrain-splatmap-v3`

## Implementation Details
- Removed vertex shader modifications entirely (no more world position varying)
- Simplified fragment shader to only apply slope-based color tinting
- Maintained consistent slope shading coefficients for each terrain type
- Changes applied to both `DemoTerrain.tsx` and `WorldTerrain.tsx` for consistency

https://claude.ai/code/session_01BMpQ2xNgXKuJiBBaZrgU3H