### PR TITLE
Add portal system for inter-world navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import {
   type InputBindings,
   type KeyboardBindings,
 } from './input/bindings';
+import { usePointerLockEngagement } from './input/usePointerLockEngagement';
 import { GameScene } from './scene/GameScene';
 import type { CrosshairAimState } from './scene/aimTargeting';
 import type { DeviceFamily, InputFamilyMode, InputSample } from './input/types';
@@ -220,6 +221,16 @@ export function App({
   const { controller: damageFeedbackController, renderState: damageOverlayState } = useDamageFeedback();
   const touchMode = isTouchDevice();
   const renderStatsParentRef = useRef<HTMLDivElement>(null);
+
+  const getGameCanvas = useCallback(
+    () => document.querySelector<HTMLCanvasElement>('canvas[data-testid="game-canvas"]'),
+    [],
+  );
+  usePointerLockEngagement({
+    enabled: connected && !touchMode,
+    getCanvas: getGameCanvas,
+  });
+
   const copyNoticeTimerRef = useRef<number | null>(null);
   const benchmarkStartedAtRef = useRef<string | null>(null);
   const benchmarkDisconnectReasonRef = useRef<string | null>(null);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -170,7 +170,11 @@ export function App({
     } : undefined,
     [benchmarkConfig],
   );
-  const effectiveAutoConnect = autoConnect || benchmarkConfig?.autostart === true;
+  const portalAutoConnect = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+    return new URLSearchParams(window.location.search).get('portal') === 'true';
+  }, []);
+  const effectiveAutoConnect = autoConnect || benchmarkConfig?.autostart === true || portalAutoConnect;
   const pathLabel = routeLabel ?? (
     mode === 'multiplayer'
       ? buildMatchHref('/play', multiplayerMatchId)

--- a/client/src/input/usePointerLockEngagement.ts
+++ b/client/src/input/usePointerLockEngagement.ts
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+
+// Pointer lock requires a user gesture — there's no way around it. What we
+// can do is make the gesture frictionless: listen for ANY keydown/pointerdown
+// at the document level, lock on the first one, and re-arm if the user
+// presses Escape. This makes portal-arrival feel as close to "instant" as the
+// platform allows: the player presses W to start moving and the camera locks
+// without ever clicking a join overlay.
+
+type Options = {
+  enabled: boolean;
+  getCanvas: () => HTMLElement | null;
+};
+
+function isTextInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export function usePointerLockEngagement({ enabled, getCanvas }: Options): void {
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof document === 'undefined') return;
+
+    let armed = true;
+
+    const tryLock = (): void => {
+      if (!armed) return;
+      if (document.pointerLockElement !== null) return;
+      const canvas = getCanvas();
+      if (!canvas) return;
+      armed = false;
+      const result = (canvas as HTMLElement & {
+        requestPointerLock: () => Promise<void> | void;
+      }).requestPointerLock();
+      // Some browsers return a Promise; older ones return void. Either way,
+      // a failure should re-arm so the next gesture tries again.
+      if (result && typeof (result as Promise<void>).catch === 'function') {
+        (result as Promise<void>).catch(() => {
+          armed = true;
+        });
+      }
+    };
+
+    const onGesture = (event: Event): void => {
+      if (isTextInputTarget(event.target)) return;
+      tryLock();
+    };
+
+    const onPointerLockChange = (): void => {
+      if (document.pointerLockElement === null) {
+        // Lock lost (Escape pressed, tab switch, etc.) — re-arm so the next
+        // user gesture re-locks.
+        armed = true;
+      }
+    };
+
+    document.addEventListener('keydown', onGesture, true);
+    document.addEventListener('pointerdown', onGesture, true);
+    document.addEventListener('pointerlockchange', onPointerLockChange);
+
+    return () => {
+      document.removeEventListener('keydown', onGesture, true);
+      document.removeEventListener('pointerdown', onGesture, true);
+      document.removeEventListener('pointerlockchange', onPointerLockChange);
+    };
+  }, [enabled, getCanvas]);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -22,6 +22,20 @@ if (window.location.pathname === '/godmode' || window.location.pathname === '/go
   window.history.replaceState(null, '', '/builder/world' + window.location.search + window.location.hash);
 }
 
+// Vibe Jam portal landing: `/` is the URL we publish to the webring, so any
+// portal-arrival hits there. Forward to `/play` (auto-connect happens once the
+// game route loads) while preserving the full query string + hash.
+if (
+  (window.location.pathname === '/' || window.location.pathname === '/index.html')
+  && new URLSearchParams(window.location.search).get('portal') === 'true'
+) {
+  window.history.replaceState(
+    null,
+    '',
+    '/play' + window.location.search + window.location.hash,
+  );
+}
+
 const route = resolveAppRoute(window.location.pathname, window.location.search);
 
 switch (route.kind) {

--- a/client/src/scene/GameWorld.tsx
+++ b/client/src/scene/GameWorld.tsx
@@ -81,6 +81,7 @@ import type { BotIntent, ObservedPlayer, Vec3Tuple } from '../bots/types';
 import { anchorForBot, type LoadTestScenario, type PlayBenchmarkDriverProfile } from '../loadtest/scenario';
 import type { PracticeBotRuntime, PracticeBotShotVisual } from '../bots';
 import { BotsDebugOverlay } from './BotsDebugOverlay';
+import { Portals } from './Portals';
 import { WorldTerrain } from './WorldTerrain';
 import { WorldStaticProps } from './WorldStaticProps';
 import {
@@ -3130,6 +3131,7 @@ export function GameWorld({
       <directionalLight position={[-28, 20, -32]} intensity={0.55} color={0xa8c8ff} />
       <WorldTerrain world={worldDocument} />
       <WorldStaticProps world={worldDocument} />
+      <Portals runtimeRef={runtimeRef} />
 
       {renderBlocks.map((block) => (
         <WorldBlock

--- a/client/src/scene/Portals.tsx
+++ b/client/src/scene/Portals.tsx
@@ -1,5 +1,5 @@
 import { Html } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
+import { useFrame, useThree } from '@react-three/fiber';
 import { useMemo, useRef, type RefObject } from 'react';
 import * as THREE from 'three';
 import type { GameRuntimeClient } from '../runtime/gameRuntime';
@@ -7,15 +7,59 @@ import {
   VIBE_JAM_PORTAL_URL,
   buildPortalRedirectUrl,
   buildReturnPortalUrl,
+  getCanonicalSelfRef,
   readPortalParams,
 } from './portalParams';
 
 const PORTAL_TRIGGER_RADIUS_M = 1.6;
 const PORTAL_REARM_RADIUS_M = 2.6;
+// Ring is radius 1.4 m; lifting the center to ground+1.4 puts the bottom of
+// the ring on the ground and the player walks comfortably through the middle.
+const PORTAL_GROUND_OFFSET_M = 1.4;
+// Cast from well above any plausible terrain height down to its lowest plausible value.
+const TERRAIN_RAYCAST_FROM_Y = 200;
+const TERRAIN_RAYCAST_DISTANCE = 400;
+// Default exit portal XZ — east of world origin, where the demo worlds spawn.
+const EXIT_PORTAL_XZ: [number, number] = [8, 0];
 
 function getCurrentSelfRef(): string | null {
   if (typeof window === 'undefined') return null;
-  return window.location.host || null;
+  return getCanonicalSelfRef(window.location.origin);
+}
+
+const DOWN = new THREE.Vector3(0, -1, 0);
+const RAY_ORIGIN = new THREE.Vector3();
+
+// Casts a ray straight down at (x, z) and returns the highest hit Y, or null
+// if the scene has no geometry yet. Hits any visible mesh — terrain tiles,
+// world props, the player capsule helper — which is fine for clamping a portal
+// to "the surface beneath it".
+function raycastTerrainY(
+  scene: THREE.Object3D,
+  raycaster: THREE.Raycaster,
+  x: number,
+  z: number,
+): number | null {
+  RAY_ORIGIN.set(x, TERRAIN_RAYCAST_FROM_Y, z);
+  raycaster.set(RAY_ORIGIN, DOWN);
+  raycaster.near = 0;
+  raycaster.far = TERRAIN_RAYCAST_DISTANCE;
+  const hits = raycaster.intersectObject(scene, true);
+  for (const hit of hits) {
+    // Skip the portal's own geometry / labels / lights.
+    let parent: THREE.Object3D | null = hit.object;
+    let isPortalDescendant = false;
+    while (parent) {
+      if (parent.userData.isVibeJamPortal === true) {
+        isPortalDescendant = true;
+        break;
+      }
+      parent = parent.parent;
+    }
+    if (isPortalDescendant) continue;
+    return hit.point.y;
+  }
+  return null;
 }
 
 export function Portals({
@@ -26,6 +70,7 @@ export function Portals({
   const params = useMemo(() => readPortalParams(window.location.search), []);
   const selfRef = useMemo(() => getCurrentSelfRef(), []);
   const startActive = params.isFromPortal && params.ref !== null;
+  const scene = useThree((state) => state.scene);
 
   const exitGroupRef = useRef<THREE.Group>(null);
   const startGroupRef = useRef<THREE.Group>(null);
@@ -35,15 +80,33 @@ export function Portals({
   const startInitializedRef = useRef(false);
   const exitArmedRef = useRef(false);
   const startArmedRef = useRef(false);
+  const exitGroundedRef = useRef(false);
 
   const tmpVec = useRef(new THREE.Vector3());
-  const exitPos = useMemo(() => new THREE.Vector3(8, 1.8, 0), []);
+  const raycaster = useMemo(() => new THREE.Raycaster(), []);
+  const exitPos = useMemo(
+    () => new THREE.Vector3(EXIT_PORTAL_XZ[0], PORTAL_GROUND_OFFSET_M, EXIT_PORTAL_XZ[1]),
+    [],
+  );
   const startPosRef = useRef(new THREE.Vector3());
 
   useFrame((_, dt) => {
     // Idle spin even before player is ready.
     if (exitRingRef.current) exitRingRef.current.rotation.z += dt * 0.6;
     if (startRingRef.current) startRingRef.current.rotation.z -= dt * 0.6;
+
+    // Resolve the exit portal's ground height once terrain has mounted.
+    // Retried every frame until it sticks; cheap (single ray).
+    if (!exitGroundedRef.current) {
+      const groundY = raycastTerrainY(scene, raycaster, exitPos.x, exitPos.z);
+      if (groundY !== null) {
+        exitPos.set(exitPos.x, groundY + PORTAL_GROUND_OFFSET_M, exitPos.z);
+        if (exitGroupRef.current) {
+          exitGroupRef.current.position.copy(exitPos);
+        }
+        exitGroundedRef.current = true;
+      }
+    }
 
     if (triggeredRef.current) return;
     const client = runtimeRef.current;
@@ -55,7 +118,9 @@ export function Portals({
     // Initialize start portal at the player's first valid position so they
     // appear to spawn out of it. Stays invisible until placed.
     if (startActive && !startInitializedRef.current) {
-      startPosRef.current.set(pos[0], pos[1] + 0.4, pos[2]);
+      const groundY = raycastTerrainY(scene, raycaster, pos[0], pos[2]);
+      const baseY = groundY !== null ? groundY : pos[1];
+      startPosRef.current.set(pos[0], baseY + PORTAL_GROUND_OFFSET_M, pos[2]);
       const group = startGroupRef.current;
       if (group) {
         group.position.copy(startPosRef.current);
@@ -101,6 +166,7 @@ export function Portals({
       <group
         ref={startGroupRef}
         visible={false}
+        userData={{ isVibeJamPortal: true }}
       >
         {startActive && (
           <PortalVisualBody
@@ -126,7 +192,7 @@ type PortalVisualProps = {
 
 function PortalVisual({ groupRef, ringRef, position, color, emissive, label }: PortalVisualProps) {
   return (
-    <group ref={groupRef} position={position}>
+    <group ref={groupRef} position={position} userData={{ isVibeJamPortal: true }}>
       <PortalVisualBody ringRef={ringRef} color={color} emissive={emissive} label={label} />
     </group>
   );

--- a/client/src/scene/Portals.tsx
+++ b/client/src/scene/Portals.tsx
@@ -1,0 +1,191 @@
+import { Html } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { useMemo, useRef, type RefObject } from 'react';
+import * as THREE from 'three';
+import type { GameRuntimeClient } from '../runtime/gameRuntime';
+import {
+  VIBE_JAM_PORTAL_URL,
+  buildPortalRedirectUrl,
+  buildReturnPortalUrl,
+  readPortalParams,
+} from './portalParams';
+
+const PORTAL_TRIGGER_RADIUS_M = 1.6;
+const PORTAL_REARM_RADIUS_M = 2.6;
+
+function getCurrentSelfRef(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.location.host || null;
+}
+
+export function Portals({
+  runtimeRef,
+}: {
+  runtimeRef: RefObject<GameRuntimeClient | null>;
+}) {
+  const params = useMemo(() => readPortalParams(window.location.search), []);
+  const selfRef = useMemo(() => getCurrentSelfRef(), []);
+  const startActive = params.isFromPortal && params.ref !== null;
+
+  const exitGroupRef = useRef<THREE.Group>(null);
+  const startGroupRef = useRef<THREE.Group>(null);
+  const exitRingRef = useRef<THREE.Mesh>(null);
+  const startRingRef = useRef<THREE.Mesh>(null);
+  const triggeredRef = useRef(false);
+  const startInitializedRef = useRef(false);
+  const exitArmedRef = useRef(false);
+  const startArmedRef = useRef(false);
+
+  const tmpVec = useRef(new THREE.Vector3());
+  const exitPos = useMemo(() => new THREE.Vector3(8, 1.8, 0), []);
+  const startPosRef = useRef(new THREE.Vector3());
+
+  useFrame((_, dt) => {
+    // Idle spin even before player is ready.
+    if (exitRingRef.current) exitRingRef.current.rotation.z += dt * 0.6;
+    if (startRingRef.current) startRingRef.current.rotation.z -= dt * 0.6;
+
+    if (triggeredRef.current) return;
+    const client = runtimeRef.current;
+    if (!client) return;
+    const pos = client.getPosition();
+    if (!pos) return;
+    const player = tmpVec.current.set(pos[0], pos[1], pos[2]);
+
+    // Initialize start portal at the player's first valid position so they
+    // appear to spawn out of it. Stays invisible until placed.
+    if (startActive && !startInitializedRef.current) {
+      startPosRef.current.set(pos[0], pos[1] + 0.4, pos[2]);
+      const group = startGroupRef.current;
+      if (group) {
+        group.position.copy(startPosRef.current);
+        group.visible = true;
+      }
+      startInitializedRef.current = true;
+    }
+
+    const dExit = player.distanceTo(exitPos);
+    if (!exitArmedRef.current && dExit > PORTAL_REARM_RADIUS_M) {
+      exitArmedRef.current = true;
+    }
+    if (exitArmedRef.current && dExit < PORTAL_TRIGGER_RADIUS_M) {
+      triggeredRef.current = true;
+      const url = buildPortalRedirectUrl(VIBE_JAM_PORTAL_URL, params.forwarded, selfRef);
+      window.location.href = url;
+      return;
+    }
+
+    if (startActive && startInitializedRef.current && params.ref) {
+      const dStart = player.distanceTo(startPosRef.current);
+      if (!startArmedRef.current && dStart > PORTAL_REARM_RADIUS_M) {
+        startArmedRef.current = true;
+      }
+      if (startArmedRef.current && dStart < PORTAL_TRIGGER_RADIUS_M) {
+        triggeredRef.current = true;
+        const url = buildReturnPortalUrl(params.ref, params.forwarded, selfRef);
+        window.location.href = url;
+      }
+    }
+  });
+
+  return (
+    <>
+      <PortalVisual
+        groupRef={exitGroupRef}
+        ringRef={exitRingRef}
+        position={exitPos}
+        color="#ff4488"
+        emissive="#ff77aa"
+        label="Vibe Jam Portal"
+      />
+      <group
+        ref={startGroupRef}
+        visible={false}
+      >
+        {startActive && (
+          <PortalVisualBody
+            ringRef={startRingRef}
+            color="#44ddff"
+            emissive="#88eeff"
+            label={`Return: ${params.ref ?? ''}`}
+          />
+        )}
+      </group>
+    </>
+  );
+}
+
+type PortalVisualProps = {
+  groupRef: RefObject<THREE.Group>;
+  ringRef: RefObject<THREE.Mesh>;
+  position: THREE.Vector3;
+  color: string;
+  emissive: string;
+  label: string;
+};
+
+function PortalVisual({ groupRef, ringRef, position, color, emissive, label }: PortalVisualProps) {
+  return (
+    <group ref={groupRef} position={position}>
+      <PortalVisualBody ringRef={ringRef} color={color} emissive={emissive} label={label} />
+    </group>
+  );
+}
+
+type PortalVisualBodyProps = {
+  ringRef: RefObject<THREE.Mesh>;
+  color: string;
+  emissive: string;
+  label: string;
+};
+
+function PortalVisualBody({ ringRef, color, emissive, label }: PortalVisualBodyProps) {
+  return (
+    <>
+      <mesh ref={ringRef}>
+        <torusGeometry args={[1.4, 0.18, 16, 64]} />
+        <meshStandardMaterial
+          color={color}
+          emissive={emissive}
+          emissiveIntensity={1.4}
+          roughness={0.3}
+          metalness={0.1}
+        />
+      </mesh>
+      <mesh>
+        <circleGeometry args={[1.28, 48]} />
+        <meshBasicMaterial
+          color={color}
+          transparent
+          opacity={0.55}
+          side={THREE.DoubleSide}
+          depthWrite={false}
+          toneMapped={false}
+        />
+      </mesh>
+      <pointLight color={emissive} intensity={6} distance={12} decay={1.4} />
+      <Html
+        position={[0, 1.95, 0]}
+        center
+        distanceFactor={9}
+        style={{ pointerEvents: 'none', userSelect: 'none' }}
+      >
+        <div
+          style={{
+            background: 'rgba(0, 0, 0, 0.7)',
+            color: '#fff',
+            padding: '4px 10px',
+            fontFamily: 'system-ui, sans-serif',
+            fontSize: 14,
+            fontWeight: 600,
+            borderRadius: 4,
+            whiteSpace: 'nowrap',
+            letterSpacing: 0.4,
+          }}
+        >
+          {label}
+        </div>
+      </Html>
+    </>
+  );
+}

--- a/client/src/scene/Portals.tsx
+++ b/client/src/scene/Portals.tsx
@@ -20,7 +20,7 @@ const PORTAL_GROUND_OFFSET_M = 1.4;
 const TERRAIN_RAYCAST_FROM_Y = 200;
 const TERRAIN_RAYCAST_DISTANCE = 400;
 // Default exit portal XZ — east of world origin, where the demo worlds spawn.
-const EXIT_PORTAL_XZ: [number, number] = [8, 0];
+const EXIT_PORTAL_XZ: [number, number] = [20, 0];
 
 function getCurrentSelfRef(): string | null {
   if (typeof window === 'undefined') return null;

--- a/client/src/scene/portalParams.test.ts
+++ b/client/src/scene/portalParams.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  VIBE_JAM_PORTAL_URL,
+  buildPortalRedirectUrl,
+  buildReturnPortalUrl,
+  readPortalParams,
+} from './portalParams';
+
+describe('readPortalParams', () => {
+  it('returns inactive defaults for an empty query string', () => {
+    expect(readPortalParams('')).toEqual({
+      isFromPortal: false,
+      ref: null,
+      forwarded: {},
+    });
+  });
+
+  it('detects portal=true and ref', () => {
+    const result = readPortalParams('?portal=true&ref=fly.pieter.com');
+    expect(result.isFromPortal).toBe(true);
+    expect(result.ref).toBe('fly.pieter.com');
+    expect(result.forwarded).toEqual({});
+  });
+
+  it('treats portal=anything-else as not from portal', () => {
+    expect(readPortalParams('?portal=1').isFromPortal).toBe(false);
+    expect(readPortalParams('?portal=false').isFromPortal).toBe(false);
+  });
+
+  it('captures all forwarded keys when present', () => {
+    const search =
+      '?portal=true&username=levelsio&color=red&speed=5&avatar_url=https://x/y.png'
+      + '&team=blue&hp=88&speed_x=1&speed_y=2&speed_z=3'
+      + '&rotation_x=0.1&rotation_y=0.2&rotation_z=0.3&ref=fly.pieter.com';
+    const result = readPortalParams(search);
+    expect(result.isFromPortal).toBe(true);
+    expect(result.ref).toBe('fly.pieter.com');
+    expect(result.forwarded).toEqual({
+      username: 'levelsio',
+      color: 'red',
+      speed: '5',
+      avatar_url: 'https://x/y.png',
+      team: 'blue',
+      hp: '88',
+      speed_x: '1',
+      speed_y: '2',
+      speed_z: '3',
+      rotation_x: '0.1',
+      rotation_y: '0.2',
+      rotation_z: '0.3',
+    });
+  });
+
+  it('ignores empty forwarded values', () => {
+    expect(readPortalParams('?username=&color=blue').forwarded).toEqual({ color: 'blue' });
+  });
+
+  it('ignores ref outside the params object even when empty', () => {
+    expect(readPortalParams('?ref=').ref).toBeNull();
+  });
+});
+
+describe('buildPortalRedirectUrl', () => {
+  it('forwards params and sets ref', () => {
+    const url = buildPortalRedirectUrl(
+      VIBE_JAM_PORTAL_URL,
+      { username: 'levelsio', color: 'red', speed: '5' },
+      'vibe-land.example',
+    );
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe(VIBE_JAM_PORTAL_URL);
+    expect(parsed.searchParams.get('username')).toBe('levelsio');
+    expect(parsed.searchParams.get('color')).toBe('red');
+    expect(parsed.searchParams.get('speed')).toBe('5');
+    expect(parsed.searchParams.get('ref')).toBe('vibe-land.example');
+  });
+
+  it('omits ref when selfRef is null', () => {
+    const url = buildPortalRedirectUrl(VIBE_JAM_PORTAL_URL, {}, null);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('ref')).toBeNull();
+  });
+
+  it('overrides any inbound ref forwarded into the dict with selfRef', () => {
+    const url = buildPortalRedirectUrl(
+      VIBE_JAM_PORTAL_URL,
+      { username: 'a' },
+      'me.example',
+    );
+    expect(new URL(url).searchParams.get('ref')).toBe('me.example');
+  });
+});
+
+describe('buildReturnPortalUrl', () => {
+  it('prepends https:// when ref is bare host and adds portal=true', () => {
+    const url = buildReturnPortalUrl('fly.pieter.com', { username: 'levelsio' }, 'me.example');
+    const parsed = new URL(url);
+    expect(parsed.protocol).toBe('https:');
+    expect(parsed.host).toBe('fly.pieter.com');
+    expect(parsed.searchParams.get('portal')).toBe('true');
+    expect(parsed.searchParams.get('username')).toBe('levelsio');
+    expect(parsed.searchParams.get('ref')).toBe('me.example');
+  });
+
+  it('keeps explicit https:// scheme', () => {
+    const url = buildReturnPortalUrl('https://fly.pieter.com/foo', {}, null);
+    const parsed = new URL(url);
+    expect(parsed.protocol).toBe('https:');
+    expect(parsed.host).toBe('fly.pieter.com');
+    expect(parsed.pathname).toBe('/foo');
+    expect(parsed.searchParams.get('portal')).toBe('true');
+    expect(parsed.searchParams.get('ref')).toBeNull();
+  });
+
+  it('preserves http:// when caller explicitly requests it', () => {
+    const url = buildReturnPortalUrl('http://localhost:3000', {}, null);
+    expect(new URL(url).protocol).toBe('http:');
+  });
+});

--- a/client/src/scene/portalParams.test.ts
+++ b/client/src/scene/portalParams.test.ts
@@ -3,6 +3,7 @@ import {
   VIBE_JAM_PORTAL_URL,
   buildPortalRedirectUrl,
   buildReturnPortalUrl,
+  getCanonicalSelfRef,
   readPortalParams,
 } from './portalParams';
 
@@ -115,5 +116,22 @@ describe('buildReturnPortalUrl', () => {
   it('preserves http:// when caller explicitly requests it', () => {
     const url = buildReturnPortalUrl('http://localhost:3000', {}, null);
     expect(new URL(url).protocol).toBe('http:');
+  });
+});
+
+describe('getCanonicalSelfRef', () => {
+  it('returns null for null/undefined/empty origin', () => {
+    expect(getCanonicalSelfRef(null)).toBeNull();
+    expect(getCanonicalSelfRef(undefined)).toBeNull();
+    expect(getCanonicalSelfRef('')).toBeNull();
+  });
+
+  it('appends a single trailing slash to the origin', () => {
+    expect(getCanonicalSelfRef('https://vibe-land.example')).toBe('https://vibe-land.example/');
+  });
+
+  it('does not double trailing slashes', () => {
+    expect(getCanonicalSelfRef('https://vibe-land.example/')).toBe('https://vibe-land.example/');
+    expect(getCanonicalSelfRef('https://vibe-land.example///')).toBe('https://vibe-land.example/');
   });
 });

--- a/client/src/scene/portalParams.ts
+++ b/client/src/scene/portalParams.ts
@@ -1,5 +1,15 @@
 export const VIBE_JAM_PORTAL_URL = 'https://vibejam.cc/portal/2026';
 
+// `/` is the URL we publish to the Vibe Jam webring. All outbound portals send
+// this as `ref=` so reciprocal portals from other games come back to our
+// canonical landing page (which forwards to /play on arrival).
+export function getCanonicalSelfRef(origin: string | null | undefined): string | null {
+  if (!origin) return null;
+  // Tolerate trailing slashes / explicit paths in the origin string.
+  const trimmed = origin.replace(/\/+$/, '');
+  return `${trimmed}/`;
+}
+
 export const FORWARDED_PORTAL_KEYS = [
   'username',
   'color',

--- a/client/src/scene/portalParams.ts
+++ b/client/src/scene/portalParams.ts
@@ -1,0 +1,69 @@
+export const VIBE_JAM_PORTAL_URL = 'https://vibejam.cc/portal/2026';
+
+export const FORWARDED_PORTAL_KEYS = [
+  'username',
+  'color',
+  'speed',
+  'avatar_url',
+  'team',
+  'hp',
+  'speed_x',
+  'speed_y',
+  'speed_z',
+  'rotation_x',
+  'rotation_y',
+  'rotation_z',
+] as const;
+
+export type PortalParams = {
+  isFromPortal: boolean;
+  ref: string | null;
+  forwarded: Record<string, string>;
+};
+
+export function readPortalParams(search: string): PortalParams {
+  const params = new URLSearchParams(search);
+  const isFromPortal = params.get('portal') === 'true';
+  const refRaw = params.get('ref');
+  const ref = refRaw && refRaw.length > 0 ? refRaw : null;
+  const forwarded: Record<string, string> = {};
+  for (const key of FORWARDED_PORTAL_KEYS) {
+    const value = params.get(key);
+    if (value !== null && value !== '') {
+      forwarded[key] = value;
+    }
+  }
+  return { isFromPortal, ref, forwarded };
+}
+
+export function buildPortalRedirectUrl(
+  base: string,
+  forwarded: Record<string, string>,
+  selfRef: string | null,
+): string {
+  const url = new URL(base);
+  for (const [key, value] of Object.entries(forwarded)) {
+    url.searchParams.set(key, value);
+  }
+  if (selfRef) {
+    url.searchParams.set('ref', selfRef);
+  }
+  return url.toString();
+}
+
+export function buildReturnPortalUrl(
+  ref: string,
+  forwarded: Record<string, string>,
+  selfRef: string | null,
+): string {
+  const target = ref.startsWith('http://') || ref.startsWith('https://') ? ref : `https://${ref}`;
+  const url = new URL(target);
+  for (const [key, value] of Object.entries(forwarded)) {
+    url.searchParams.set(key, value);
+  }
+  url.searchParams.set('portal', 'true');
+  if (selfRef) {
+    url.searchParams.set('ref', selfRef);
+  }
+  return url.toString();
+}


### PR DESCRIPTION
## Summary
Implements a portal system that enables players to navigate between different game worlds. Players can enter portals to travel to other worlds and return to their origin world through return portals.

## Key Changes
- **New Portal Components** (`Portals.tsx`): 
  - Renders two interactive portals in the game world (exit portal at fixed position, return portal at player spawn)
  - Implements proximity-based trigger detection with hysteresis (armed/disarmed states) to prevent accidental re-triggering
  - Portals continuously spin and emit light for visual feedback
  - Displays labels identifying each portal's destination

- **Portal URL Parameter Handling** (`portalParams.ts`):
  - Parses incoming portal parameters (`portal=true`, `ref`, and forwarded player state)
  - Builds redirect URLs for outbound portal travel and return portal navigation
  - Supports forwarding player state (username, color, speed, avatar, team, hp, position/rotation) across portal boundaries
  - Handles both bare hostnames and full URLs with automatic https:// scheme injection

- **Portal Parameter Tests** (`portalParams.test.ts`):
  - Comprehensive test coverage for parameter parsing and URL building
  - Validates forwarded state filtering, ref handling, and scheme normalization

- **Auto-connect on Portal Entry** (`App.tsx`):
  - Automatically connects to multiplayer when arriving via portal (`portal=true` parameter)
  - Ensures seamless experience when transitioning between worlds

- **Portal Integration** (`GameWorld.tsx`):
  - Renders portal component in the game scene
  - Passes runtime reference for player position tracking

## Implementation Details
- Portals use a hysteresis-based trigger system: players must move beyond `PORTAL_REARM_RADIUS_M` (2.6m) before re-arming, then enter `PORTAL_TRIGGER_RADIUS_M` (1.6m) to trigger
- Return portals spawn at player's initial position (with 0.4m offset) to create the illusion of emerging from the portal
- Portal visuals use torus geometry with emissive materials and point lights for atmospheric effect
- All portal navigation happens via `window.location.href` to enable cross-origin travel

https://claude.ai/code/session_017ZDmpS8rpWCaa1gyr3z6qY