### PR TITLE
Sync client chunk rendering with WASM fracture expansion

### DIFF
--- a/client/src/scene/DestructibleChunks.tsx
+++ b/client/src/scene/DestructibleChunks.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { Chunk, Destructible, WorldDocument } from '../world/worldDocument';
+import type { Chunk, WorldDocument } from '../world/worldDocument';
+import { fractureChunks } from '../world/destructibleFactory';
 
 /**
  * Stride of the chunk transforms buffer produced by
@@ -119,8 +120,17 @@ export function DestructibleChunks({ world, getChunkTransforms }: DestructibleCh
       // Structure: group chunks by a (shape + size) key so each unique
       // geometry gets its own InstancedMesh. Slot order = order within the
       // group (not global chunk index), so we record the mapping.
+      //
+      // When `fractured` is true the WASM side subdivides each authored
+      // box chunk into brick-sized sub-chunks at spawn (see
+      // `fracture_chunks_default` in `destructibles_fracture.rs`), and the
+      // chunk indices returned by `get_destructible_chunk_transforms` index
+      // into that expanded list — not the authored one. Mirror the same
+      // expansion on the client so the visual chunks line up 1:1 with the
+      // physics chunks.
+      const renderChunks: Chunk[] = doc.fractured ? fractureChunks(doc.chunks) : doc.chunks;
       const groupByKey = new Map<string, { key: string; indices: number[]; geom: THREE.BufferGeometry }>();
-      doc.chunks.forEach((chunk: Chunk, index: number) => {
+      renderChunks.forEach((chunk: Chunk, index: number) => {
         const key = chunkGeometryKey(chunk);
         const existing = groupByKey.get(key);
         if (existing) {

--- a/shared/src/destructibles_real.rs
+++ b/shared/src/destructibles_real.rs
@@ -298,7 +298,10 @@ fn chunk_unit_rotation(chunk: &DocChunk) -> UnitQuaternion<f32> {
     UnitQuaternion::from_quaternion(q)
 }
 
-fn box_piece_triangles(half_extents: [f32; 3], rot: &UnitQuaternion<f32>) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
+fn box_piece_triangles(
+    half_extents: [f32; 3],
+    rot: &UnitQuaternion<f32>,
+) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
     let hx = half_extents[0];
     let hy = half_extents[1];
     let hz = half_extents[2];
@@ -329,7 +332,10 @@ fn box_piece_triangles(half_extents: [f32; 3], rot: &UnitQuaternion<f32>) -> (Ve
     (triangles, corners)
 }
 
-fn sphere_piece_triangles(radius: f32, rot: &UnitQuaternion<f32>) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
+fn sphere_piece_triangles(
+    radius: f32,
+    rot: &UnitQuaternion<f32>,
+) -> (Vec<BlastVec3>, Vec<BlastVec3>) {
     // 8-face octahedron is enough for bonding-surface coverage at low radius.
     let r = radius;
     let raw_pts = [
@@ -422,11 +428,7 @@ fn chunk_to_piece(chunk: &DocChunk, density: f32) -> ScenarioPiece {
     };
 
     let aabb = chunk.aabb_half_extents();
-    let node_size = Some(BlastVec3::new(
-        aabb[0] * 2.0,
-        aabb[1] * 2.0,
-        aabb[2] * 2.0,
-    ));
+    let node_size = Some(BlastVec3::new(aabb[0] * 2.0, aabb[1] * 2.0, aabb[2] * 2.0));
 
     let (local_triangles, hull_points, collider_shape) = match chunk {
         DocChunk::Box { half_extents, .. } => {
@@ -454,7 +456,11 @@ fn chunk_to_piece(chunk: &DocChunk, density: f32) -> ScenarioPiece {
         }
         DocChunk::Capsule { radius, height, .. } => {
             let (tris, pts) = capsule_piece_triangles(*radius, *height, &rotation);
-            (tris, pts.clone(), Some(ScenarioCollider::ConvexHull { points: pts }))
+            (
+                tris,
+                pts.clone(),
+                Some(ScenarioCollider::ConvexHull { points: pts }),
+            )
         }
     };
 
@@ -469,7 +475,9 @@ fn chunk_to_piece(chunk: &DocChunk, density: f32) -> ScenarioPiece {
         (DocChunk::Sphere { .. }, _) => {
             // Translate hull points to sit at origin in body-local frame
             // (centroid is applied separately via node pose); leave as-is.
-            Some(ScenarioCollider::ConvexHull { points: hull_points })
+            Some(ScenarioCollider::ConvexHull {
+                points: hull_points,
+            })
         }
         (_, other) => other,
     };

--- a/shared/src/physics_arena/mod.rs
+++ b/shared/src/physics_arena/mod.rs
@@ -339,19 +339,27 @@ impl PhysicsArena {
     #[cfg(target_arch = "wasm32")]
     pub fn spawn_destructible(&mut self, doc: &crate::world_document::DestructibleDoc) -> bool {
         match doc {
-            crate::world_document::DestructibleDoc::Wall { id, position, rotation } => {
+            crate::world_document::DestructibleDoc::Wall {
+                id,
+                position,
+                rotation,
+            } => {
                 let pose = pose_from_world_doc(DestructibleKind::Wall, *position, *rotation);
                 self.destructibles
                     .spawn_wall(&mut self.dynamic.sim, *id, pose)
             }
-            crate::world_document::DestructibleDoc::Tower { id, position, rotation } => {
+            crate::world_document::DestructibleDoc::Tower {
+                id,
+                position,
+                rotation,
+            } => {
                 let pose = pose_from_world_doc(DestructibleKind::Tower, *position, *rotation);
                 self.destructibles
                     .spawn_tower(&mut self.dynamic.sim, *id, pose)
             }
-            crate::world_document::DestructibleDoc::Structure { .. } => {
-                self.destructibles.spawn_structure(&mut self.dynamic.sim, doc)
-            }
+            crate::world_document::DestructibleDoc::Structure { .. } => self
+                .destructibles
+                .spawn_structure(&mut self.dynamic.sim, doc),
         }
     }
 
@@ -371,10 +379,7 @@ impl PhysicsArena {
         let doc_rot = doc.rotation();
         let doc_id = doc.id();
         let rot = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
-            doc_rot[3],
-            doc_rot[0],
-            doc_rot[1],
-            doc_rot[2],
+            doc_rot[3], doc_rot[0], doc_rot[1], doc_rot[2],
         ));
         let chunks = match doc {
             crate::world_document::DestructibleDoc::Wall { .. }

--- a/shared/src/wasm_api.rs
+++ b/shared/src/wasm_api.rs
@@ -298,11 +298,19 @@ impl WasmSimWorld {
 
         for doc in &world.destructibles {
             match doc {
-                crate::world_document::DestructibleDoc::Wall { id, position, rotation } => {
+                crate::world_document::DestructibleDoc::Wall {
+                    id,
+                    position,
+                    rotation,
+                } => {
                     let pose = pose_from_world_doc(DocDestructibleKind::Wall, *position, *rotation);
                     self.destructibles.spawn_wall(&mut self.sim, *id, pose);
                 }
-                crate::world_document::DestructibleDoc::Tower { id, position, rotation } => {
+                crate::world_document::DestructibleDoc::Tower {
+                    id,
+                    position,
+                    rotation,
+                } => {
                     let pose =
                         pose_from_world_doc(DocDestructibleKind::Tower, *position, *rotation);
                     self.destructibles.spawn_tower(&mut self.sim, *id, pose);

--- a/shared/src/world_document.rs
+++ b/shared/src/world_document.rs
@@ -315,9 +315,7 @@ impl ChunkDoc {
             Self::Box { half_extents, .. } => {
                 8.0 * half_extents[0] * half_extents[1] * half_extents[2]
             }
-            Self::Sphere { radius, .. } => {
-                (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3)
-            }
+            Self::Sphere { radius, .. } => (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3),
             Self::Capsule { radius, height, .. } => {
                 let sphere = (4.0 / 3.0) * std::f32::consts::PI * radius.powi(3);
                 let cyl = std::f32::consts::PI * radius.powi(2) * *height;
@@ -335,9 +333,7 @@ impl ChunkDoc {
             Self::Sphere { radius, .. } => [*radius, *radius, *radius],
             // Capsule aligned along local Y: caps extend beyond `height/2`
             // by `radius` on top and bottom.
-            Self::Capsule { radius, height, .. } => {
-                [*radius, height * 0.5 + *radius, *radius]
-            }
+            Self::Capsule { radius, height, .. } => [*radius, height * 0.5 + *radius, *radius],
         }
     }
 }


### PR DESCRIPTION
## Summary
Updated the DestructibleChunks component to mirror WASM-side chunk fracturing on the client, ensuring visual chunks align 1:1 with physics chunks when destructibles are configured as fractured.

## Key Changes
- Imported `fractureChunks` utility from `destructibleFactory` module
- Removed unused `Destructible` type import
- Added conditional logic to expand chunks on the client when `doc.fractured` is true, matching the WASM behavior that subdivides authored box chunks into brick-sized sub-chunks at spawn
- Updated chunk iteration to use the expanded `renderChunks` array instead of the original `doc.chunks`

## Implementation Details
When a destructible is marked as `fractured`, the WASM side (`fracture_chunks_default` in `destructibles_fracture.rs`) automatically subdivides each authored box chunk into smaller brick-sized sub-chunks. The chunk indices returned by `get_destructible_chunk_transforms` reference this expanded list. This change ensures the client performs the same expansion, so the InstancedMesh grouping and slot mapping correctly correspond to the physics simulation's chunk structure.

https://claude.ai/code/session_017gm8N8RtUfSV27tfoMVTK5